### PR TITLE
Update handling of dao-server endpoints

### DIFF
--- a/src/components/common/blocks/wallet/index.js
+++ b/src/components/common/blocks/wallet/index.js
@@ -54,7 +54,7 @@ export class Wallet extends React.Component {
         ChallengeProof,
       } = nextProps;
 
-      const hasChallenge = Challenge.data && Challenge.data.challenge;
+      const hasChallenge = Challenge.data;
       const hasProof = (ChallengeProof.data && ChallengeProof.data.client) || this.state.signed;
 
       if ((fetching === null && defaultAddress) || (error && defaultAddress)) {
@@ -93,7 +93,7 @@ export class Wallet extends React.Component {
     } = this.props;
     const network = defaultNetworks[0];
 
-    const message = Challenge.data.challenge.challenge;
+    const message = Challenge.data.challenge;
     const caption =
       'By signing this message, I am proving that I control the selected account for use on DigixDAO.';
     const signMessage = new Promise(resolve =>
@@ -109,7 +109,7 @@ export class Wallet extends React.Component {
       if (this.state.proving) return;
       return proveChallengeAction({
         address,
-        challenge: Challenge.data.challenge.id,
+        challenge_id: Challenge.data.id,
         message,
         signature: signature.signedTx,
       }).then(this.setState({ proving: true }));

--- a/src/reducers/dao-server/actions.js
+++ b/src/reducers/dao-server/actions.js
@@ -21,11 +21,11 @@ function fetchData(url, type) {
           })
       )
       .then(({ json, res }) => {
-        if (res.status === 200) {
+        if (json.result) {
           return dispatch({
             type,
             payload: {
-              data: json,
+              data: json.result,
               fetching: false,
               error: null,
               updated: new Date(),
@@ -33,7 +33,7 @@ function fetchData(url, type) {
           });
         }
 
-        throw json;
+        throw json.error;
       })
       .catch(error => dispatch({ type, payload: { fetching: false, error } }));
   };
@@ -66,11 +66,11 @@ function postData(url, type, data, authToken, client, uid) {
           })
       )
       .then(({ json, res }) => {
-        if (res.status === 200) {
+        if (json.result) {
           return dispatch({
             type,
             payload: {
-              data: json,
+              data: json.result,
               fetching: false,
               error: null,
               updated: new Date(),
@@ -78,7 +78,7 @@ function postData(url, type, data, authToken, client, uid) {
           });
         }
 
-        throw json;
+        throw json.error;
       })
       .catch(error => dispatch({ type, payload: { fetching: false, error } }));
   };
@@ -89,10 +89,13 @@ export function getChallenge(address) {
 }
 
 export function proveChallenge(payload) {
-  const { address, challenge, message, signature } = payload;
-  return fetchData(
-    `${DAO_SERVER}/prove?address=${address}&challenge_id=${challenge}&message=${message}&signature=${signature}`,
-    actions.PROVE_CHALLENGE
+  const { address, challenge_id, message, signature } = payload;
+  return postData(
+    `${DAO_SERVER}/prove`,
+    actions.PROVE_CHALLENGE,
+    { address, challenge_id, message, signature },
+    undefined,
+    undefined,
   );
 }
 


### PR DESCRIPTION
This updates the endpoints so they're compatible with the changes from `dao-server`. All endpoints from `dao-server` will now return a uniform structure of `{ result }` or `{ error }`.