### PR TITLE
Revert react quill

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-markdown": "^4.0.3",
+    "react-quill": "^1.3.2",
     "react-redux": "^5.0.7",
     "react-responsive-modal": "^3.4.0",
     "react-scripts": "1.1.5",

--- a/src/pages/proposals/forms/details.js
+++ b/src/pages/proposals/forms/details.js
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { TextArea } from '../../../components/common/elements/index';
-// import ReactQuill from 'react-quill';
-// import 'react-quill/dist/quill.snow.css';
-// import './quill.css';
-
-// import PropTypes from 'prop-types';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import './quill.css';
 
 import { Fieldset, FormItem, Label, EditorContainer } from './style';
 
@@ -18,17 +15,11 @@ class Details extends React.Component {
         <FormItem>
           <Label>Project Information</Label>
           <EditorContainer>
-            <TextArea
-              value={form.details || ''}
-              id="details"
-              onChange={onChange}
-              placeholder="Short description of your project"
-            />
-            {/* <ReactQuill
+            <ReactQuill
               id="details"
               value={form.details || ''}
               onChange={value => onChange('details', value)}
-            /> */}
+            />
           </EditorContainer>
         </FormItem>
       </Fieldset>


### PR DESCRIPTION
This reverts [85164b6](https://github.com/DigixGlobal/governance-ui-components/commit/85164b609818b7b178a7c183ad4d2f392c670549) which removes the `react-quill` library that allows formatting/text editing when creating a proposal.