### PR TITLE
Lock DGD from Wallet page

### DIFF
--- a/src/components/common/blocks/lock-dgd/index.js
+++ b/src/components/common/blocks/lock-dgd/index.js
@@ -2,14 +2,10 @@ import React from 'react';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-
 import PropTypes, { array } from 'prop-types';
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
-
 import DaoStakeLocking from '@digix/dao-contracts/build/contracts/DaoStakeLocking.json';
-
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import {
   getDefaultAddress,
@@ -17,19 +13,18 @@ import {
   getDefaultNetworks,
 } from 'spectrum-lightsuite/src/selectors';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
-
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
-
-import { showHideLockDgdOverlay, fetchMaxAllowance } from '@digix/gov-ui/reducers/gov-ui/actions';
+import {
+  fetchMaxAllowance,
+  showHideAlert,
+  showHideLockDgdOverlay,
+} from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
-
 import TextField from '@digix/gov-ui/components/common/elements/textfield';
-
 import Button from '@digix/gov-ui/components/common/elements/buttons';
-
 import getContract, { getDGDBalanceContract } from '@digix/gov-ui/utils/contracts';
-
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE, ETHERSCAN_URL } from '@digix/gov-ui/constants';
+import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
 
 import {
   Container,
@@ -58,6 +53,7 @@ class LockDgd extends React.Component {
     this.state = {
       dgd: 0,
       error: '',
+      disableLockDgdButton: true,
       openError: false,
       txHash: undefined,
     };
@@ -70,7 +66,6 @@ class LockDgd extends React.Component {
       !_.isEqual(this.props.lockDgdOverlay, nextProps.lockDgdOverlay)
     )
       if (defaultAddress && lockDgdOverlay.show) {
-        // this.toggleBodyOverflow(nextProps.lockDgdOverlay);
         this.getMaxAllowance();
       }
   };
@@ -81,10 +76,23 @@ class LockDgd extends React.Component {
   onDgdInputChange = e => {
     const { value } = e.target;
     const { addressMaxAllowance } = this.props;
+    let disableLockDgdButton = true;
+    let error;
 
-    if (Number(`${value}e9`) > Number(addressMaxAllowance)) {
-      this.setError(`You can only stake up to ${addressMaxAllowance} DGDs`);
-    } else this.setState({ dgd: value, error: undefined, openError: false });
+    if (!value || Number(value) <= 0) {
+      disableLockDgdButton = true;
+    } else if (Number(`${value}e9`) > Number(addressMaxAllowance)) {
+      disableLockDgdButton = true;
+      error = `You can only stake up to ${addressMaxAllowance} DGDs`;
+    } else {
+      disableLockDgdButton = false;
+    }
+
+    this.setError(error);
+    this.setState({
+      dgd: value,
+      disableLockDgdButton,
+    });
   };
 
   getMaxAllowance = () => {
@@ -171,6 +179,15 @@ class LockDgd extends React.Component {
       }
     };
 
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'DGD Locked',
+        txHash,
+      });
+
+      this.props.getAddressDetails(sourceAddress.address);
+    };
+
     this.setError();
 
     const payload = {
@@ -180,6 +197,7 @@ class LockDgd extends React.Component {
       params: [dgd * 1e9],
       onFailure: this.setError,
       onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
       network,
       web3Params,
       ui,
@@ -226,9 +244,9 @@ class LockDgd extends React.Component {
   };
 
   renderLockDgd = () => {
-    const { dgd, openError, error } = this.state;
+    const { dgd, disableLockDgdButton, openError, error } = this.state;
     const { daoDetails } = this.props;
-    const invalidDgd = !dgd || Number(dgd) <= 0;
+
     let phase = 'staking';
     if (new Date(daoDetails.startOfMainphase * 1000) > Date.now()) {
       phase = 'main';
@@ -247,7 +265,12 @@ class LockDgd extends React.Component {
           <strong>Please enter the amount of DGD you wish to lock in:</strong>
         </TextCaption>
         <InputDgxBox>
-          <TextField type="number" autoFocus onChange={this.onDgdInputChange} />
+          <TextField
+            type="number"
+            autoFocus
+            data-digix="LockDgdOverlay-DgdAmount"
+            onChange={this.onDgdInputChange}
+          />
           DGD
         </InputDgxBox>
         <Note>
@@ -263,7 +286,8 @@ class LockDgd extends React.Component {
           large
           fluid
           onClick={this.handleButtonClick}
-          disabled={invalidDgd}
+          disabled={disableLockDgdButton}
+          data-digix="LockDgdOverlay-LockDgd"
           style={{ marginTop: '4rem' }}
         >
           Lock DGD
@@ -293,6 +317,7 @@ class LockDgd extends React.Component {
 const { object, func, number, oneOfType } = PropTypes;
 
 LockDgd.propTypes = {
+  getAddressDetails: func.isRequired,
   lockDgdOverlay: object.isRequired,
   showTxSigningModal: func.isRequired,
   showHideLockDgdOverlay: func.isRequired,
@@ -304,6 +329,7 @@ LockDgd.propTypes = {
   daoDetails: object.isRequired,
   defaultAddress: object,
   addresses: array,
+  showHideAlert: func.isRequired,
 };
 
 LockDgd.defaultProps = {
@@ -327,7 +353,9 @@ export default web3Connect(
   connect(
     mapStateToProps,
     {
+      getAddressDetails,
       showTxSigningModal,
+      showHideAlert,
       showHideLockDgdOverlay,
       sendTransactionToDaoServer,
       fetchMaxAllowance,

--- a/src/components/common/blocks/navbar/wallet.js
+++ b/src/components/common/blocks/navbar/wallet.js
@@ -21,16 +21,30 @@ class WalletButton extends React.Component {
     return (
       <WalletWrapper>
         {!defaultAddress && (
-          <Button kind="round" primary small onClick={() => this.onWalletClick()}>
+          <Button
+            kind="round"
+            primary
+            small
+            data-digix="Header-LoadWallet"
+            onClick={() => this.onWalletClick()}
+          >
             Load Wallet
           </Button>
         )}
         {canLockDgd && canLockDgd.show && (
-          <Button kind="round" primary small onClick={() => showHideLockDgd(true)}>
+          <Button
+            kind="round"
+            primary
+            small
+            data-digix="Header-LockDgd"
+            onClick={() => showHideLockDgd(true)}
+          >
             Lock DGD
           </Button>
         )}
-        {defaultAddress && <AddressLabel>{defaultAddress.address}</AddressLabel>}
+        {defaultAddress && (
+          <AddressLabel data-digix="Header-Address">{defaultAddress.address}</AddressLabel>
+        )}
       </WalletWrapper>
     );
   }

--- a/src/components/common/blocks/user-DAO-stats/index.js
+++ b/src/components/common/blocks/user-DAO-stats/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
-import { Container, Point } from './style';
+import { Container, Point } from '@digix/gov-ui/components/common/blocks/user-DAO-stats/style';
 
 class UserDAOStats extends React.Component {
   render() {
@@ -13,14 +13,17 @@ class UserDAOStats extends React.Component {
       <Container>
         <Point>
           Quarter Points
-          <span>{stats.data.quarterPoint || 0}</span>
+          <span data-digix="Dashboard-Stats-QuarterPoints">{stats.data.quarterPoint || 0}</span>
         </Point>
         <Point>
-          Reputation Points <span>{stats.data.reputationPoint || 0}</span>
+          Reputation Points
+          <span data-digix="Dashboard-Stats-ReputationPoints">
+            {stats.data.reputationPoint || 0}
+          </span>
         </Point>
         <Point>
           My Stake
-          <span>{stake}</span>
+          <span data-digix="Dashboard-Stats-Stake">{stake}</span>
         </Point>
       </Container>
     );
@@ -28,7 +31,9 @@ class UserDAOStats extends React.Component {
 }
 
 const { object } = PropTypes;
+
 UserDAOStats.propTypes = {
   stats: object.isRequired,
 };
+
 export default UserDAOStats;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,15 +3,23 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 
-import ProposalCard from '../components/proposal-card';
-import Timeline from '../components/common/blocks/timeline';
-import DashboardStats from '../components/common/blocks/user-DAO-stats/index';
-import ProposalFilter from '../components/common/blocks/filter/index';
+import ProposalCard from '@digix/gov-ui/components/proposal-card';
+import Timeline from '@digix/gov-ui/components/common/blocks/timeline';
+import DashboardStats from '@digix/gov-ui/components/common/blocks/user-DAO-stats/index';
+import ProposalFilter from '@digix/gov-ui/components/common/blocks/filter/index';
 
-import { getDaoDetails, getProposals } from '../reducers/info-server/actions';
-import { getProposalLikesByUser, getProposalLikesStats } from '../reducers/dao-server/actions';
+import {
+  getAddressDetails,
+  getDaoDetails,
+  getProposals,
+} from '@digix/gov-ui/reducers/info-server/actions';
 
-import Snackbar from '../components/common/elements/snackbar/index';
+import {
+  getProposalLikesByUser,
+  getProposalLikesStats,
+} from '@digix/gov-ui/reducers/dao-server/actions';
+
+import Snackbar from '@digix/gov-ui/components/common/elements/snackbar/index';
 
 class LandingPage extends Component {
   constructor(props) {
@@ -23,13 +31,19 @@ class LandingPage extends Component {
 
   componentWillMount = () => {
     const {
+      AddressDetails,
+      getAddressDetailsAction,
       getDaoDetailsAction,
       getProposalsAction,
       getProposalLikesByUserAction,
       ChallengeProof,
     } = this.props;
 
-    Promise.all([getDaoDetailsAction(), getProposalsAction()]).then(result => {
+    Promise.all([
+      getAddressDetailsAction(AddressDetails.data.address),
+      getDaoDetailsAction(),
+      getProposalsAction(),
+    ]).then(() => {
       this.getUserLikes('all', ChallengeProof, getProposalLikesByUserAction);
       return this.getProposalLikes();
     });
@@ -158,6 +172,7 @@ LandingPage.propTypes = {
   ProposalLikes: object,
   ShowWallet: bool,
   history: object.isRequired,
+  getAddressDetailsAction: func.isRequired,
   getDaoDetailsAction: func.isRequired,
   getProposalsAction: func.isRequired,
   getProposalLikesByUserAction: func.isRequired,
@@ -186,6 +201,7 @@ export default connect(
     ShowWallet,
   }),
   {
+    getAddressDetailsAction: getAddressDetails,
     getDaoDetailsAction: getDaoDetails,
     getProposalsAction: getProposals,
     getProposalLikesByUserAction: getProposalLikesByUser,

--- a/src/pages/user/wallet/index.js
+++ b/src/pages/user/wallet/index.js
@@ -3,17 +3,17 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import DaoRewardsManager from '@digix/dao-contracts/build/contracts/DaoRewardsManager.json';
-import getContract from '@digix/gov-ui/utils/contracts';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { getAddressDetails, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { getContract } from '@digix/gov-ui/utils/contracts';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
-import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
+import { showHideAlert, showHideLockDgdOverlay } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import { Button } from '@digix/gov-ui/components/common/elements/index';
@@ -53,7 +53,10 @@ class Wallet extends React.Component {
   }
 
   componentDidMount() {
+    const { AddressDetails } = this.props;
+
     this.props.getDaoDetails();
+    this.props.getAddressDetails(AddressDetails.data.address);
   }
 
   setError = error => {
@@ -159,7 +162,12 @@ class Wallet extends React.Component {
                 move your DGD back into your wallet.
               </Desc>
               <Actions>
-                <Button primary data-digix="Wallet-LockDgd">
+                <Button
+                  primary
+                  data-digix="Wallet-LockDgd"
+                  disabled={!this.props.CanLockDgd.show}
+                  onClick={() => this.props.showHideLockDgdOverlay(true)}
+                >
                   Lock DGD
                 </Button>
                 <Button primary disabled data-digix="Wallet-UnlockDgd">
@@ -220,22 +228,29 @@ const { array, func, object } = PropTypes;
 Wallet.propTypes = {
   addresses: array.isRequired,
   AddressDetails: object.isRequired,
+  CanLockDgd: object,
   ChallengeProof: object.isRequired,
   DaoDetails: object,
+  getAddressDetails: func.isRequired,
   getDaoDetails: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlert: func.isRequired,
+  showHideLockDgdOverlay: func.isRequired,
   showTxSigningModal: func.isRequired,
   web3Redux: object.isRequired,
 };
 
 Wallet.defaultProps = {
+  CanLockDgd: {
+    show: false,
+  },
   DaoDetails: undefined,
 };
 
 const mapStateToProps = state => ({
   addresses: getAddresses(state),
   AddressDetails: state.infoServer.AddressDetails,
+  CanLockDgd: state.govUI.CanLockDgd,
   ChallengeProof: state.daoServer.ChallengeProof,
   DaoDetails: state.infoServer.DaoDetails,
 });
@@ -244,8 +259,10 @@ export default web3Connect(
   connect(
     mapStateToProps,
     {
+      getAddressDetails,
       getDaoDetails,
       showHideAlert,
+      showHideLockDgdOverlay,
       sendTransactionToDaoServer,
       showTxSigningModal,
     }


### PR DESCRIPTION
Ref: [DGDG-33](https://tracker.digixdev.com/agiles/88-5/89-5?query=%23Feature%20%23JS%20%23CSS&issue=DGDG-33)

The button on the Wallet page opens the same overlay for locking DGDs. The condition for checking if user is allowed to lock DGD is updated in `getDgdBalance` of `<ConnectedWallet/>`. The buttons in the Header, Wallet Page, and Connected Wallet Overlay should all now point to `govUI.canLockDgd.show` for consistency.

Moreover, the Wallet page and Dashboard will fetch `AddressDetails` when the page loads to ensure that the stake value is always updated.

**Note**: We also fetch `AddressDetails` after locking DGD, but the `info-server` may not be updated by that time, so this is not a reliable way to refresh the data.

`data-digix` attributes were also added to several components related to Lock DGD.