### PR TITLE
Update username from the profile page.

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -60,6 +60,21 @@ const UserMutations = {
       }
     }
   `,
+  changeUsername: gql`
+    mutation changeUsername($username: String!) {
+      changeUsername(input: { username: $username }) {
+        user {
+          id
+          displayName
+          username
+        }
+        errors {
+          field
+          message
+        }
+      }
+    }
+  `,
 };
 
 export const withFetchUser = Component => props => (
@@ -96,6 +111,28 @@ export const withChangeEmail = Component => props => (
       }
 
       return <Component {...props} changeEmail={changeEmail} />;
+    }}
+  </Mutation>
+);
+
+export const withChangeUsername = Component => props => (
+  <Mutation
+    mutation={UserMutations.changeUsername}
+    onCompleted={props.onUsernameUpdate}
+    onError={props.onUsernameUpdateError}
+  >
+    {(mutation, { loading }) => {
+      const changeUsername = username => {
+        mutation({
+          variables: { username },
+        });
+      };
+
+      if (loading) {
+        return <Component {...props} disabled />;
+      }
+
+      return <Component {...props} changeUsername={changeUsername} />;
     }}
   </Mutation>
 );

--- a/src/components/common/blocks/overlay/profile-email/index.js
+++ b/src/components/common/blocks/overlay/profile-email/index.js
@@ -45,7 +45,7 @@ class EmailOverlay extends React.Component {
     });
   };
 
-  onEmailUpdateError = error => {
+  onEmailUpdateError = () => {
     this.setState({
       error: this.ERROR_MESSAGES.connectionError,
     });
@@ -76,7 +76,8 @@ class EmailOverlay extends React.Component {
 
   render() {
     const { email, error } = this.state;
-    const disableButton = !email || email === '' || !!error;
+    const invalidInput = !!error && error !== this.ERROR_MESSAGES.connectionError;
+    const disableButton = !email || email === '' || invalidInput;
 
     return (
       <IntroContainer>

--- a/src/components/common/blocks/overlay/profile-username/index.js
+++ b/src/components/common/blocks/overlay/profile-username/index.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import UpdateUsernameButton from '@digix/gov-ui/components/common/blocks/overlay/profile-username/update-username';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-import { Button, Input } from '@digix/gov-ui/components/common/elements/index';
+import {
+  CallToAction,
+  UsernameInput,
+} from '@digix/gov-ui/components/common/blocks/overlay/profile-username/style';
 import {
   IntroContainer,
   OverlayHeader as Header,
@@ -10,11 +15,67 @@ import {
   Label,
   Hint,
 } from '@digix/gov-ui/components/common/common-styles';
-
-import { CallToAction } from '@digix/gov-ui/components/common/blocks/overlay/profile-username/style';
+import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 class UsernameOverlay extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: '',
+      error: undefined,
+    };
+
+    this.USERNAME_REGEX = /^(?!user)[a-z0-9_]{2,20}$/;
+    this.ERROR_MESSAGES = {
+      invalid: `Username must be between 2-20 characters, can only be composed of alphanumeric and underscore characters, and must not begin with the word "user".`,
+      connectionError: `Unable to update username. Please try again.`,
+    };
+  }
+
+  onUsernameUpdate = response => {
+    const { errors } = response.changeUsername;
+    if (errors.length) {
+      this.setState({ error: errors[0].message });
+      return;
+    }
+
+    this.props.showRightPanel({ show: false });
+    this.props.showHideAlert({
+      message: 'Username updated',
+    });
+  };
+
+  onUsernameUpdateError = () => {
+    this.setState({
+      error: this.ERROR_MESSAGES.connectionError,
+    });
+  };
+
+  handleInput = e => {
+    const username = e.target.value.toLowerCase().trim();
+    let error;
+
+    if (!this.USERNAME_REGEX.test(username)) {
+      error = this.ERROR_MESSAGES.invalid;
+    }
+
+    this.setState({ username, error });
+  };
+
+  renderHint = () => {
+    const { error } = this.state;
+    if (!error) {
+      return null;
+    }
+
+    return <Hint error>{error}</Hint>;
+  };
+
   render() {
+    const { username, error } = this.state;
+    const invalidInput = !!error && error !== this.ERROR_MESSAGES.connectionError;
+    const disableButton = !username || username === '' || invalidInput;
+
     return (
       <IntroContainer>
         <Header uppercase>Set Username</Header>
@@ -22,25 +83,34 @@ class UsernameOverlay extends React.Component {
           You can only assign a username to yourself <span>ONCE</span>.
         </Notifications>
         <Label>Please enter your desired user name</Label>
-        <Input type="text" data-digix="SetUsername-TexBox" />
-        <Hint>
-          This email is already used with a DigixDAO account. Please try another email address.
-        </Hint>
+        <UsernameInput type="text" data-digix="SetUsername-TexBox" onChange={this.handleInput} />
+        {this.renderHint()}
         <CallToAction>
-          <Button primary fluid large data-digix="SetUsername-Cta">
-            Set Username
-          </Button>
+          <UpdateUsernameButton
+            disable={disableButton}
+            username={username}
+            onUsernameUpdate={this.onUsernameUpdate}
+            onUsernameUpdateError={this.onUsernameUpdateError}
+          />
         </CallToAction>
       </IntroContainer>
     );
   }
 }
 
-UsernameOverlay.propTypes = {};
+const { func } = PropTypes;
+UsernameOverlay.propTypes = {
+  showHideAlert: func.isRequired,
+  showRightPanel: func.isRequired,
+};
+
 const mapStateToProps = () => ({});
 export default web3Connect(
   connect(
     mapStateToProps,
-    {}
+    {
+      showHideAlert,
+      showRightPanel,
+    }
   )(UsernameOverlay)
 );

--- a/src/components/common/blocks/overlay/profile-username/style.js
+++ b/src/components/common/blocks/overlay/profile-username/style.js
@@ -1,41 +1,10 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import { Input } from '@digix/gov-ui/components/common/elements/index';
-
-export const UnlockDGDContainer = styled.div`
-  display: flex;
-  align-items: center;
-  background: ${props => props.theme.backgroundDefault.toString()};
-  border-radius: ${props => props.theme.borderRadius};
-  border: 1px solid ${props => props.theme.borderColor.light.toString()};
-  color: ${props => props.theme.textDefault.default.toString()};
-  margin: 1rem 0;
-  position: relative;
-`;
-
-export const TextBox = styled(Input)`
-  font-size: 1.6rem;
-  margin: 0;
-  width: calc(100% - 160px);
-  border: 0;
-  outline: 0;
-
-  ::placeholder {
-    text-align: right;
-    transition: opacity 0.5s 0.5s ease;
-    opacity: 0;
-  }
-`;
-
-export const MaxAmount = styled(Link)`
-  margin: 0 1rem;
-  text-decoration: underline;
-  color: ${props => props.theme.textDefault.light.toString()};
-  font-family: 'Futura PT Light', sans-serif;
-`;
-
-export const Currency = styled.div``;
 
 export const CallToAction = styled.div`
   margin-top: 2rem;
+`;
+
+export const UsernameInput = styled(Input)`
+  text-transform: lowercase;
 `;

--- a/src/components/common/blocks/overlay/profile-username/update-username.js
+++ b/src/components/common/blocks/overlay/profile-username/update-username.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import { withChangeUsername } from '@digix/gov-ui/api/users';
+
+class UpdateUsernameButton extends React.Component {
+  render() {
+    const { changeUsername, disable, username } = this.props;
+    const disableButton = disable || !username;
+
+    return (
+      <Button
+        primary
+        fluid
+        large
+        disabled={disableButton}
+        data-digix="UsernameOverlay-SetUsername"
+        onClick={() => changeUsername(username)}
+      >
+        Change Username
+      </Button>
+    );
+  }
+}
+
+const { bool, func, string } = PropTypes;
+
+UpdateUsernameButton.propTypes = {
+  changeUsername: func.isRequired,
+  disable: bool.isRequired,
+  username: string,
+};
+
+UpdateUsernameButton.defaultProps = {
+  username: undefined,
+};
+
+const mapStateToProps = () => ({});
+
+export default withChangeUsername(
+  connect(
+    mapStateToProps,
+    {}
+  )(UpdateUsernameButton)
+);

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -157,6 +157,7 @@ class Profile extends React.Component {
     const { AddressDetails } = this.props;
     const { stake } = this.state;
     const address = AddressDetails.data;
+    const usernameIsSet = this.props.userData.username;
 
     const status = this.getStatus();
     const moderatorRequirements = this.getModeratorRequirements();
@@ -171,15 +172,17 @@ class Profile extends React.Component {
           <UserItem>
             <UserLabel>User:</UserLabel>
             <UserData data-digix="Profile-UserName">{displayName}</UserData>
-            <Button
-              primary
-              icon
-              data-digix="Profile-UserName-Cta"
-              onClick={() => this.showSetUsernameOverlay()}
-            >
-              <Icon kind="plus" />
-              Set Username
-            </Button>
+            {!usernameIsSet && (
+              <Button
+                primary
+                icon
+                data-digix="Profile-UserName-Cta"
+                onClick={() => this.showSetUsernameOverlay()}
+              >
+                <Icon kind="plus" />
+                Set Username
+              </Button>
+            )}
           </UserItem>
           <UserItem>
             <UserLabel>Status:</UserLabel>


### PR DESCRIPTION
Ref: [DGDG-251](https://tracker.digixdev.com/agiles/88-14/89-14?issue=DGDG-251). Dependent on [PR#42](https://github.com/DigixGlobal/governance-ui-components/pull/42).

User should be able to update their username **once** from the profile page. This implements the `changeUsername` mutation to update the username via graphql.