### PR TITLE
Minor fixes for locking and unlocking DGD

### DIFF
--- a/src/components/common/blocks/lock-dgd/index.js
+++ b/src/components/common/blocks/lock-dgd/index.js
@@ -143,13 +143,16 @@ class LockDgd extends React.Component {
   };
 
   handleButtonClick = () => {
+    const { dgd } = this.state;
+    const stakeAdded = this.getStake(dgd);
+
     const {
       web3Redux,
       sendTransactionToDaoServer: sendTransactionToDaoServerAction,
       challengeProof,
       addresses,
     } = this.props;
-    const { dgd } = this.state;
+
     const { abi, address } = getContract(DaoStakeLocking, network);
     const contract = web3Redux
       .web3(network)
@@ -180,10 +183,15 @@ class LockDgd extends React.Component {
     };
 
     const onTransactionSuccess = txHash => {
+      const { onSuccess } = this.props.lockDgdOverlay;
       this.props.showHideAlert({
         message: 'DGD Locked',
         txHash,
       });
+
+      if (onSuccess) {
+        onSuccess(stakeAdded);
+      }
 
       this.props.getAddressDetails(sourceAddress.address);
     };

--- a/src/components/common/blocks/overlay/unlock-dgd/index.js
+++ b/src/components/common/blocks/overlay/unlock-dgd/index.js
@@ -10,11 +10,13 @@ import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
+import { getDaoConfig } from '@digix/gov-ui/reducers/info-server/actions';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
+import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 
 import {
   IntroContainer,
@@ -39,10 +41,14 @@ class UnlockDgdOverlay extends React.Component {
   constructor(props) {
     super(props);
 
-    this.MAX_AMOUNT = Number(props.AddressDetails.lockedDgd);
+    this.MAX_AMOUNT = props.maxAmount;
     this.state = {
       unlockAmount: 0,
     };
+  }
+
+  componentDidMount() {
+    this.props.getDaoConfig();
   }
 
   onDgdInputChange = e => {
@@ -153,7 +159,7 @@ class UnlockDgdOverlay extends React.Component {
         <Hint>
           <span>This will leave you with&nbsp;</span>
           <b>
-            <span data-digix="UnlockDgd-RemainingDgd">{remainingDgd}</span>
+            <span data-digix="UnlockDgd-RemainingDgd">{truncateNumber(remainingDgd)}</span>
             <span>&nbsp;STAKE</span>
           </b>
           <span>&nbsp;in DigixDAO.</span>
@@ -165,7 +171,7 @@ class UnlockDgdOverlay extends React.Component {
       <Hint error>
         <span>This will leave you with&nbsp;</span>
         <b>
-          <span data-digix="UnlockDgd-RemainingDgd">{remainingDgd}</span>
+          <span data-digix="UnlockDgd-RemainingDgd">{truncateNumber(remainingDgd)}</span>
           <span>&nbsp;STAKE.&nbsp;</span>
         </b>
         <span>You will no longer continue to be a participant.</span>
@@ -218,13 +224,14 @@ class UnlockDgdOverlay extends React.Component {
   }
 }
 
-const { array, func, object } = PropTypes;
+const { array, func, number, object } = PropTypes;
 
 UnlockDgdOverlay.propTypes = {
   addresses: array.isRequired,
-  AddressDetails: object.isRequired,
   ChallengeProof: object.isRequired,
   DaoConfig: object.isRequired,
+  getDaoConfig: func.isRequired,
+  maxAmount: number.isRequired,
   onSuccess: func.isRequired,
   showRightPanel: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
@@ -237,7 +244,6 @@ UnlockDgdOverlay.defaultProps = {};
 
 const mapStateToProps = state => ({
   addresses: getAddresses(state),
-  AddressDetails: state.infoServer.AddressDetails.data,
   ChallengeProof: state.daoServer.ChallengeProof.data,
   DaoConfig: state.infoServer.DaoConfig.data,
 });
@@ -246,6 +252,7 @@ export default web3Connect(
   connect(
     mapStateToProps,
     {
+      getDaoConfig,
       showHideAlert,
       showRightPanel,
       sendTransactionToDaoServer,

--- a/src/pages/user/wallet/index.js
+++ b/src/pages/user/wallet/index.js
@@ -65,9 +65,15 @@ class Wallet extends React.Component {
     });
   }
 
+  onLockDgd = amountLocked => {
+    let { stake } = this.state;
+    stake = truncateNumber(stake + amountLocked);
+    this.setState({ stake });
+  };
+
   onUnlockDgd = amountUnlocked => {
     let { stake } = this.state;
-    stake -= amountUnlocked;
+    stake = truncateNumber(stake - amountUnlocked);
     this.setState({ stake });
   };
 
@@ -147,8 +153,9 @@ class Wallet extends React.Component {
   };
 
   showUnlockDgdOverlay() {
+    const { stake } = this.state;
     this.props.showRightPanel({
-      component: <UnlockDgdOverlay onSuccess={this.onUnlockDgd} />,
+      component: <UnlockDgdOverlay maxAmount={stake} onSuccess={this.onUnlockDgd} />,
       show: true,
     });
   }
@@ -164,8 +171,7 @@ class Wallet extends React.Component {
 
     const currentTime = Date.now() / 1000;
     const inLockingPhase = currentTime < DaoDetails.data.startOfMainphase;
-    const lockedDgd = Number(AddressDetails.data.lockedDgd);
-    const canUnlockDgd = inLockingPhase && lockedDgd > 0 && isGlobalRewardsSet;
+    const canUnlockDgd = inLockingPhase && stake > 0 && isGlobalRewardsSet;
 
     return (
       <WalletWrapper>
@@ -198,7 +204,7 @@ class Wallet extends React.Component {
                   primary
                   data-digix="Wallet-LockDgd"
                   disabled={!this.props.CanLockDgd.show}
-                  onClick={() => this.props.showHideLockDgdOverlay(true)}
+                  onClick={() => this.props.showHideLockDgdOverlay(true, this.onLockDgd)}
                 >
                   Lock DGD
                 </Button>

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -36,9 +36,9 @@ export function fetchConfigPreproposalCollateral(contract, config) {
   return fetchConfig(contract, config, actions.GET_CONFIG_PREPROPOSAL_COLLATERAL);
 }
 
-export function showHideLockDgdOverlay(show) {
+export function showHideLockDgdOverlay(show, onSuccess) {
   return dispatch => {
-    dispatch({ type: actions.SHOW_LOCK_DGD_OVERLAY, payload: { show } });
+    dispatch({ type: actions.SHOW_LOCK_DGD_OVERLAY, payload: { show, onSuccess } });
   };
 }
 


### PR DESCRIPTION
Fix for [DGDG-33](https://tracker.digixdev.com/agiles/88-14/89-14?issue=DGDG-33).

This adds the following fixes:

- Add lock DGD functionality in the profile page
- Update stake in wallet and profile page after locking DGD
- Make sure stake value is truncated after unlocking DGD
- Fix condition for disabling Unlock DGD button

For locking DGDs, an `onSuccess` callback has been added in `lockDgdOverlay`, which sends the estimated stake added after locking. This ensures that the stake value will be updated on the page. There may be slight discrepancies with the calculation (~0.001 error margin) since we are not directly fetching the data from the `info-server`. This will be fixed in the future when we implement websockets.