### PR TITLE
Add a parameter that toggles the size of the overlay

### DIFF
--- a/src/components/common/blocks/right-panel-overlay/index.js
+++ b/src/components/common/blocks/right-panel-overlay/index.js
@@ -28,8 +28,8 @@ const PanelOverlay = props => {
 
   return (
     <Container>
-      <TransparentOverlay kyc />
-      <DrawerContainer kyc>
+      <TransparentOverlay large={showPanel.large} />
+      <DrawerContainer large={showPanel.large}>
         <CloseButton onClick={showPanel.onClose || closePanel}>
           <Icon kind="close" />
         </CloseButton>

--- a/src/components/common/common-styles.js
+++ b/src/components/common/common-styles.js
@@ -181,7 +181,7 @@ export const TransparentOverlay = styled.div`
   width: 75%;
 
   ${props =>
-    props.kyc &&
+    props.large &&
     css`
       width: 25%;
       ${media.tablet`width: 0%`};
@@ -197,7 +197,7 @@ export const DrawerContainer = styled.div`
   width: 25%;
   
   ${props =>
-    props.kyc &&
+    props.large &&
     css`
       overflow-y: scroll;
       width: 75%;

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -126,6 +126,7 @@ class Profile extends React.Component {
   showKycOverlay() {
     this.props.showRightPanel({
       component: <KycOverlay />,
+      large: true,
       show: true,
     });
   }

--- a/src/reducers/gov-ui/index.js
+++ b/src/reducers/gov-ui/index.js
@@ -11,6 +11,7 @@ const defaultState = {
   CanLockDgd: undefined,
   ShowRightPanel: {
     show: false,
+    large: false,
     component: undefined,
     onClose: undefined,
   },


### PR DESCRIPTION
This allows devs to use the wider overlay (like the one used in the KYC overlay) by setting `large` to true when calling `showRightPanel`. For example:

```js
this.props.showRightPanel({
  component: <KycOverlay />,
  large: true,
  show: true,
});
```