### PR TITLE
Disable lock DGD button in Profile page after locking DGD

### DIFF
--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -42,7 +42,7 @@ class Profile extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      stake: props.AddressDetails.data.lockedDgdStake,
+      hasPendingLockTransaction: false,
     };
   }
 
@@ -56,21 +56,13 @@ class Profile extends React.Component {
 
     getDaoConfigAction();
     getDaoDetailsAction();
-    getAddressDetailsAction(AddressDetails.data.address).then(() => {
-      this.setStateFromAddressDetails();
-    });
+    getAddressDetailsAction(AddressDetails.data.address);
   }
 
-  onLockDgd = ({ addedStake }) => {
-    let { stake } = this.state;
-    stake += addedStake;
-    this.setState({ stake });
-  };
-
-  setStateFromAddressDetails = () => {
-    const address = this.props.AddressDetails.data;
-    const stake = Number(address.lockedDgdStake);
-    this.setState({ stake });
+  onLockDgd = () => {
+    this.setState({
+      hasPendingLockTransaction: true,
+    });
   };
 
   getStakePerDgd = () => {
@@ -133,8 +125,10 @@ class Profile extends React.Component {
   render() {
     const { displayName, email } = this.props.userData;
     const { AddressDetails } = this.props;
-    let { stake } = this.state;
+    const { hasPendingLockTransaction } = this.state;
+
     const address = AddressDetails.data;
+    let stake = Number(address.lockedDgdStake);
     const usernameIsSet = this.props.userData.username;
 
     const status = getUserStatus(address);
@@ -275,6 +269,7 @@ class Profile extends React.Component {
               <Button
                 primary
                 data-digix="Profile-LockMoreDgd-Cta"
+                disabled={hasPendingLockTransaction}
                 onClick={() => this.props.showHideLockDgdOverlay(true, this.onLockDgd)}
               >
                 Lock More DGD


### PR DESCRIPTION
When locking DGD, we need to wait for the transaction to be confirmed by the `info-server`. Since there's no reliable way (yet) to fetch this data and update the values on the page immediately after the action, we should disable the button to prevent the user from locking more DGD until the transaction has been confirmed.

**Test Plan**:
- Load a participant user then go to the Profile page.
- Lock DGD. The snackbar should show up and the Lock DGD button should be disabled. However, the stake should remain the same.
- Check the data on the `info-server` to confirm that the transaction passed.
- Go to another tab then return to the Profile page. The stake should now be updated and the user can lock DGD again.