### PR TITLE
[FIX] Replace missing stake variable in Profile component

### DIFF
--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -88,10 +88,10 @@ class Profile extends React.Component {
     const minReputation = Number(config.CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR);
     const requiredReputation = Math.max(0, minReputation - currentReputation);
 
-    const currentStake = this.state.stake;
+    const currentStake = Number(address.lockedDgdStake);
     const minStake = Number(config.CONFIG_MINIMUM_DGD_FOR_MODERATOR);
     const stakePerDgd = this.getStakePerDgd();
-    const requiredStake = stakePerDgd ? Math.max(0, (minStake - currentStake) / stakePerDgd) : 0;
+    const requiredStake = Math.max(0, (minStake - currentStake) / stakePerDgd);
 
     const requirements = {
       reputation: truncateNumber(requiredReputation),


### PR DESCRIPTION
`state.stake` was removed in a prior refactor (commit https://github.com/DigixGlobal/governance-ui-components/commit/216151041fe379e6c29c06ebd15608f482d84a48) and should have been replaced with `AddressDetails.lockedDgdStake` to fix the calculation for the required stake to become a moderator.