### PR TITLE
Fix NaN values for voter result

### DIFF
--- a/src/pages/proposals/voting-result.js
+++ b/src/pages/proposals/voting-result.js
@@ -17,6 +17,9 @@ import {
   ApprovalMinLabel,
 } from './style';
 
+// should be string so <ProgressBar/> doesn't interpret the zero as false
+const EMPTY_PROGRESS_BAR_VALUE = '0';
+
 // eslint-disable-next-line
 const countdownRenderer = ({ days, hours, minutes, seconds, completed }) => {
   if (completed) {
@@ -42,11 +45,17 @@ class VotingResult extends React.Component {
     const totalModeratorLockedDgds = parseBigNumber(daoInfo.totalModeratorLockedDgds, 0, false);
     const totalVoterStake = parseBigNumber(draftVoting.totalVoterStake, 0, false);
 
-    const minimumQuorum = this.formatPercentage(quorum / totalModeratorLockedDgds);
-    const quorumProgress = this.formatPercentage(totalVoterStake / totalModeratorLockedDgds);
+    const minimumQuorum = totalModeratorLockedDgds
+      ? this.formatPercentage(quorum / totalModeratorLockedDgds)
+      : EMPTY_PROGRESS_BAR_VALUE;
+    const quorumProgress = totalModeratorLockedDgds
+      ? this.formatPercentage(totalVoterStake / totalModeratorLockedDgds)
+      : EMPTY_PROGRESS_BAR_VALUE;
 
     const minimumApproval = this.formatPercentage(quota);
-    const approvalProgress = this.formatPercentage(draftVoting.yes / totalVoterStake);
+    const approvalProgress = totalVoterStake
+      ? this.formatPercentage(draftVoting.yes / totalVoterStake)
+      : EMPTY_PROGRESS_BAR_VALUE;
 
     return (
       <VotingResultWrapper>


### PR DESCRIPTION
This checks that we're not dividing by zero, which results in `NaN` values for the progress bars in the `<VoterResultWrapper/>` component. The empty value should be typecasted to a string since `<ProgressBar/>` interprets it as falsy otherwise.