### PR TITLE
Add initial layout for KYC overlay. Needed for DGDG-248.

### DIFF
--- a/src/components/common/blocks/overlay/kyc/address.js
+++ b/src/components/common/blocks/overlay/kyc/address.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import {
+  IntroContainer,
+  OverlayHeader as Header,
+} from '@digix/gov-ui/components/common/common-styles';
+
+class KycOverlayAddress extends React.Component {
+  render() {
+    return (
+      <IntroContainer>
+        <Header uppercase>Address</Header>
+        <Button onClick={() => this.props.onPreviousStep()}>Previous</Button>
+        <Button onClick={() => this.props.onNextStep()}>Next</Button>
+      </IntroContainer>
+    );
+  }
+}
+
+const { func } = PropTypes;
+
+KycOverlayAddress.propTypes = {
+  onPreviousStep: func.isRequired,
+  onNextStep: func.isRequired,
+};
+
+const mapStateToProps = () => ({});
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {}
+  )(KycOverlayAddress)
+);

--- a/src/components/common/blocks/overlay/kyc/basic-information.js
+++ b/src/components/common/blocks/overlay/kyc/basic-information.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import {
+  IntroContainer,
+  OverlayHeader as Header,
+} from '@digix/gov-ui/components/common/common-styles';
+
+class KycOverlayBasicInformation extends React.Component {
+  render() {
+    return (
+      <IntroContainer>
+        <Header uppercase>Basic Information</Header>
+        <Button onClick={() => this.props.onNextStep()}>Next</Button>
+      </IntroContainer>
+    );
+  }
+}
+
+const { func } = PropTypes;
+
+KycOverlayBasicInformation.propTypes = {
+  onNextStep: func.isRequired,
+};
+
+const mapStateToProps = () => ({});
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {}
+  )(KycOverlayBasicInformation)
+);

--- a/src/components/common/blocks/overlay/kyc/index.js
+++ b/src/components/common/blocks/overlay/kyc/index.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import KycOverlayIntro from '@digix/gov-ui/components/common/blocks/overlay/kyc/intro';
+import KycOverlayBasicInformation from '@digix/gov-ui/components/common/blocks/overlay/kyc/basic-information';
+import KycOverlayAddress from '@digix/gov-ui/components/common/blocks/overlay/kyc/address';
+import KycOverlayPhotoUpload from '@digix/gov-ui/components/common/blocks/overlay/kyc/photo-upload';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+
+class KycOverlay extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.STAGES = {
+      intro: 1,
+      basicInformation: 2,
+      address: 3,
+      photoUpload: 4,
+    };
+
+    this.MAX_STEPS = Object.keys(this.STAGES).length;
+    this.state = {
+      step: this.STAGES.intro,
+    };
+  }
+
+  onPreviousStep = () => {
+    let { step } = this.state;
+    if (step < 1) {
+      return;
+    }
+
+    step -= 1;
+    this.setState({ step });
+  };
+
+  onNextStep = () => {
+    let { step } = this.state;
+    if (step >= this.MAX_STEPS) {
+      return;
+    }
+
+    step += 1;
+    this.setState({ step });
+  };
+
+  renderKycStep() {
+    const { step } = this.state;
+
+    switch (step) {
+      case this.STAGES.basicInformation:
+        return <KycOverlayBasicInformation onNextStep={this.onNextStep} />;
+      case this.STAGES.address:
+        return (
+          <KycOverlayAddress onNextStep={this.onNextStep} onPreviousStep={this.onPreviousStep} />
+        );
+      case this.STAGES.photoUpload:
+        return <KycOverlayPhotoUpload onPreviousStep={this.onPreviousStep} />;
+      default:
+        return <KycOverlayIntro onNextStep={this.onNextStep} />;
+    }
+  }
+
+  render() {
+    return this.renderKycStep();
+  }
+}
+
+KycOverlay.propTypes = {};
+const mapStateToProps = () => ({});
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {}
+  )(KycOverlay)
+);

--- a/src/components/common/blocks/overlay/kyc/intro.js
+++ b/src/components/common/blocks/overlay/kyc/intro.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import {
+  IntroContainer,
+  OverlayHeader as Header,
+} from '@digix/gov-ui/components/common/common-styles';
+
+class KycOverlayIntro extends React.Component {
+  render() {
+    return (
+      <IntroContainer>
+        <Header uppercase>KYC</Header>
+        <Button onClick={() => this.props.onNextStep()}>Proceed to KYC</Button>
+      </IntroContainer>
+    );
+  }
+}
+
+const { func } = PropTypes;
+
+KycOverlayIntro.propTypes = {
+  onNextStep: func.isRequired,
+};
+
+const mapStateToProps = () => ({});
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {}
+  )(KycOverlayIntro)
+);

--- a/src/components/common/blocks/overlay/kyc/photo-upload.js
+++ b/src/components/common/blocks/overlay/kyc/photo-upload.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import {
+  IntroContainer,
+  OverlayHeader as Header,
+} from '@digix/gov-ui/components/common/common-styles';
+
+class KycOverlayPhotoUpload extends React.Component {
+  render() {
+    return (
+      <IntroContainer>
+        <Header uppercase>Photo Upload</Header>
+        <Button onClick={() => this.props.onPreviousStep()}>Previous</Button>
+      </IntroContainer>
+    );
+  }
+}
+
+const { func } = PropTypes;
+
+KycOverlayPhotoUpload.propTypes = {
+  onPreviousStep: func.isRequired,
+};
+
+const mapStateToProps = () => ({});
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {}
+  )(KycOverlayPhotoUpload)
+);

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import KycOverlay from '@digix/gov-ui/components/common/blocks/overlay/kyc/index';
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
 import { DEFAULT_STAKE_PER_DGD } from '@digix/gov-ui/constants';
 import { getDaoConfig, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
@@ -113,6 +114,13 @@ class Profile extends React.Component {
     });
   }
 
+  showKycOverlay() {
+    this.props.showRightPanel({
+      component: <KycOverlay />,
+      show: true,
+    });
+  }
+
   render() {
     const { AddressDetails } = this.props;
     const address = AddressDetails.data;
@@ -216,7 +224,11 @@ class Profile extends React.Component {
             <Data data-digix="Profile-KycStatus">Not Verified</Data>
             <Label>&nbsp;</Label>
             <Actions>
-              <Button primary data-digix="Profile-KycStatus-Cta">
+              <Button
+                primary
+                data-digix="Profile-KycStatus-Cta"
+                onClick={() => this.showKycOverlay()}
+              >
                 Submit KYC
               </Button>
             </Actions>


### PR DESCRIPTION
This adds a KYC wizard where each step of the KYC resides in its own component. `<KycOverlay/>` will be the parent component that will take care of navigating through the steps and collect data from the children to submit to the endpoint.