### PR TITLE
Integrate Comments UI with API from DAO server

### DIFF
--- a/src/api/comments.js
+++ b/src/api/comments.js
@@ -1,0 +1,81 @@
+import { requestFromApi } from '@digix/gov-ui/api';
+import { DAO_SERVER } from '@digix/gov-ui/reducers/dao-server/constants';
+
+// NOTE: endpoints that connect to the dao-server use payload = { client, data, authToken, uid }
+
+export const CommentsApi = {
+  /*
+   * DAO SERVER ENDPOINTS
+   */
+
+  create: (commentId, body, payload) => {
+    const requestParams = {
+      ...payload,
+      data: { body },
+      method: 'POST',
+      url: `${DAO_SERVER}/comments/${commentId}/`,
+    };
+
+    return requestFromApi(requestParams);
+  },
+
+  delete: (commentId, payload) => {
+    const requestParams = {
+      ...payload,
+      method: 'DELETE',
+      url: `${DAO_SERVER}/comments/${commentId}`,
+    };
+
+    return requestFromApi(requestParams);
+  },
+
+  // getParams = {stage, last_seen_id, sort_by}
+  getThread: (commentId, getParams, payload) => {
+    const requestParams = {
+      ...payload,
+      data: getParams,
+      method: 'GET',
+      url: `${DAO_SERVER}/comments/${commentId}/threads`,
+    };
+
+    return requestFromApi(requestParams);
+  },
+
+  like: (commentId, payload) => {
+    const requestParams = {
+      ...payload,
+      method: 'POST',
+      url: `${DAO_SERVER}/comments/${commentId}/likes`,
+    };
+
+    return requestFromApi(requestParams);
+  },
+
+  unlike: (commentId, payload) => {
+    const requestParams = {
+      ...payload,
+      method: 'DELETE',
+      url: `${DAO_SERVER}/comments/${commentId}/likes`,
+    };
+
+    return requestFromApi(requestParams);
+  },
+
+  /*
+   * HELPERS
+   */
+
+  generateNewThread: comment => ({
+    hasMore: false,
+    data: [comment],
+  }),
+
+  ERROR_MESSAGES: {
+    fetch: 'Unable to fetch comments.',
+    createComment: 'Unable to create comment.',
+    createReply: 'Unable to create reply.',
+    like: 'Unable to like comment.',
+    remove: 'Unable to delete comment.',
+    unlike: 'Unable to unlike comment.',
+  },
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,67 @@
+export function requestOptions(options) {
+  const { authToken, client, method, uid } = options;
+  const payload = {
+    method,
+    mode: 'cors',
+    cache: 'no-cache',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'access-token': authToken,
+      client,
+      uid,
+    },
+    redirect: 'follow',
+    referrer: 'no-referrer',
+  };
+
+  if (options.data) {
+    if (options.method === 'GET') {
+      let params = Object.keys(options.data);
+      params = params.map(key => `${key}=${options.data[key]}`);
+      params = params.join('&');
+      payload.url = `${options.url}?${params}`;
+    } else {
+      // body data type must match "Content-Type" header
+      payload.body = JSON.stringify(options.data);
+    }
+  }
+
+  return payload;
+}
+
+export function initializePayload(ChallengeProof, data) {
+  return {
+    data,
+    authToken: ChallengeProof.data['access-token'],
+    client: ChallengeProof.data.client,
+    uid: ChallengeProof.data.uid,
+  };
+}
+
+export function requestFromApi(payload) {
+  let { url } = payload;
+  const { authToken, client, data, method, uid } = payload;
+
+  const options = requestOptions({ method, authToken, client, uid, url, data });
+  url = options.url ? options.url : url;
+
+  return fetch(url, options)
+    .then(response =>
+      response
+        .json()
+        .then(json => ({ json, response }))
+        .catch(() => {
+          throw response.statusText;
+        })
+    )
+    .then(({ json, response }) => {
+      if (json.result) {
+        return json.result;
+      }
+      throw json.error;
+    })
+    .catch(error => {
+      throw error;
+    });
+}

--- a/src/components/common/elements/buttons/text-button/style.js
+++ b/src/components/common/elements/buttons/text-button/style.js
@@ -15,16 +15,34 @@ export const TextBtn = styled.button`
   background-color: transparent;
   border: 0;
   border-radius: 30px;
-  color: ${props => props.theme.buttonTextDefault.toString()};
   display: inline-flex;
   align-items: center;
   justify-content: flex-start;
 
+  color: ${props =>
+    props.active
+      ? props.theme.buttonBgSecondary.default.toString()
+      : props.theme.buttonTextDefault.toString()};
+
+  svg {
+    fill: ${props =>
+      props.active
+        ? props.theme.buttonBgSecondary.default.toString()
+        : props.theme.buttonTextDefault.toString()};
+  }
+
   &:hover {
     background-color: ${props => props.theme.backgroundTertiary.lightest.toString()};
+    color: ${props =>
+      props.active
+        ? props.theme.buttonTextDefault.toString()
+        : props.theme.buttonBgSecondary.default.toString()};
 
     svg {
-      fill: ${props => props.theme.buttonBgSecondary.default.toString()};
+      fill: ${props =>
+        props.active
+          ? props.theme.buttonTextDefault.toString()
+          : props.theme.buttonBgSecondary.default.toString()};
     }
   }
 `;

--- a/src/components/common/elements/icons/style.js
+++ b/src/components/common/elements/icons/style.js
@@ -9,10 +9,15 @@ export const Container = styled.div`
   margin-right: 1rem;
 
   > svg {
-    fill: ${props =>
-      props.selected
+    fill: ${props => {
+      if (props.active) {
+        return props.theme.buttonBgSecondary.default.toString();
+      }
+
+      return props.selected
         ? props.theme.textSecondary.default.toString()
-        : props.theme.iconColor.toString()};
+        : props.theme.iconColor.toString();
+    }};
     width: 100%;
     height: 100%;
   }

--- a/src/pages/proposals/comment/author.js
+++ b/src/pages/proposals/comment/author.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { UserInfo } from '@digix/gov-ui/pages/proposals/comment/style';
+
+export default class CommentAuthor extends React.Component {
+  render() {
+    const { user } = this.props;
+    return (
+      <UserInfo>
+        {user.address}
+        <span>•</span>
+        Reputation Points: 100
+        <span>•</span>
+        Quarter Points: 100
+      </UserInfo>
+    );
+  }
+}
+
+const { object } = PropTypes;
+
+CommentAuthor.propTypes = {
+  user: object.isRequired,
+};

--- a/src/pages/proposals/comment/comment.js
+++ b/src/pages/proposals/comment/comment.js
@@ -1,0 +1,109 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
+import { ActionBar, CommentPost } from '@digix/gov-ui/pages/proposals/comment/style';
+import { CommentsApi } from '@digix/gov-ui/api/comments';
+import { initializePayload } from '@digix/gov-ui/api';
+
+class Comment extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      comment: this.props.comment,
+    };
+
+    this.DELETE_MESSAGE = 'This message has been removed by the user.';
+  }
+
+  deleteComment() {
+    const { comment } = this.state;
+    const { ChallengeProof, setError } = this.props;
+
+    comment.body = null;
+    this.setState({ comment });
+
+    if (ChallengeProof.data) {
+      const payload = initializePayload(ChallengeProof);
+      CommentsApi.delete(comment.id, payload).catch(() => {
+        setError(CommentsApi.ERROR_MESSAGES.remove);
+      });
+    }
+  }
+
+  toggleLike = () => {
+    const { comment } = this.state;
+    const { ChallengeProof, setError } = this.props;
+
+    comment.liked = !comment.liked;
+    comment.likes = comment.liked ? comment.likes + 1 : comment.likes - 1;
+    const request = comment.liked ? 'like' : 'unlike';
+    this.setState({ comment });
+
+    if (ChallengeProof.data) {
+      const payload = initializePayload(ChallengeProof);
+      CommentsApi[request](comment.id, payload).catch(() => {
+        setError(CommentsApi.ERROR_MESSAGES[request]);
+      });
+    }
+  };
+
+  render() {
+    const { toggleEditor, uid } = this.props;
+    const { comment } = this.state;
+    const { body, liked, user } = comment;
+    const isAuthor = uid === user.address;
+
+    return (
+      <article className="comment">
+        <CommentPost>
+          {body || this.DELETE_MESSAGE}
+          {body && (
+            <ActionBar>
+              <Button kind="text" xsmall onClick={() => toggleEditor()}>
+                <Icon kind="reply" />
+                <span>Reply</span>
+              </Button>
+              <Button kind="text" xsmall active={liked} onClick={() => this.toggleLike()}>
+                <Icon active={liked} kind="like" />
+                {liked && <span>Unlike</span>}
+                {!liked && <span>Like</span>}
+              </Button>
+              {isAuthor && (
+                <Button kind="text" xsmall onClick={() => this.deleteComment()}>
+                  <Icon kind="trash" />
+                  <span>Trash</span>
+                </Button>
+              )}
+            </ActionBar>
+          )}
+        </CommentPost>
+      </article>
+    );
+  }
+}
+
+const { func, object, string } = PropTypes;
+
+Comment.propTypes = {
+  comment: object.isRequired,
+  ChallengeProof: object,
+  setError: func.isRequired,
+  toggleEditor: func,
+  uid: string.isRequired,
+};
+
+Comment.defaultProps = {
+  ChallengeProof: undefined,
+  toggleEditor: undefined,
+};
+
+const mapStateToProps = state => ({
+  ChallengeProof: state.daoServer.ChallengeProof,
+});
+
+export default connect(
+  mapStateToProps,
+  {}
+)(Comment);

--- a/src/pages/proposals/comment/editor.js
+++ b/src/pages/proposals/comment/editor.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button, TextArea } from '@digix/gov-ui/components/common/elements/index';
+import {
+  Author,
+  CommentEditor,
+  EditorContainer,
+} from '@digix/gov-ui/pages/proposals/comment/style';
+
+export default class CommentTextEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      content: '',
+    };
+  }
+
+  onChange = e => {
+    this.setState({
+      content: e.target.value,
+    });
+  };
+
+  createComment = () => {
+    const { addComment, callback } = this.props;
+
+    addComment(this.state.content);
+    this.setState({
+      content: '',
+    });
+
+    if (callback !== undefined) {
+      callback();
+    }
+  };
+
+  render() {
+    const { uid } = this.props;
+    const { content } = this.state;
+    const isContentEmpty = content === '';
+
+    return (
+      <EditorContainer>
+        <Button
+          kind="round"
+          primary
+          ghost
+          disabled={isContentEmpty}
+          onClick={() => this.createComment()}
+        >
+          Comment
+        </Button>
+        <CommentEditor>
+          <Author>
+            Comment as <span>{uid}</span>
+          </Author>
+          <TextArea
+            onChange={this.onChange}
+            placeholder="Write your comment here."
+            value={content}
+          />
+        </CommentEditor>
+      </EditorContainer>
+    );
+  }
+}
+
+const { func, string } = PropTypes;
+
+CommentTextEditor.propTypes = {
+  addComment: func.isRequired,
+  callback: func, // to call after a comment is submitted
+  uid: string,
+};
+
+CommentTextEditor.defaultProps = {
+  callback: undefined,
+  uid: '',
+};

--- a/src/pages/proposals/comment/reply.js
+++ b/src/pages/proposals/comment/reply.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import Comment from '@digix/gov-ui/pages/proposals/comment/comment';
+import CommentAuthor from '@digix/gov-ui/pages/proposals/comment/author';
+import CommentTextEditor from '@digix/gov-ui/pages/proposals/comment/editor';
+import { CommentReplyPost } from '@digix/gov-ui/pages/proposals/comment/style';
+import { CommentsApi } from '@digix/gov-ui/api/comments';
+import { initializePayload } from '@digix/gov-ui/api';
+
+class CommentReply extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      comment: this.props.comment,
+      showEditor: false,
+    };
+  }
+
+  addReply = body => {
+    const comment = { ...this.state.comment };
+    const { ChallengeProof, setError } = this.props;
+
+    if (!ChallengeProof.data) {
+      return;
+    }
+
+    const payload = initializePayload(ChallengeProof);
+    CommentsApi.create(comment.id, body, payload)
+      .then(newComment => {
+        if (!comment.replies) {
+          comment.replies = CommentsApi.generateNewThread(newComment);
+        } else {
+          comment.replies.data.push(newComment);
+        }
+
+        this.setState({ comment });
+      })
+      .catch(() => {
+        setError(CommentsApi.ERROR_MESSAGES.createReply);
+      });
+  };
+
+  hideEditor = () => {
+    this.setState({
+      showEditor: false,
+    });
+  };
+
+  toggleEditor = () => {
+    const { showEditor } = this.state;
+    this.setState({
+      showEditor: !showEditor,
+    });
+  };
+
+  render() {
+    const { hasMore, renderThreadReplies, setError, uid } = this.props;
+    const { comment, showEditor } = this.state;
+    if (!comment) {
+      return null;
+    }
+
+    return (
+      <CommentReplyPost>
+        <CommentAuthor user={comment.user} />
+        <Comment comment={comment} setError={setError} toggleEditor={this.toggleEditor} uid={uid} />
+        {showEditor && (
+          <CommentTextEditor addComment={this.addReply} callback={this.hideEditor} uid={uid} />
+        )}
+
+        {renderThreadReplies(comment.replies)}
+        {hasMore && <a href="#">Load more replies...</a>}
+      </CommentReplyPost>
+    );
+  }
+}
+
+const { bool, func, object, string } = PropTypes;
+
+CommentReply.propTypes = {
+  ChallengeProof: object,
+  comment: object.isRequired,
+  hasMore: bool.isRequired,
+  renderThreadReplies: func.isRequired,
+  setError: func.isRequired,
+  uid: string.isRequired,
+};
+
+CommentReply.defaultProps = {
+  ChallengeProof: undefined,
+};
+
+const mapStateToProps = state => ({
+  ChallengeProof: state.daoServer.ChallengeProof,
+});
+
+export default connect(
+  mapStateToProps,
+  {}
+)(CommentReply);

--- a/src/pages/proposals/comment/thread.js
+++ b/src/pages/proposals/comment/thread.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import Comment from '@digix/gov-ui/pages/proposals/comment/comment';
+import CommentAuthor from '@digix/gov-ui/pages/proposals/comment/author';
+import CommentTextEditor from '@digix/gov-ui/pages/proposals/comment/editor';
+import CommentReply from '@digix/gov-ui/pages/proposals/comment/reply';
+import { CommentsApi } from '@digix/gov-ui/api/comments';
+import { initializePayload } from '@digix/gov-ui/api';
+import { ParentCommentItem } from '@digix/gov-ui/pages/proposals/comment/style';
+
+class ParentThread extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      thread: this.props.thread,
+      showEditor: false,
+    };
+  }
+
+  addReply = body => {
+    const thread = { ...this.state.thread };
+    const { ChallengeProof } = this.props;
+
+    if (ChallengeProof.data) {
+      const payload = initializePayload(ChallengeProof);
+      CommentsApi.create(thread.id, body, payload).then(newComment => {
+        if (!thread.replies) {
+          thread.replies = CommentsApi.generateNewThread(newComment);
+        } else {
+          thread.replies.data.push(newComment);
+        }
+
+        this.setState({ thread });
+      });
+    }
+  };
+
+  hideEditor = () => {
+    this.setState({
+      showEditor: false,
+    });
+  };
+
+  toggleEditor = () => {
+    const { showEditor } = this.state;
+    this.setState({
+      showEditor: !showEditor,
+    });
+  };
+
+  renderThreadReplies = replies => {
+    const { setError, uid } = this.props;
+    if (!replies) {
+      return null;
+    }
+
+    return replies.data.map(comment => (
+      <CommentReply
+        comment={comment}
+        hasMore={replies.hasMore}
+        key={comment.id}
+        setError={setError}
+        renderThreadReplies={this.renderThreadReplies}
+        uid={uid}
+      />
+    ));
+  };
+
+  render() {
+    const { setError, uid } = this.props;
+    const { thread, showEditor } = this.state;
+    if (!thread) {
+      return null;
+    }
+
+    return (
+      <ParentCommentItem>
+        <CommentAuthor user={thread.user} />
+        <Comment comment={thread} setError={setError} toggleEditor={this.toggleEditor} uid={uid} />
+        {showEditor && (
+          <CommentTextEditor addComment={this.addReply} callback={this.hideEditor} uid={uid} />
+        )}
+        {this.renderThreadReplies(thread.replies)}
+      </ParentCommentItem>
+    );
+  }
+}
+
+const { func, object, string } = PropTypes;
+
+ParentThread.propTypes = {
+  ChallengeProof: object,
+  setError: func.isRequired,
+  thread: object.isRequired,
+  uid: string.isRequired,
+};
+
+ParentThread.defaultProps = {
+  ChallengeProof: undefined,
+};
+
+const mapStateToProps = state => ({
+  ChallengeProof: state.daoServer.ChallengeProof,
+});
+
+export default connect(
+  mapStateToProps,
+  {}
+)(ParentThread);

--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -7,6 +7,7 @@ import { EMPTY_HASH } from '@digix/gov-ui/constants';
 import Button from '@digix/gov-ui/components/common/elements/buttons/index';
 import Vote from '@digix/gov-ui/components/common/elements/vote/index';
 import { getProposalDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { clearDaoProposalDetails } from '@digix/gov-ui/reducers/dao-server/actions';
 
 import PreviousVersion from './previous';
 import NextVersion from './next';
@@ -51,16 +52,27 @@ class Proposal extends React.Component {
       versions: undefined,
       currentVersion: 0,
     };
+
+    const path = this.props.location.pathname.split('/');
+    const proposalId = path[2];
+    this.PROPOSAL_ID = proposalId;
   }
 
   componentWillMount = () => {
-    const { getProposalDetailsAction, location, challengeProof, history } = this.props;
+    const {
+      challengeProof,
+      clearDaoProposalDetailsAction,
+      getProposalDetailsAction,
+      history,
+      location,
+    } = this.props;
     if (!challengeProof.data) history.push('/');
 
     if (location.pathname) {
-      const path = location.pathname.split('/');
-      const proposalId = path[2];
-      if (proposalId) getProposalDetailsAction(proposalId);
+      clearDaoProposalDetailsAction();
+      if (this.PROPOSAL_ID) {
+        getProposalDetailsAction(this.PROPOSAL_ID);
+      }
     }
   };
 
@@ -106,6 +118,7 @@ class Proposal extends React.Component {
     const proposalVersion = proposalDetails.data.proposalVersions[currentVersion];
     const { dijixObject } = proposalVersion;
     const versionCount = versions ? versions.length : 0;
+
     return (
       <ProposalsWrapper>
         <ProjectSummary>
@@ -228,7 +241,7 @@ class Proposal extends React.Component {
         <VotingResult draftVoting={proposalDetails.data.draftVoting} daoInfo={daoInfo} />
         <ProjectDetails project={dijixObject} />
         <Milestones milestones={dijixObject.milestones || []} />
-        <CommentThread />
+        <CommentThread proposalId={this.PROPOSAL_ID} uid={addressDetails.data.address} />
       </ProposalsWrapper>
     );
   }
@@ -239,6 +252,7 @@ const { object, func } = PropTypes;
 Proposal.propTypes = {
   proposalDetails: object.isRequired,
   daoInfo: object.isRequired,
+  clearDaoProposalDetailsAction: func.isRequired,
   getProposalDetailsAction: func.isRequired,
   addressDetails: object.isRequired,
   challengeProof: object,
@@ -265,6 +279,7 @@ export default connect(
     daoInfo: data,
   }),
   {
+    clearDaoProposalDetailsAction: clearDaoProposalDetails,
     getProposalDetailsAction: getProposalDetails,
   }
 )(Proposal);

--- a/src/reducers/dao-server/actions.js
+++ b/src/reducers/dao-server/actions.js
@@ -3,9 +3,13 @@ import { REDUX_PREFIX, DAO_SERVER } from './constants';
 export const actions = {
   GET_CHALLENGE: `${REDUX_PREFIX}GET_CHALLENGE`,
   PROVE_CHALLENGE: `${REDUX_PREFIX}PROVE_CHALLENGE`,
+
   ADD_TRANSACTION: `${REDUX_PREFIX}ADD_TRANSACTION`,
   GET_TRANSACTIONS: `${REDUX_PREFIX}GET_TRANSACTIONS`,
   GET_TRANSACION_STATUS: `${REDUX_PREFIX}GET_TRANSACION_STATUS`,
+
+  GET_PROPOSAL_DETAILS: `${REDUX_PREFIX}GET_PROPOSAL_DETAILS`,
+  CLEAR_PROPOSAL_DETAILS: `${REDUX_PREFIX}CLEAR_PROPOSAL_DETAILS`,
 };
 
 // TODO: remove (not being used)
@@ -127,4 +131,27 @@ export function sendTransactionToDaoServer(payload) {
   const { txHash, title, token, client, uid } = payload;
   const data = { txhash: txHash, title };
   return postData(`${DAO_SERVER}/transactions`, actions.ADD_TRANSACTION, data, token, client, uid);
+}
+
+/**
+ * Proposals
+ */
+
+export function clearDaoProposalDetails() {
+  return dispatch => {
+    dispatch({ type: actions.CLEAR_PROPOSAL_DETAILS, payload: {} });
+  };
+}
+
+export function getDaoProposalDetails(payload) {
+  const { client, proposalId, authToken, uid } = payload;
+  return sendData(
+    'GET',
+    `${DAO_SERVER}/proposals/${proposalId}`,
+    actions.GET_PROPOSAL_DETAILS,
+    undefined,
+    authToken,
+    client,
+    uid
+  );
 }

--- a/src/reducers/dao-server/index.js
+++ b/src/reducers/dao-server/index.js
@@ -19,6 +19,12 @@ const defaultState = {
     error: null,
     fetching: null,
   },
+  ProposalDaoDetails: {
+    history: [],
+    data: {},
+    error: null,
+    fetching: null,
+  },
   Transactions: {
     history: [],
     data: {},
@@ -88,6 +94,29 @@ export default function(state = defaultState, action) {
                 .concat(state.AddTransaction.history)
                 .slice(0, 100),
         },
+      };
+    case actions.GET_PROPOSAL_DETAILS:
+      return {
+        ...state,
+        ProposalDaoDetails: {
+          ...state.ProposalDaoDetails,
+          ...action.payload,
+          history: !action.payload.data
+            ? state.ProposalDaoDetails.history
+            : [
+                {
+                  ...action.payload.data,
+                  updated: action.payload.updated,
+                },
+              ]
+                .concat(state.ProposalDaoDetails.history)
+                .slice(0, 100),
+        },
+      };
+    case actions.CLEAR_PROPOSAL_DETAILS:
+      return {
+        ...state,
+        ProposalDaoDetails: defaultState.ProposalDaoDetails,
       };
     case actions.GET_TRANSACION_STATUS:
       return {


### PR DESCRIPTION
This commit adds the following:

- Add comments API
- Load comments in the Proposal page
- Like, Unlike, Delete, and Create comments
- Show error message when comment requests fail
- Handle filter change

The comments are handled by the component states instead of redux, since comments are inherently nested in structure and redux does not play well with nested data. Moreover, the data for comments don't really need to be shared with other components.

This adds the `api/` directory, which provides a function for initializing the payload created from the `ChallengeProof`, and a template for interfacing with the `dao-server` without going through the reducers.

Other things to finish for the comments feature:
- Loading more comments/replies not shown initially
- Loading comments by stage
- Pagination
- Creating/Showing comments in markdown