### PR TITLE
Move `getUserStatus` to helpers

### DIFF
--- a/src/components/common/blocks/collapsible-menu/index.js
+++ b/src/components/common/blocks/collapsible-menu/index.js
@@ -14,6 +14,7 @@ import {
   MenuList,
   MenuItem,
 } from '@digix/gov-ui/components/common/blocks/collapsible-menu/style.js';
+import { getUserStatus } from '@digix/gov-ui/utils/helpers';
 
 const DEFAULT_MENU = [
   {
@@ -49,22 +50,6 @@ const DEFAULT_MENU = [
 ];
 
 class CollapsibleMenu extends React.Component {
-  getUserType = details => {
-    if (!details) {
-      return null;
-    }
-
-    if (details.data.isModerator) {
-      return 'Moderator';
-    }
-
-    if (details.data.isParticipant) {
-      return 'Participant';
-    }
-
-    return null;
-  };
-
   renderMenuItem = item => {
     const { ChallengeProof, location, theme } = this.props;
     const authorized = ChallengeProof.data && ChallengeProof.data.client;
@@ -86,7 +71,7 @@ class CollapsibleMenu extends React.Component {
 
   render() {
     const { addressDetails, defaultAddress, menuItems } = this.props;
-    const userType = this.getUserType(addressDetails);
+    const userType = getUserStatus(addressDetails.data);
     const menu = menuItems || DEFAULT_MENU;
     const menuItemElements = menu.map(item => this.renderMenuItem(item));
 
@@ -97,7 +82,7 @@ class CollapsibleMenu extends React.Component {
             <Welcome>
               Welcome, <span>{defaultAddress.address}</span>
             </Welcome>
-            <UserType>{userType}</UserType>
+            <UserType data-digix="Sidebar-UserStatus">{userType}</UserType>
           </ProfileContainer>
         )}
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,3 +57,10 @@ export const VotingStages = {
   commit: 'commit',
   reveal: 'reveal',
 };
+
+export const UserStatus = {
+  moderator: 'Moderator',
+  participant: 'Participant',
+  pastParticipant: 'Past Participant',
+  guest: 'Have not participated',
+};

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -12,8 +12,8 @@ import {
   getDaoConfig,
   getDaoDetails,
 } from '@digix/gov-ui/reducers/info-server/actions';
+import { getUserStatus, truncateNumber } from '@digix/gov-ui/utils/helpers';
 import { showHideLockDgdOverlay, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
-import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 import { withFetchUser } from '@digix/gov-ui/api/users';
 import {
   ProfileWrapper,
@@ -41,13 +41,6 @@ import RedeemBadge from './buttons/redeem-badge';
 class Profile extends React.Component {
   constructor(props) {
     super(props);
-    this.STATUS = {
-      moderator: 'Moderator',
-      participant: 'Participant',
-      pastParticipant: 'Past Participant',
-      guest: 'Have not participated',
-    };
-
     this.state = {
       stake: truncateNumber(props.AddressDetails.data.lockedDgdStake),
     };
@@ -115,21 +108,6 @@ class Profile extends React.Component {
     return requirements;
   };
 
-  getStatus = () => {
-    const { AddressDetails } = this.props;
-    const address = AddressDetails.data;
-
-    if (address.isModerator) {
-      return this.STATUS.moderator;
-    } else if (address.isParticipant) {
-      return this.STATUS.participant;
-    } else if (address.lastParticipatedQuarter > 0) {
-      return this.STATUS.pastParticipant;
-    }
-
-    return this.STATUS.guest;
-  };
-
   showSetUsernameOverlay() {
     this.props.showRightPanel({
       component: <UsernameOverlay />,
@@ -158,7 +136,7 @@ class Profile extends React.Component {
     const { stake } = this.state;
     const address = AddressDetails.data;
 
-    const status = this.getStatus();
+    const status = getUserStatus(address);
     const moderatorRequirements = this.getModeratorRequirements();
     const hasUnmetModerationRequirements =
       !address.isModerator &&

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,5 +1,6 @@
 import multihash from '@digix/multi-hash';
 import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
+import { UserStatus } from '@digix/gov-ui/constants';
 
 export function encodeHash(hash) {
   // eslint-disable-line import/prefer-default-export
@@ -47,4 +48,24 @@ export const formatPercentage = num => {
   }
 
   return formatted;
+};
+
+export const getUserStatus = addressDetails => {
+  if (!addressDetails) {
+    return null;
+  }
+
+  if (addressDetails.isModerator) {
+    return UserStatus.moderator;
+  }
+
+  if (addressDetails.isParticipant) {
+    return UserStatus.participant;
+  }
+
+  if (addressDetails.lastParticipatedQuarter > 0) {
+    return UserStatus.pastParticipant;
+  }
+
+  return UserStatus.guest;
 };


### PR DESCRIPTION
This is so we can have one source of truth for the user status on different parts of the site. It ensures that the logic for showing the user status in the profile page and sidebar are the same.