### PR TITLE
Always post transactions to the DAO server

### DIFF
--- a/src/components/common/blocks/lock-dgd/index.js
+++ b/src/components/common/blocks/lock-dgd/index.js
@@ -159,7 +159,7 @@ class LockDgd extends React.Component {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (challengeProof.data) {
         this.setState({ txHash, dgd: undefined }, () => {
           sendTransactionToDaoServerAction({
@@ -180,10 +180,8 @@ class LockDgd extends React.Component {
       contract,
       func: contract.lockDGD,
       params: [dgd * 1e9],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
       network,
       web3Params,
       ui,

--- a/src/components/common/blocks/overlay/approve-draft/index.js
+++ b/src/components/common/blocks/overlay/approve-draft/index.js
@@ -30,8 +30,8 @@ class ApproveProposalOverlay extends React.Component {
     };
   }
 
-  onSuccessfulTransaction = txHash => {
-    const { ChallengeProof, history, showHideAlertAction, showRightPanelAction } = this.props;
+  onTransactionAttempt = txHash => {
+    const { ChallengeProof, showRightPanelAction } = this.props;
 
     if (ChallengeProof.data) {
       this.props.sendTransactionToDaoServer({
@@ -44,6 +44,10 @@ class ApproveProposalOverlay extends React.Component {
     }
 
     showRightPanelAction({ show: false });
+  };
+
+  onTransactionSuccess = txHash => {
+    const { history, showHideAlertAction } = this.props;
     showHideAlertAction({
       message: 'Proposal Approved',
       txHash,
@@ -91,10 +95,9 @@ class ApproveProposalOverlay extends React.Component {
       contract,
       func: contract.voteOnDraft,
       params: [proposalId, this.state.vote],
-      onSuccess: txHash => {
-        this.onSuccessfulTransaction(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => this.onTransactionAttempt(txHash),
+      onSuccess: txHash => this.onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/components/common/blocks/overlay/vote/commit.js
+++ b/src/components/common/blocks/overlay/vote/commit.js
@@ -39,8 +39,8 @@ class CommitVote extends React.Component {
     };
   }
 
-  onSuccessfulTransaction = txHash => {
-    const { ChallengeProof, history, showHideAlertAction, showRightPanelAction } = this.props;
+  onTransactionAttempt = txHash => {
+    const { ChallengeProof, showRightPanelAction } = this.props;
 
     if (ChallengeProof.data) {
       this.props.sendTransactionToDaoServer({
@@ -53,6 +53,10 @@ class CommitVote extends React.Component {
     }
 
     showRightPanelAction({ show: false });
+  };
+
+  onTransactionSuccess = txHash => {
+    const { history, showHideAlertAction } = this.props;
     showHideAlertAction({
       message: 'Vote Accepted',
       txHash,
@@ -121,10 +125,9 @@ class CommitVote extends React.Component {
       contract,
       func: contract.commitVoteOnProposal,
       params: [proposalId, currentVotingRound, hash],
-      onSuccess: txHash => {
-        this.onSuccessfulTransaction(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => this.onTransactionAttempt(txHash),
+      onSuccess: txHash => this.onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/components/common/blocks/overlay/vote/reveal.js
+++ b/src/components/common/blocks/overlay/vote/reveal.js
@@ -34,8 +34,8 @@ class RevealVote extends React.Component {
     };
   }
 
-  onSuccessfulTransaction = txHash => {
-    const { ChallengeProof, history, showHideAlertAction, showRightPanelAction } = this.props;
+  onTransactionAttempt = txHash => {
+    const { ChallengeProof, showRightPanelAction } = this.props;
 
     if (ChallengeProof.data) {
       this.props.sendTransactionToDaoServer({
@@ -48,6 +48,10 @@ class RevealVote extends React.Component {
     }
 
     showRightPanelAction({ show: false });
+  };
+
+  onTransactionSuccess = txHash => {
+    const { history, showHideAlertAction } = this.props;
     showHideAlertAction({
       message: 'Vote Revealed',
       txHash,
@@ -93,10 +97,9 @@ class RevealVote extends React.Component {
       contract,
       func: contract.revealVoteOnProposal,
       params: [proposalId, currentVotingRound, voteObject.vote, voteObject.salt],
-      onSuccess: txHash => {
-        this.onSuccessfulTransaction(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => this.onTransactionAttempt(txHash),
+      onSuccess: txHash => this.onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/create/index.js
+++ b/src/pages/proposals/create/index.js
@@ -165,7 +165,7 @@ class CreateProposal extends React.Component {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (challengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -175,8 +175,15 @@ class CreateProposal extends React.Component {
           uid: challengeProof.data.uid,
         });
       }
-      if (this.props.history) this.props.history.push('/');
-      this.props.showHideAlert({ message: 'Proposal Created', txHash });
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Proposal Created',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     this.setError();
@@ -187,10 +194,9 @@ class CreateProposal extends React.Component {
         contract,
         func: contract.submitPreproposal,
         params: [ipfsHash, funds, finalReward, web3Params],
-        onSuccess: txHash => {
-          onSuccess(txHash);
-        },
         onFailure: this.setError,
+        onFinally: txHash => onTransactionAttempt(txHash),
+        onSuccess: txHash => onTransactionSuccess(txHash),
         network,
         web3Params,
         ui,

--- a/src/pages/proposals/edit/index.js
+++ b/src/pages/proposals/edit/index.js
@@ -176,7 +176,7 @@ class EditProposal extends React.Component {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -186,8 +186,15 @@ class EditProposal extends React.Component {
           uid: ChallengeProof.data.uid,
         });
       }
-      if (this.props.history) this.props.history.push('/');
-      this.props.showHideAlert({ message: 'Proposal Updated', txHash });
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Proposal Updated',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     this.createAttestation().then(ipfsHash => {
@@ -202,10 +209,9 @@ class EditProposal extends React.Component {
           toBigNumber(parseFloat(form.finalReward, 0) * 1e18),
           web3Params,
         ],
-        onSuccess: txHash => {
-          onSuccess(txHash);
-        },
         onFailure: this.setError,
+        onFinally: txHash => onTransactionAttempt(txHash),
+        onSuccess: txHash => onTransactionSuccess(txHash),
         network,
         web3Params,
         ui,

--- a/src/pages/proposals/proposal-buttons/abort.js
+++ b/src/pages/proposals/proposal-buttons/abort.js
@@ -53,7 +53,7 @@ class AbortProjectButton extends React.PureComponent {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -63,8 +63,15 @@ class AbortProjectButton extends React.PureComponent {
           uid: ChallengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Proposal Aborted', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Proposal Aborted',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -72,10 +79,9 @@ class AbortProjectButton extends React.PureComponent {
       contract,
       func: contract.closeProposal,
       params: [proposalId],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/proposal-buttons/claim-approval.js
+++ b/src/pages/proposals/proposal-buttons/claim-approval.js
@@ -73,7 +73,7 @@ class ClaimApprovalButton extends React.Component {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -83,8 +83,15 @@ class ClaimApprovalButton extends React.Component {
           uid: ChallengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Approval Claimed', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Approval Claimed',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -92,10 +99,9 @@ class ClaimApprovalButton extends React.Component {
       contract,
       func: contract.claimDraftVotingResult,
       params: [proposalId, toBigNumber(50)],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/proposal-buttons/claim-funding.js
+++ b/src/pages/proposals/proposal-buttons/claim-funding.js
@@ -54,7 +54,7 @@ class ClaimFundingButton extends React.PureComponent {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -64,8 +64,15 @@ class ClaimFundingButton extends React.PureComponent {
           uid: ChallengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Funding Claimed', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Funding Claimed',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -73,10 +80,9 @@ class ClaimFundingButton extends React.PureComponent {
       contract,
       func: contract.claimFunding,
       params: [proposalId, proposal.currentMilestone - 1],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/proposal-buttons/claim-results.js
+++ b/src/pages/proposals/proposal-buttons/claim-results.js
@@ -88,7 +88,7 @@ class ClaimResultsButton extends React.PureComponent {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -98,8 +98,15 @@ class ClaimResultsButton extends React.PureComponent {
           uid: ChallengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Voting Result Claimed', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Voting Result Claimed',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -107,10 +114,9 @@ class ClaimResultsButton extends React.PureComponent {
       contract,
       func: contract.claimProposalVotingResult,
       params: [proposalId, currentVotingRound, toBigNumber(50)],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/proposal-buttons/endorse.js
+++ b/src/pages/proposals/proposal-buttons/endorse.js
@@ -53,7 +53,7 @@ class EndorseProjectButton extends React.PureComponent {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -63,8 +63,15 @@ class EndorseProjectButton extends React.PureComponent {
           uid: ChallengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Proposal Endorsed', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Proposal Endorsed',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -72,10 +79,9 @@ class EndorseProjectButton extends React.PureComponent {
       contract,
       func: contract.endorseProposal,
       params: [proposalId],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/proposal-buttons/finalize.js
+++ b/src/pages/proposals/proposal-buttons/finalize.js
@@ -82,7 +82,7 @@ class FinalizeProjectButton extends React.PureComponent {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (challengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -92,8 +92,15 @@ class FinalizeProjectButton extends React.PureComponent {
           uid: challengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Proposal Finalized', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Proposal Finalized',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -101,10 +108,9 @@ class FinalizeProjectButton extends React.PureComponent {
       contract,
       func: contract.finalizeProposal,
       params: [proposalId],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/pages/proposals/proposal-buttons/milestone-completed.js
+++ b/src/pages/proposals/proposal-buttons/milestone-completed.js
@@ -54,7 +54,7 @@ class CompleteMilestoneButton extends React.PureComponent {
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
-    const onSuccess = txHash => {
+    const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
           txHash,
@@ -64,8 +64,15 @@ class CompleteMilestoneButton extends React.PureComponent {
           uid: ChallengeProof.data.uid,
         });
       }
-      this.props.showHideAlert({ message: 'Milestone Completed', txHash });
-      if (this.props.history) this.props.history.push('/');
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'Milestone Completed',
+        txHash,
+      });
+
+      this.props.history.push('/');
     };
 
     const payload = {
@@ -73,10 +80,9 @@ class CompleteMilestoneButton extends React.PureComponent {
       contract,
       func: contract.finishMilestone,
       params: [proposalId, proposal.currentMilestone - 1],
-      onSuccess: txHash => {
-        onSuccess(txHash);
-      },
       onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,

--- a/src/utils/web3Helper.js
+++ b/src/utils/web3Helper.js
@@ -8,6 +8,7 @@ export const executeContractFunction = payload => {
     params,
     onSuccess,
     onFailure,
+    onFinally,
     network,
     web3Params,
     ui,
@@ -35,9 +36,21 @@ export const executeContractFunction = payload => {
       ui,
     })
       .then(txHash => {
-        onSuccess(txHash);
+        if (typeof onSuccess === 'function') {
+          onSuccess(txHash);
+        }
+
+        if (typeof onFinally === 'function') {
+          onFinally(txHash);
+        }
       })
-      .catch(error => onFailure(error));
+      .catch(error => {
+        onFailure(error);
+        if (typeof onFinally === 'function') {
+          const txHash = Object.keys(error.data)[0];
+          onFinally(txHash);
+        }
+      });
   }
 
   return func
@@ -47,7 +60,19 @@ export const executeContractFunction = payload => {
       ...web3Params,
     })
     .then(txHash => {
-      onSuccess(txHash);
+      if (typeof onSuccess === 'function') {
+        onSuccess(txHash);
+      }
+
+      if (typeof onFinally === 'function') {
+        onFinally(txHash);
+      }
     })
-    .catch(error => onFailure(error));
+    .catch(error => {
+      onFailure(error);
+      if (typeof onFinally === 'function') {
+        const txHash = Object.keys(error.data)[0];
+        onFinally(txHash);
+      }
+    });
 };


### PR DESCRIPTION
Post transactions to the DAO server regardless if the contracts were executed successfully or not.

This ensures we are saving the complete transaction history of the user in the DAO server, not just the successful transactions. `onSuccess` will only execute the showing of the snackbar when the transaction was successful.

**Note**: `Promise::finally` will not receive arguments since there's no reliable means to determine if the promise is successful or not. Thus, `onTransactionAttempt` is called on both `onSuccess` and `onFailure` so we can get `txHash` from the arguments both methods receive.

**Ref:** [DGDG-215](https://tracker.digixdev.com/agiles/88-5/89-5?issue=DGDG-215)