### PR TITLE
Make sure claimable DGX value is updated when rendering the Wallet page

### DIFF
--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
 import { DEFAULT_STAKE_PER_DGD } from '@digix/gov-ui/constants';
 import { getDaoConfig, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
-import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 
 import {
@@ -65,7 +64,7 @@ class Profile extends React.Component {
     const config = DaoConfig.data;
 
     const currentReputation = Number(address.reputationPoint);
-    const minReputation = parseBigNumber(config.CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR);
+    const minReputation = Number(config.CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR);
     const requiredReputation = Math.max(0, minReputation - currentReputation);
 
     const currentStake = Number(address.lockedDgdStake);

--- a/src/pages/user/wallet/index.js
+++ b/src/pages/user/wallet/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import DaoRewardsManager from '@digix/dao-contracts/build/contracts/DaoRewardsManager.json';
+import getContract from '@digix/gov-ui/utils/contracts';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import UnlockDgdOverlay from '@digix/gov-ui/components/common/blocks/overlay/unlock-dgd/index';
@@ -11,7 +12,6 @@ import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { getAddressDetails, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
-import { getContract } from '@digix/gov-ui/utils/contracts';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import {
@@ -48,20 +48,27 @@ class Wallet extends React.Component {
     super(props);
     this.MIN_CLAIMABLE_DGX = 0.001;
 
-    let { claimableDgx } = props.AddressDetails.data;
-    claimableDgx = claimableDgx >= this.MIN_CLAIMABLE_DGX ? truncateNumber(claimableDgx) : 0;
-
     this.state = {
-      claimableDgx,
+      claimableDgx: 0,
     };
+
+    this.setClaimableDgxFromAddress();
   }
 
   componentDidMount() {
     const { AddressDetails } = this.props;
 
     this.props.getDaoDetails();
-    this.props.getAddressDetails(AddressDetails.data.address);
+    this.props.getAddressDetails(AddressDetails.data.address).then(() => {
+      this.setClaimableDgxFromAddress();
+    });
   }
+
+  setClaimableDgxFromAddress = () => {
+    let { claimableDgx } = this.props.AddressDetails.data;
+    claimableDgx = claimableDgx >= this.MIN_CLAIMABLE_DGX ? truncateNumber(claimableDgx) : 0;
+    this.setState({ claimableDgx });
+  };
 
   setError = error => {
     this.props.showHideAlert({


### PR DESCRIPTION
Fix for [DGDG-32](https://tracker.digixdev.com/agiles/88-14/89-14?issue=DGDG-32).

The value for claimable DGX is not updated when we re-render the page. This is because we are not setting `state.claimableDgx` after fetching `AddressDetails` from the `info-server`. This diff also updates how we import `getContracts`, which fixes the bug where the transaction modal fails to show.

This also adds a minor correction in parsing `DaoConfig.CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR`.