### PR TITLE
Show number of likes per comment and fetch reputation points for the comment author

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -2,6 +2,16 @@ import { requestFromApi } from '@digix/gov-ui/api';
 import { INFO_SERVER } from '@digix/gov-ui/reducers/info-server/constants';
 
 export const UsersApi = {
+  getDetails: (address, payload) => {
+    const requestParams = {
+      ...payload,
+      method: 'GET',
+      url: `${INFO_SERVER}/address/${address}`,
+    };
+
+    return requestFromApi(requestParams);
+  },
+
   // users must be an array of addresses
   getPoints: (users, payload) => {
     const getParams = users.join('&address=');

--- a/src/components/common/elements/buttons/text-button/style.js
+++ b/src/components/common/elements/buttons/text-button/style.js
@@ -2,16 +2,18 @@ import styled, { css } from 'styled-components';
 import { Button } from '../style';
 
 export const TextBtn = styled(Button)`
-  background-color: transparent;
-  border: 0;
-
   display: inline-flex;
   align-items: center;
   justify-content: flex-start;
 
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+
   color: ${props =>
     props.primary
-      ? props.theme.buttonTextPrimary.default.toString()
+      ? props.theme.icon.default.default.toString()
       : props.theme.buttonTextDefault.default.toString()};
 
   svg {
@@ -24,7 +26,7 @@ export const TextBtn = styled(Button)`
       color: ${props.theme.buttonTextSecondary.default.toString()};
 
       svg {
-        fill: ${props.theme.backgroundSecondary.default.toString()};
+        fill: ${props.theme.icon.active.default.toString()};
       }
     `};
 `;

--- a/src/components/common/elements/like/index.js
+++ b/src/components/common/elements/like/index.js
@@ -8,7 +8,7 @@ class LikeButton extends React.Component {
   render() {
     const { hasVoted, onClick } = this.props;
     return (
-      <UpVote hasVoted={hasVoted} onClick={onClick}>
+      <UpVote active={hasVoted} onClick={onClick}>
         <Icon kind="like" active={hasVoted} />
         {hasVoted ? 'UNLIKE' : 'LIKE'}
       </UpVote>

--- a/src/pages/proposals/comment/comment.js
+++ b/src/pages/proposals/comment/comment.js
@@ -57,7 +57,7 @@ class Comment extends React.Component {
   render() {
     const { toggleEditor, uid, userPoints } = this.props;
     const { comment } = this.state;
-    const { body, liked, user } = comment;
+    const { body, liked, likes, user } = comment;
     const isAuthor = uid === user.address;
     const isDeleted = !body;
 
@@ -79,8 +79,7 @@ class Comment extends React.Component {
                 onClick={() => this.toggleLike()}
               >
                 <Icon active={liked} kind="like" />
-                {liked && <span>Unlike</span>}
-                {!liked && <span>Like</span>}
+                <span>{likes}&nbsp;Likes</span>
               </ActionCommentButton>
               {isAuthor && (
                 <ActionCommentButton kind="text" xsmall onClick={() => this.deleteComment()}>

--- a/src/pages/proposals/comment/index.js
+++ b/src/pages/proposals/comment/index.js
@@ -134,7 +134,7 @@ class CommentThread extends React.Component {
 
   fetchUserPoints = () => {
     const { threads, userAddresses } = this.state;
-    const { ChallengeProof } = this.props;
+    const { ChallengeProof, uid } = this.props;
     if (!threads || !ChallengeProof.data) {
       return;
     }
@@ -150,6 +150,18 @@ class CommentThread extends React.Component {
 
     UsersApi.getPoints(newUniqueAddresses, payload)
       .then(userPoints => {
+        this.setState({ userPoints });
+      })
+      // reputation points for first-time commenters
+      // are not available in the previous endpoint
+      .then(() => UsersApi.getDetails(uid, payload))
+      .then(details => {
+        const { userPoints } = this.state;
+        userPoints[uid] = {
+          quarterPoints: details.quarterPoint,
+          reputation: details.reputationPoint,
+        };
+
         this.setState({ userPoints });
       })
       .catch(() => {

--- a/src/pages/proposals/comment/reply.js
+++ b/src/pages/proposals/comment/reply.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 
 import Comment from '@digix/gov-ui/pages/proposals/comment/comment';
 import CommentTextEditor from '@digix/gov-ui/pages/proposals/comment/editor';
-import { Button } from '@digix/gov-ui/components/common/elements/index';
-import { CommentReplyPost } from '@digix/gov-ui/pages/proposals/comment/style';
+import { CommentReplyPost, LoadMoreButton } from '@digix/gov-ui/pages/proposals/comment/style';
 import { CommentsApi } from '@digix/gov-ui/api/comments';
 import { initializePayload } from '@digix/gov-ui/api';
 
@@ -139,9 +138,9 @@ class CommentReply extends React.Component {
         </CommentReplyPost>
         {hasMoreChildren && (
           <CommentReplyPost>
-            <Button kind="text" xsmall onClick={() => this.loadMoreReplies()}>
+            <LoadMoreButton kind="text" tertiary xsmall onClick={() => this.loadMoreReplies()}>
               Load more replies...
-            </Button>
+            </LoadMoreButton>
           </CommentReplyPost>
         )}
       </section>

--- a/src/pages/proposals/comment/style.js
+++ b/src/pages/proposals/comment/style.js
@@ -92,8 +92,10 @@ export const ActionBar = styled.div`
 `;
 
 export const ActionCommentButton = styled(Button)`
-  margin: 1rem 0;
+  margin: 1rem 0.5rem;
   margin-bottom: -1rem;
+  padding: 1rem;
+
   &:first-child {
     margin-left: -1rem;
   }
@@ -102,4 +104,8 @@ export const ActionCommentButton = styled(Button)`
 export const CommentReplyPost = styled.div`
   margin-left: 5rem;
   margin-top: 1rem;
+`;
+
+export const LoadMoreButton = styled(Button)`
+  margin-left: -2rem;
 `;

--- a/src/theme/light.js
+++ b/src/theme/light.js
@@ -172,6 +172,11 @@ const LightTheme = {
     success: green,
     failed: red,
   },
+
+  icon: {
+    default: primaryColor,
+    active: secondaryColor,
+  },
 };
 
 export default LightTheme;


### PR DESCRIPTION
... via the `address/:address` endpoint. Ref: [DGDG-232](https://tracker.digixdev.com/agiles/88-5/89-5?issue=DGDG-232), [DGDG-230](https://tracker.digixdev.com/agiles/88-5/89-5?issue=DGDG-230)

For the reputation points, the points are not available for first time commenters in the `/points` endpoint. To ensure the points for the author is always updated, we'll fetch the address details directly from the `address/:address` endpoint.