### PR TITLE
Fix condition for showing Finalize button on proposals

### DIFF
--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -124,6 +124,7 @@ class Proposal extends React.Component {
                 isProposer={isProposer}
                 proposalId={proposalDetails.data.proposalId}
                 history={history}
+                timeCreated={proposalDetails.data.timeCreated}
               />
 
               <EndorseButton


### PR DESCRIPTION
`configDeadDuration` refers to the duration of time one can finalize a project since its creation. This fixes the deadline for finalization so the button shows up properly on the page.