### PR TITLE
Update KYC status on the Profile page after a KYC is submitted, approved, rejected, or expired.

### DIFF
--- a/src/api/graphql-queries/kyc.js
+++ b/src/api/graphql-queries/kyc.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import { Mutation, Query } from 'react-apollo';
+import { fetchUserQuery } from '@digix/gov-ui/api/graphql-queries/users';
 
 const fetchKycFormOptions = gql`
   query fetchKycFormOptions {
@@ -70,6 +71,7 @@ const submitKycMutation = gql`
         message
       }
       kyc {
+        id
         status
       }
     }
@@ -124,6 +126,14 @@ export const withSubmitKyc = Component => props => (
       const submitKyc = kycRequest => {
         mutation({
           variables: { kycRequest },
+          update: (store, response) => {
+            const cache = store.readQuery({ query: fetchUserQuery });
+            cache.currentUser.kyc = response.data.submitKyc.kyc;
+            store.writeQuery({
+              data: cache,
+              query: fetchUserQuery,
+            });
+          },
         });
       };
 

--- a/src/api/graphql-queries/users.js
+++ b/src/api/graphql-queries/users.js
@@ -4,7 +4,7 @@ import React from 'react';
 import gql from 'graphql-tag';
 import { Query, Mutation } from 'react-apollo';
 
-const fetchDisplayName = gql`
+export const fetchDisplayName = gql`
   query fetchUser {
     currentUser {
       displayName
@@ -12,7 +12,7 @@ const fetchDisplayName = gql`
   }
 `;
 
-const fetchUserQuery = gql`
+export const fetchUserQuery = gql`
   query fetchUser {
     currentUser {
       id
@@ -21,11 +21,15 @@ const fetchUserQuery = gql`
       username
       displayName
       createdAt
+      kyc {
+        id
+        status
+      }
     }
   }
 `;
 
-const UserMutations = {
+export const UserMutations = {
   changeEmail: gql`
     mutation changeEmail($email: String!) {
       changeEmail(input: { email: $email }) {
@@ -72,16 +76,12 @@ export const renderDisplayName = dataDigixAttribute => (
 
 export const withFetchUser = Component => props => (
   <Query query={fetchUserQuery}>
-    {({ loading, error, data }) => {
-      if (loading) {
+    {({ loading, error, data, refetch }) => {
+      if (loading || error) {
         return null;
       }
 
-      if (error) {
-        return null;
-      }
-
-      return <Component {...props} userData={data.currentUser} />;
+      return <Component {...props} userData={data.currentUser} refetchUser={refetch} />;
     }}
   </Query>
 );

--- a/src/components/common/blocks/overlay/kyc/index.js
+++ b/src/components/common/blocks/overlay/kyc/index.js
@@ -120,6 +120,7 @@ class KycOverlay extends React.Component {
       return;
     }
 
+    this.props.refetchUser();
     this.props.showRightPanel({ show: false });
     this.props.showHideAlert({
       message: 'KYC submitted. Request is pending approval.',
@@ -271,6 +272,7 @@ KycOverlay.propTypes = {
     industries: array,
     residenceProofType: array,
   }),
+  refetchUser: func.isRequired,
   showHideAlert: func.isRequired,
   showRightPanel: func.isRequired,
   web3Redux: object.isRequired,

--- a/src/constants.js
+++ b/src/constants.js
@@ -64,3 +64,10 @@ export const UserStatus = {
   pastParticipant: 'Past Participant',
   guest: 'Have not participated',
 };
+
+export const KycStatus = {
+  pending: 'PENDING',
+  rejected: 'REJECTED',
+  expired: 'EXPIRED',
+  approved: 'APPROVED',
+};

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -4,9 +4,10 @@ import { connect } from 'react-redux';
 
 import EmailOverlay from '@digix/gov-ui/components/common/blocks/overlay/profile-email/index';
 import KycOverlay from '@digix/gov-ui/components/common/blocks/overlay/kyc/index';
+import RedeemBadge from '@digix/gov-ui/pages/user/profile/buttons/redeem-badge';
 import UsernameOverlay from '@digix/gov-ui/components/common/blocks/overlay/profile-username/index';
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
-import { DEFAULT_STAKE_PER_DGD } from '@digix/gov-ui/constants';
+import { DEFAULT_STAKE_PER_DGD, KycStatus } from '@digix/gov-ui/constants';
 import {
   getAddressDetails,
   getDaoConfig,
@@ -37,8 +38,6 @@ import {
   Actions,
 } from '@digix/gov-ui/pages/user/profile/style';
 
-import RedeemBadge from './buttons/redeem-badge';
-
 class Profile extends React.Component {
   constructor(props) {
     super(props);
@@ -58,6 +57,7 @@ class Profile extends React.Component {
     getDaoConfigAction();
     getDaoDetailsAction();
     getAddressDetailsAction(AddressDetails.data.address);
+    this.props.refetchUser();
   }
 
   onLockDgd = () => {
@@ -117,11 +117,92 @@ class Profile extends React.Component {
   }
 
   showKycOverlay() {
+    const { refetchUser } = this.props;
     this.props.showRightPanel({
-      component: <KycOverlay />,
+      component: <KycOverlay refetchUser={refetchUser} />,
       large: true,
       show: true,
     });
+  }
+
+  renderActivitySummary() {
+    const { email, kyc } = this.props.userData;
+    let currentKycStatus = 'Not Verified';
+    if (kyc && kyc.status) {
+      currentKycStatus = kyc.status.charAt(0) + kyc.status.slice(1).toLowerCase();
+    }
+
+    const kycStatusesForResubmission = [KycStatus.expired, KycStatus.approved, KycStatus.rejected];
+    const canResubmitKyc = kyc ? kycStatusesForResubmission.includes(kyc.status) : false;
+    const canSubmitKyc = (email && !kyc) || (kyc && kyc.status === KycStatus.pending);
+    const showSubmitKycButton = canSubmitKyc || canResubmitKyc;
+    const setEmailForKyc = !email && !kyc;
+
+    return (
+      <ActivitySummary>
+        <ActivityItem>
+          <Label>Participated In</Label>
+          <Data data-digix="Profile-QuarterParticipation">12</Data>
+          <Label>Quarter(s)</Label>
+          <Actions>
+            <Button primary data-digix="Profile-QuarterParticipation-Cta">
+              More Info
+            </Button>
+          </Actions>
+        </ActivityItem>
+
+        <ActivityItem>
+          <Label>Proposed</Label>
+          <Data data-digix="Profile-Proposals">0</Data>
+          <Label>Project(s)</Label>
+          <Actions>
+            <Button primary data-digix="Profile-Proposals-Cta">
+              More Info
+            </Button>
+          </Actions>
+        </ActivityItem>
+
+        <ActivityItem>
+          <Label>Claimed</Label>
+          <Data data-digix="Profile-DgxClaimed">12</Data>
+          <Label>DGX</Label>
+          <Actions>
+            <Button primary data-digix="Profile-DgxClaimed-Cta">
+              More Info
+            </Button>
+          </Actions>
+        </ActivityItem>
+
+        <ActivityItem>
+          <Label>KYC Status</Label>
+          <Data data-digix="Profile-KycStatus">{currentKycStatus}</Data>
+          <Label>&nbsp;</Label>
+          <Actions>
+            {setEmailForKyc && (
+              <Button
+                primary
+                data-digix="Profile-KycStatus-SetEmail"
+                onClick={() => this.showSetEmailOverlay()}
+              >
+                Set Email to submit KYC
+              </Button>
+            )}
+
+            {showSubmitKycButton && (
+              <Button
+                primary
+                disabled={kyc && kyc.status === KycStatus.pending}
+                data-digix="Profile-KycStatus-Submit"
+                onClick={() => this.showKycOverlay()}
+              >
+                {canSubmitKyc && <span>Submit KYC</span>}
+                {canResubmitKyc && <span>Re-submit KYC</span>}
+              </Button>
+            )}
+          </Actions>
+        </ActivityItem>
+      </ActivitySummary>
+    );
   }
 
   render() {
@@ -201,54 +282,7 @@ class Profile extends React.Component {
             <Data data-digix="Profile-Stake">{stake}</Data>
           </RewardItem>
         </RewardSummary>
-
-        {/* TODO: Fetch data for this section */}
-        <ActivitySummary>
-          <ActivityItem>
-            <Label>Participated In</Label>
-            <Data data-digix="Profile-QuarterParticipation">12</Data>
-            <Label>Quarter(s)</Label>
-            <Actions>
-              <Button primary data-digix="Profile-QuarterParticipation-Cta">
-                More Info
-              </Button>
-            </Actions>
-          </ActivityItem>
-          <ActivityItem>
-            <Label>Proposed</Label>
-            <Data data-digix="Profile-Proposals">0</Data>
-            <Label>Project(s)</Label>
-            <Actions>
-              <Button primary data-digix="Profile-Proposals-Cta">
-                More Info
-              </Button>
-            </Actions>
-          </ActivityItem>
-          <ActivityItem>
-            <Label>Claimed</Label>
-            <Data data-digix="Profile-DgxClaimed">12</Data>
-            <Label>DGX</Label>
-            <Actions>
-              <Button primary data-digix="Profile-DgxClaimed-Cta">
-                More Info
-              </Button>
-            </Actions>
-          </ActivityItem>
-          <ActivityItem>
-            <Label>KYC Status</Label>
-            <Data data-digix="Profile-KycStatus">Not Verified</Data>
-            <Label>&nbsp;</Label>
-            <Actions>
-              <Button
-                primary
-                data-digix="Profile-KycStatus-Cta"
-                onClick={() => this.showKycOverlay()}
-              >
-                Submit KYC
-              </Button>
-            </Actions>
-          </ActivityItem>
-        </ActivitySummary>
+        {this.renderActivitySummary()}
 
         {hasUnmetModerationRequirements && (
           <Moderation data-digix="Profile-ModerationRequirements">
@@ -298,6 +332,7 @@ Profile.propTypes = {
   getAddressDetailsAction: func.isRequired,
   getDaoConfigAction: func.isRequired,
   getDaoDetailsAction: func.isRequired,
+  refetchUser: func.isRequired,
   showHideLockDgdOverlay: func.isRequired,
   showRightPanel: func.isRequired,
   userData: shape({


### PR DESCRIPTION
Ref: [DGDG-248](https://tracker.digixdev.com/agiles/88-14/89-14?issue=DGDG-248).

Depends on, and is rebased on top of, PR https://github.com/DigixGlobal/governance-ui-components/pull/59

Apollo will update the cached `fetchUserQuery` after a KYC submission and refetch the query every time the `<Profile/>` component is mounted. The Profile page will show different labels and CTAs depending on the current user's KYC status.

**Test Plan**
- Load a wallet that has no email and has not submitted a KYC request yet.
- Go to the profile page. The KYC status should be `Not Verified` and the CTA should open the Set Email overlay.
- Update your email. The KYC status should be the same but the CTA should now open the KYC overlay.
- Submit your KYC request. The KYC status should now show `Pending` and the CTA should be disabled.
- Approve/Reject/Expire the submitted KYC request. You can do it through the admin UI or you can run one of the following commands in the rails console of `dao-server`:

```ruby
# expire KYC
Kyc.approve_kyc(Group.first.users.first, Kyc.last, {expiration_date: Date.current})

# approve KYC
Kyc.approve_kyc(Group.first.users.first, Kyc.last, {expiration_date: Date.current + 1.day})

# reject KYC
Kyc.reject_kyc(Group.first.users.first, Kyc.last, {rejection_reason: "DUPLICATE"})
```

- Once the KYC status has been updated, switch to another tab then go back to the Profile page. It should reflect your new KYC status and the CTA should allow you to re-submit (or create a new) KYC request.