### PR TITLE
Make sure category count is updated in the dashboard

### DIFF
--- a/src/components/common/blocks/filter/category.js
+++ b/src/components/common/blocks/filter/category.js
@@ -15,22 +15,17 @@ export class CategoryGroup extends React.Component {
   }
 
   componentWillMount = () => {
-    const {
-      ProposalsCount: { error, fetching },
-      getProposalsCountAction,
-    } = this.props;
-    if (fetching === null || error) {
-      getProposalsCountAction();
-    }
+    this.props.getProposalsCountAction();
   };
 
-  handleClick = param => {
-    const { onStageChange } = this.props;
+  handleClick(param) {
+    const { onStageChange, getProposalsCountAction } = this.props;
     if (onStageChange) {
       this.setState({ stage: param });
       onStageChange(param);
+      getProposalsCountAction();
     }
-  };
+  }
 
   render() {
     const { stage } = this.state;


### PR DESCRIPTION
This makes sure that the proposal count for each stage is updated when the user goes to the dashboard. The update happens when the user clicks on a particular category, or when the user is redirected to the dashboard (route `/`).

Note that it's possible that the count is not updated immediately due to possible drift when fetching data. This usually happens when the user completes a transaction (such as creating or aborting a proposal) and redirects to the dashboard before the blockchain can confirm the transaction. In such cases, reloading the route or clicking on the category after the transaction is confirmed should re-update the count.