### PR TITLE
Add GraphQL query and mutation for fetching KYC form options and submitting KYC data

### DIFF
--- a/src/api/graphql-queries/kyc.js
+++ b/src/api/graphql-queries/kyc.js
@@ -1,0 +1,137 @@
+/* eslint-disable react/display-name, react/prop-types */
+
+import React from 'react';
+import gql from 'graphql-tag';
+import { Mutation, Query } from 'react-apollo';
+
+const fetchKycFormOptions = gql`
+  query fetchKycFormOptions {
+    addressCountry: countries {
+      text: name
+      value
+    }
+
+    country: countries {
+      text: name
+      value
+    }
+
+    nationality: countries {
+      text: name
+      value
+    }
+
+    employmentIndustry: industries {
+      text: name
+      value
+    }
+
+    employmentStatus: __type(name: "EmploymentStatusEnum") {
+      enumValues {
+        text: name
+        value: name
+      }
+    }
+
+    gender: __type(name: "GenderEnum") {
+      enumValues {
+        text: name
+        value: name
+      }
+    }
+
+    identificationProofType: __type(name: "IdentificationProofTypeEnum") {
+      enumValues {
+        text: name
+        value: name
+      }
+    }
+
+    incomeRange: incomeRanges {
+      text: range
+      value
+    }
+
+    residenceProofType: __type(name: "ResidenceProofTypeEnum") {
+      enumValues {
+        text: name
+        value: name
+      }
+    }
+  }
+`;
+
+const submitKycMutation = gql`
+  mutation($kycRequest: SubmitKycMutationInput!) {
+    submitKyc(input: $kycRequest) {
+      clientMutationId
+      errors {
+        field
+        message
+      }
+      kyc {
+        status
+      }
+    }
+  }
+`;
+
+export const withFetchKycFormOptions = Component => props => (
+  <Query query={fetchKycFormOptions}>
+    {({ loading, error, data }) => {
+      if (loading || error) {
+        return <Component {...props} />;
+      }
+
+      const dataKeys = Object.keys(data);
+      let dataValues = Object.values(data);
+
+      const formatString = string => string.replace('_', ' ');
+
+      const formatDataArray = dataArray =>
+        dataArray.map(option => ({
+          text: formatString(option.text),
+          value: option.value,
+        }));
+
+      dataValues = dataValues.map(options => {
+        if (options.enumValues) {
+          return formatDataArray(options.enumValues);
+        }
+        return options;
+      });
+
+      const formattedData = dataValues.reduce(
+        (newData, value, index) => ({
+          ...newData,
+          [dataKeys[index]]: value,
+        }),
+        {}
+      );
+
+      return <Component {...props} formOptions={formattedData} />;
+    }}
+  </Query>
+);
+
+export const withSubmitKyc = Component => props => (
+  <Mutation
+    mutation={submitKycMutation}
+    onCompleted={props.onSubmitKyc}
+    onError={props.onSubmitKycError}
+  >
+    {(mutation, { loading }) => {
+      const submitKyc = kycRequest => {
+        mutation({
+          variables: { kycRequest },
+        });
+      };
+
+      if (loading) {
+        return <Component {...props} disabled />;
+      }
+
+      return <Component {...props} submitKyc={submitKyc} />;
+    }}
+  </Mutation>
+);

--- a/src/components/common/blocks/overlay/kyc/buttons/submit-kyc.js
+++ b/src/components/common/blocks/overlay/kyc/buttons/submit-kyc.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import { withSubmitKyc } from '@digix/gov-ui/api/graphql-queries/kyc';
+
+class SubmitKycButton extends React.Component {
+  submit = () => {
+    const { collectFormData, submitKyc } = this.props;
+    const kycRequest = collectFormData();
+    submitKyc(kycRequest);
+  };
+
+  render() {
+    const { disable } = this.props;
+    return (
+      <Button secondary disabled={disable} data-digix="KycOverlay-Submit" onClick={this.submit}>
+        Submit KYC
+      </Button>
+    );
+  }
+}
+const { bool, func } = PropTypes;
+
+SubmitKycButton.propTypes = {
+  collectFormData: func.isRequired,
+  disable: bool,
+  submitKyc: func.isRequired,
+};
+
+SubmitKycButton.defaultProps = {
+  disable: false,
+};
+
+const mapStateToProps = () => ({});
+export default withSubmitKyc(
+  connect(
+    mapStateToProps,
+    {}
+  )(SubmitKycButton)
+);


### PR DESCRIPTION
Ref: [DGDG-248](https://tracker.digixdev.com/agiles/88-14/89-14?issue=DGDG-248).

This adds the `withFetchKycFormOptions` and `withSubmitKyc` HOCs for the KYC flow.

**Fetching KYC form options**

Simply wrap the component in the `withFetchKycFormOptions` HOC, which will pass the data in `props.formOptions`. This includes all the options that should be shown on the select elements in the form.

**Submitting a KYC request**

The `<SubmitKycButton/>` component uses the `withSubmitKyc` HOC that will trigger the mutation for submitting a KYC request. Make sure to pass the necessary callbacks for handling the response, like so:
```jsx
<SubmitKycButton
  collectFormData={this.collectFormData} // should return an object that follows the schema for SubmitKycMutationInput
  onSubmitKyc={this.onSubmitKyc}
  onSubmitKycError={this.onSubmitKycError}
/>
```
```