### PR TITLE
[REFACTOR] Modularize components in Wallet page

### DIFF
--- a/src/pages/user/wallet/index.js
+++ b/src/pages/user/wallet/index.js
@@ -2,26 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import DaoRewardsManager from '@digix/dao-contracts/build/contracts/DaoRewardsManager.json';
-import getContract from '@digix/gov-ui/utils/contracts';
-import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
-import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
-import UnlockDgdOverlay from '@digix/gov-ui/components/common/blocks/overlay/unlock-dgd/index';
+import ParticipationReward from '@digix/gov-ui/pages/user/wallet/sections/participation-reward';
+import VotingStake from '@digix/gov-ui/pages/user/wallet/sections/voting-stake';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
-import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { getAddressDetails, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
-import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
-import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import {
   showHideAlert,
   showRightPanel,
   showHideLockDgdOverlay,
 } from '@digix/gov-ui/reducers/gov-ui/actions';
-import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
-import { Button } from '@digix/gov-ui/components/common/elements/index';
-import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 
 import {
   WalletWrapper,
@@ -40,153 +31,22 @@ import {
   Actions,
 } from '@digix/gov-ui/pages/user/wallet/style';
 
-registerUIs({ txVisualization: { component: TxVisualization } });
-const network = SpectrumConfig.defaultNetworks[0];
-
 class Wallet extends React.Component {
-  constructor(props) {
-    super(props);
-    this.MIN_CLAIMABLE_DGX = 0.001;
-
-    this.state = {
-      claimableDgx: 0,
-      lockedDgd: 0,
-      stake: 0,
-    };
-
-    this.setStateFromAddressDetails();
-  }
-
   componentDidMount() {
     const { AddressDetails } = this.props;
 
     this.props.getDaoDetails();
-    this.props.getAddressDetails(AddressDetails.data.address).then(() => {
-      this.setStateFromAddressDetails();
-    });
-  }
-
-  onLockDgd = ({ addedStake, addedDgd }) => {
-    let { lockedDgd, stake } = this.state;
-    lockedDgd += addedDgd;
-    stake += addedStake;
-
-    this.setState({ lockedDgd, stake });
-  };
-
-  onUnlockDgd = amountUnlocked => {
-    let { lockedDgd, stake } = this.state;
-
-    // NOTE: you can only unlock during the locking phase,
-    // where stake == locked dgd
-    lockedDgd -= amountUnlocked;
-    stake -= amountUnlocked;
-
-    this.setState({ lockedDgd, stake });
-  };
-
-  setStateFromAddressDetails = () => {
-    const address = this.props.AddressDetails.data;
-    const stake = Number(address.lockedDgdStake);
-    const lockedDgd = Number(address.lockedDgd);
-
-    let claimableDgx = Number(address.claimableDgx);
-    if (claimableDgx < this.MIN_CLAIMABLE_DGX) {
-      claimableDgx = 0;
-    }
-
-    this.setState({ claimableDgx, lockedDgd, stake });
-  };
-
-  setError = error => {
-    this.props.showHideAlert({
-      message: JSON.stringify(error && error.message) || error,
-    });
-  };
-
-  claimReward = () => {
-    const { addresses, ChallengeProof, web3Redux } = this.props;
-    const { abi, address } = getContract(DaoRewardsManager, network);
-
-    const sourceAddress = addresses.find(({ isDefault }) => isDefault);
-    const contract = web3Redux
-      .web3(network)
-      .eth.contract(abi)
-      .at(address);
-
-    const ui = {
-      caption: 'Claim DGX',
-      header: 'User',
-      type: 'txVisualization',
-    };
-
-    const web3Params = {
-      gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
-      ui,
-    };
-
-    const onTransactionAttempt = txHash => {
-      if (ChallengeProof.data) {
-        this.props.sendTransactionToDaoServer({
-          txHash,
-          title: 'Claim DGX',
-          token: ChallengeProof.data['access-token'],
-          client: ChallengeProof.data.client,
-          uid: ChallengeProof.data.uid,
-        });
-      }
-    };
-
-    const onTransactionSuccess = txHash => {
-      this.props.showHideAlert({
-        message: 'DGX Claimed',
-        txHash,
-      });
-
-      this.setState({ claimableDgx: 0 });
-    };
-
-    const payload = {
-      address: sourceAddress,
-      contract,
-      func: contract.claimRewards,
-      network,
-      onFailure: this.setError,
-      onFinally: txHash => onTransactionAttempt(txHash),
-      onSuccess: txHash => onTransactionSuccess(txHash),
-      params: [],
-      showTxSigningModal: this.props.showTxSigningModal,
-      ui,
-      web3Params,
-    };
-
-    return executeContractFunction(payload);
-  };
-
-  showUnlockDgdOverlay() {
-    const { lockedDgd } = this.state;
-    this.props.showRightPanel({
-      component: <UnlockDgdOverlay maxAmount={lockedDgd} onSuccess={this.onUnlockDgd} />,
-      show: true,
-    });
+    this.props.getAddressDetails(AddressDetails.data.address);
   }
 
   render() {
-    const { AddressDetails, DaoDetails } = this.props;
-    let { claimableDgx, stake } = this.state;
+    const { AddressDetails } = this.props;
     const address = AddressDetails.data;
 
-    const isGlobalRewardsSet = DaoDetails ? DaoDetails.data.isGlobalRewardsSet : false;
-    const canClaimDgx = claimableDgx > this.MIN_CLAIMABLE_DGX && isGlobalRewardsSet;
     const eth = 0;
-
-    const currentTime = Date.now() / 1000;
-    const inLockingPhase = currentTime < DaoDetails.data.startOfMainphase;
-    const canUnlockDgd = inLockingPhase && stake > 0 && isGlobalRewardsSet;
-
-    claimableDgx = truncateNumber(claimableDgx);
-    stake = truncateNumber(stake);
+    const claimableDgx = Number(address.claimableDgx);
+    const lockedDgd = Number(address.lockedDgd);
+    const stake = Number(address.lockedDgdStake);
 
     return (
       <WalletWrapper>
@@ -202,61 +62,8 @@ class Wallet extends React.Component {
           <WalletItem>&nbsp;</WalletItem>
         </WalletDetails> */}
         <DigixDAO>
-          <StakeRewards>
-            <Title>DigixDAO Voting Stake</Title>
-            <Content>
-              <Label>Your Current Stake</Label>
-              <Data>
-                <span data-digix="Wallet-Stake">{stake}</span>
-                <span>&nbsp;Stake</span>
-              </Data>
-              <Desc>
-                You can lock more DGD to increase your voting power or unlock after a quarter to
-                move your DGD back into your wallet.
-              </Desc>
-              <Actions>
-                <Button
-                  primary
-                  data-digix="Wallet-LockDgd"
-                  disabled={!this.props.CanLockDgd.show}
-                  onClick={() => this.props.showHideLockDgdOverlay(true, this.onLockDgd)}
-                >
-                  Lock DGD
-                </Button>
-                <Button
-                  primary
-                  disabled={!canUnlockDgd}
-                  data-digix="Wallet-UnlockDgd"
-                  onClick={() => this.showUnlockDgdOverlay()}
-                >
-                  Unlock DGD
-                </Button>
-              </Actions>
-            </Content>
-          </StakeRewards>
-          <StakeRewards>
-            <Title>DigixDAO Participation Reward</Title>
-            <Content>
-              <Label>Your Unclaimed Reward</Label>
-              <Data>
-                <span data-digix="Wallet-DGXReward">{claimableDgx}</span>
-                <span>&nbsp;DGX</span>
-              </Data>
-              <Desc>
-                You can claim rewards from actively participating in the DigixDAO during a quarter.
-              </Desc>
-              <Actions>
-                <Button
-                  primary
-                  disabled={!canClaimDgx}
-                  data-digix="Wallet-ClaimReward"
-                  onClick={() => this.claimReward()}
-                >
-                  Claim Reward
-                </Button>
-              </Actions>
-            </Content>
-          </StakeRewards>
+          <VotingStake lockedDgd={lockedDgd} stake={stake} />
+          <ParticipationReward claimableDgx={claimableDgx} />
           <StakeRewards>
             <Title>DigixDAO Project Funding</Title>
             <Content>
@@ -281,29 +88,12 @@ class Wallet extends React.Component {
   }
 }
 
-const { array, func, object } = PropTypes;
+const { func, object } = PropTypes;
 
 Wallet.propTypes = {
-  addresses: array.isRequired,
   AddressDetails: object.isRequired,
-  CanLockDgd: object,
-  ChallengeProof: object.isRequired,
-  DaoDetails: object,
   getAddressDetails: func.isRequired,
   getDaoDetails: func.isRequired,
-  showRightPanel: func.isRequired,
-  sendTransactionToDaoServer: func.isRequired,
-  showHideAlert: func.isRequired,
-  showHideLockDgdOverlay: func.isRequired,
-  showTxSigningModal: func.isRequired,
-  web3Redux: object.isRequired,
-};
-
-Wallet.defaultProps = {
-  CanLockDgd: {
-    show: false,
-  },
-  DaoDetails: undefined,
 };
 
 const mapStateToProps = state => ({
@@ -323,8 +113,6 @@ export default web3Connect(
       showHideAlert,
       showRightPanel,
       showHideLockDgdOverlay,
-      sendTransactionToDaoServer,
-      showTxSigningModal,
     }
   )(Wallet)
 );

--- a/src/pages/user/wallet/sections/participation-reward.js
+++ b/src/pages/user/wallet/sections/participation-reward.js
@@ -1,0 +1,182 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import DaoRewardsManager from '@digix/dao-contracts/build/contracts/DaoRewardsManager.json';
+import getContract from '@digix/gov-ui/utils/contracts';
+import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
+import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
+import { getAddresses } from 'spectrum-lightsuite/src/selectors';
+import { getAddressDetails, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
+import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
+import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
+import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
+import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+
+import {
+  StakeRewards,
+  Title,
+  Content,
+  Label,
+  Data,
+  Desc,
+  Actions,
+} from '@digix/gov-ui/pages/user/wallet/style';
+
+registerUIs({ txVisualization: { component: TxVisualization } });
+const network = SpectrumConfig.defaultNetworks[0];
+
+class ParticipationReward extends React.Component {
+  constructor(props) {
+    super(props);
+    this.MIN_CLAIMABLE_DGX = 0.001;
+
+    this.state = {
+      hasPendingTransaction: false,
+    };
+  }
+
+  setError = error => {
+    this.props.showHideAlert({
+      message: JSON.stringify(error && error.message) || error,
+    });
+  };
+
+  claimReward = () => {
+    const { addresses, ChallengeProof, web3Redux } = this.props;
+    const { abi, address } = getContract(DaoRewardsManager, network);
+
+    const sourceAddress = addresses.find(({ isDefault }) => isDefault);
+    const contract = web3Redux
+      .web3(network)
+      .eth.contract(abi)
+      .at(address);
+
+    const ui = {
+      caption: 'Claim DGX',
+      header: 'User',
+      type: 'txVisualization',
+    };
+
+    const web3Params = {
+      gasPrice: DEFAULT_GAS_PRICE,
+      gas: DEFAULT_GAS,
+      ui,
+    };
+
+    const onTransactionAttempt = txHash => {
+      if (ChallengeProof.data) {
+        this.props.sendTransactionToDaoServer({
+          txHash,
+          title: 'Claim DGX',
+          token: ChallengeProof.data['access-token'],
+          client: ChallengeProof.data.client,
+          uid: ChallengeProof.data.uid,
+        });
+      }
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: 'DGX Claimed',
+        txHash,
+      });
+
+      this.setState({ hasPendingTransaction: true });
+    };
+
+    const payload = {
+      address: sourceAddress,
+      contract,
+      func: contract.claimRewards,
+      network,
+      onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
+      params: [],
+      showTxSigningModal: this.props.showTxSigningModal,
+      ui,
+      web3Params,
+    };
+
+    return executeContractFunction(payload);
+  };
+
+  render() {
+    const { DaoDetails } = this.props;
+    const { hasPendingTransaction } = this.state;
+    let { claimableDgx } = this.props;
+
+    const isGlobalRewardsSet = DaoDetails ? DaoDetails.data.isGlobalRewardsSet : false;
+    const canClaimDgx =
+      claimableDgx > this.MIN_CLAIMABLE_DGX && isGlobalRewardsSet && !hasPendingTransaction;
+
+    claimableDgx = truncateNumber(claimableDgx);
+
+    return (
+      <StakeRewards>
+        <Title>DigixDAO Participation Reward</Title>
+        <Content>
+          <Label>Your Unclaimed Reward</Label>
+          <Data>
+            <span data-digix="Wallet-DGXReward">{claimableDgx}</span>
+            <span>&nbsp;DGX</span>
+          </Data>
+          <Desc>
+            You can claim rewards from actively participating in the DigixDAO during a quarter.
+          </Desc>
+          <Actions>
+            <Button
+              primary
+              disabled={!canClaimDgx}
+              data-digix="Wallet-ClaimReward"
+              onClick={() => this.claimReward()}
+            >
+              Claim Reward
+            </Button>
+          </Actions>
+        </Content>
+      </StakeRewards>
+    );
+  }
+}
+
+const { array, func, number, object } = PropTypes;
+
+ParticipationReward.propTypes = {
+  addresses: array.isRequired,
+  claimableDgx: number.isRequired,
+  ChallengeProof: object.isRequired,
+  DaoDetails: object.isRequired,
+  sendTransactionToDaoServer: func.isRequired,
+  showHideAlert: func.isRequired,
+  showTxSigningModal: func.isRequired,
+  web3Redux: object.isRequired,
+};
+
+const mapStateToProps = state => ({
+  addresses: getAddresses(state),
+  AddressDetails: state.infoServer.AddressDetails,
+  CanLockDgd: state.govUI.CanLockDgd,
+  ChallengeProof: state.daoServer.ChallengeProof,
+  DaoDetails: state.infoServer.DaoDetails,
+});
+
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {
+      getAddressDetails,
+      getDaoDetails,
+      showHideAlert,
+      sendTransactionToDaoServer,
+      showTxSigningModal,
+    }
+  )(ParticipationReward)
+);

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -1,0 +1,144 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import UnlockDgdOverlay from '@digix/gov-ui/components/common/blocks/overlay/unlock-dgd/index';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import { getAddresses } from 'spectrum-lightsuite/src/selectors';
+import {
+  showHideAlert,
+  showRightPanel,
+  showHideLockDgdOverlay,
+} from '@digix/gov-ui/reducers/gov-ui/actions';
+import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+
+import {
+  StakeRewards,
+  Title,
+  Content,
+  Label,
+  Data,
+  Desc,
+  Actions,
+} from '@digix/gov-ui/pages/user/wallet/style';
+
+class Wallet extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hasPendingLockTransaction: false,
+      hasPendingUnlockTransaction: false,
+    };
+  }
+
+  onLockDgd = () => {
+    this.setState({ hasPendingLockTransaction: true });
+  };
+
+  onUnlockDgd = () => {
+    this.setState({ hasPendingUnlockTransaction: true });
+  };
+
+  setError = error => {
+    this.props.showHideAlert({
+      message: JSON.stringify(error && error.message) || error,
+    });
+  };
+
+  showUnlockDgdOverlay() {
+    const { lockedDgd } = this.props;
+    this.props.showRightPanel({
+      component: <UnlockDgdOverlay maxAmount={lockedDgd} onSuccess={this.onUnlockDgd} />,
+      show: true,
+    });
+  }
+
+  render() {
+    const { hasPendingLockTransaction, hasPendingUnlockTransaction } = this.state;
+    const stake = truncateNumber(this.props.stake);
+    const DaoDetails = this.props.DaoDetails.data;
+
+    const canLockDgd = this.props.CanLockDgd.show && !hasPendingLockTransaction;
+
+    const currentTime = Date.now() / 1000;
+    const isGlobalRewardsSet = DaoDetails ? DaoDetails.isGlobalRewardsSet : false;
+    const inLockingPhase = currentTime < DaoDetails.startOfMainphase;
+    const canUnlockDgd =
+      inLockingPhase && stake > 0 && isGlobalRewardsSet && !hasPendingUnlockTransaction;
+
+    return (
+      <StakeRewards>
+        <Title>DigixDAO Voting Stake</Title>
+        <Content>
+          <Label>Your Current Stake</Label>
+          <Data>
+            <span data-digix="Wallet-Stake">{stake}</span>
+            <span>&nbsp;Stake</span>
+          </Data>
+          <Desc>
+            You can lock more DGD to increase your voting power or unlock after a quarter to move
+            your DGD back into your wallet.
+          </Desc>
+          <Actions>
+            <Button
+              primary
+              data-digix="Wallet-LockDgd"
+              disabled={!canLockDgd}
+              onClick={() => this.props.showHideLockDgdOverlay(true, this.onLockDgd)}
+            >
+              Lock DGD
+            </Button>
+            <Button
+              primary
+              disabled={!canUnlockDgd}
+              data-digix="Wallet-UnlockDgd"
+              onClick={() => this.showUnlockDgdOverlay()}
+            >
+              Unlock DGD
+            </Button>
+          </Actions>
+        </Content>
+      </StakeRewards>
+    );
+  }
+}
+
+const { func, number, object } = PropTypes;
+
+Wallet.propTypes = {
+  CanLockDgd: object,
+  DaoDetails: object,
+  lockedDgd: number.isRequired,
+  showRightPanel: func.isRequired,
+  showHideAlert: func.isRequired,
+  showHideLockDgdOverlay: func.isRequired,
+  stake: number.isRequired,
+};
+
+Wallet.defaultProps = {
+  CanLockDgd: {
+    show: false,
+  },
+  DaoDetails: undefined,
+};
+
+const mapStateToProps = state => ({
+  addresses: getAddresses(state),
+  AddressDetails: state.infoServer.AddressDetails,
+  CanLockDgd: state.govUI.CanLockDgd,
+  ChallengeProof: state.daoServer.ChallengeProof,
+  DaoDetails: state.infoServer.DaoDetails,
+});
+
+export default web3Connect(
+  connect(
+    mapStateToProps,
+    {
+      showHideAlert,
+      showRightPanel,
+      showHideLockDgdOverlay,
+    }
+  )(Wallet)
+);


### PR DESCRIPTION
The **Voting Stake** and **Participation Reward** sections of the wallet page have been moved to their own components.

When locking and unlocking DGD, we need to wait for the transactions to be confirmed by the info-server. Since there's no reliable way (yet) to fetch this data and update the values on the page immediately after the action, we should disable the buttons to prevent the user from locking/unlocking more DGD until the transactions have been confirmed.

**Test Plan: Claim DGX**

- Run `npm run teleport:main_phase` on the `dao-contracts` repo then restart the `info-server`.
- Load the `account4` wallet and go to the Wallet Page.
- Claim your DGX. After the transaction, the button should be disabled while the DGX value remains the same.
- Confirm that the data has been updated in the `info-server`.
- Go to another tab then return to the Profile page. You should have zero claimable DGX.

**Test Plan: Lock DGD**

- Load any wallet then go to the Wallet page.
- Lock some DGD. After the transaction, the button should be disabled while the stake value remains the same.
- Confirmt hat the data has bee updated in the `info-server`.
- Go to another tab then return to the Profile page. The stake should be updated and the button should be enabled again.

**Test Plan: Unlock DGD**

- Run `npm run teleport:locking_phase` on the `dao-contracts` repo then restart the `info-server`.
- Repeat the test for **Lock DGD** with the **Unlock DGD** button. The results should be the same.