### PR TITLE
Add react-ga and track Lock DGD funnel via Google Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-burger-menu": "^2.6.2",
     "react-countdown-now": "^1.3.0",
     "react-dom": "^16.5.2",
+    "react-ga": "^2.5.7",
     "react-markdown": "^4.0.3",
     "react-quill": "^1.3.2",
     "react-redux": "^5.0.7",

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -1,0 +1,95 @@
+import ReactGA from 'react-ga';
+
+const TRACKING_ID = 'UA-61278742-4';
+const DEFAULT_OPTIONS = {
+  // NOTE: set debug to true to view logs on console
+  debug: false,
+  titleCase: true,
+};
+
+const TXN_ACTIONS = {
+  cancelSigning: 'Cancel Signing',
+  failTxn: 'Fail Transaction',
+  hideAdvanced: 'Hide Advanced Tab',
+  hideDetails: 'Hide Details',
+  passTxn: 'Pass Transaction',
+  showAdvanced: 'Show Advanced Tab',
+  showDetails: 'Show Details',
+  sign: 'Sign Transaction',
+};
+
+const _parseMessage = msg => {
+  if (msg) {
+    return msg.message || msg;
+  }
+
+  return 'Unknown';
+};
+
+function init(opt) {
+  const options = {
+    ...DEFAULT_OPTIONS,
+    ...opt,
+  };
+
+  ReactGA.initialize(TRACKING_ID, options);
+}
+
+// Base template for logging transaction events.
+// Pass an instance of this in payload.logTxn of executeContractFunction
+// to log transaction events from governance-ui.
+const LogTxn = (category, txnLabel) => ({
+  cancel: () =>
+    ReactGA.event({
+      category,
+      action: TXN_ACTIONS.cancelSigning,
+      label: txnLabel,
+    }),
+
+  completeTransaction: (isSuccessful, message) => {
+    const action = isSuccessful ? TXN_ACTIONS.passTxn : TXN_ACTIONS.failTxn;
+    const eventParams = {
+      category,
+      action,
+    };
+
+    if (!isSuccessful) {
+      eventParams.label = _parseMessage(message);
+    }
+
+    ReactGA.event(eventParams);
+  },
+
+  // for json wallets
+  sign: () =>
+    ReactGA.event({
+      category,
+      action: TXN_ACTIONS.sign,
+      label: txnLabel,
+    }),
+
+  toggleAdvanced: show => {
+    const action = show ? TXN_ACTIONS.showAdvanced : TXN_ACTIONS.hideAdvanced;
+    ReactGA.event({
+      category,
+      action,
+      label: txnLabel,
+    });
+  },
+
+  toggleDetails: show => {
+    const action = show ? TXN_ACTIONS.showDetails : TXN_ACTIONS.hideDetails;
+    ReactGA.event({
+      category,
+      action,
+      label: txnLabel,
+    });
+  },
+});
+
+const Analytics = {
+  init,
+  LogTxn,
+};
+
+export default Analytics;

--- a/src/analytics/lockDgd.js
+++ b/src/analytics/lockDgd.js
@@ -1,0 +1,44 @@
+import ReactGA from 'react-ga';
+import Analytics from '@digix/gov-ui/analytics';
+
+const CATEGORY = 'LockDgd';
+const TXN_LABEL = 'LockDgdTxn';
+
+const ACTIONS = {
+  closeOverlay: 'Close Overlay',
+  openOverlay: 'Open Overlay',
+  submit: 'Submit',
+};
+
+const LABELS = {
+  submit: 'Amount of DGD',
+};
+
+const LogLockDgd = {
+  submit: dgd => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.submit,
+      label: LABELS.submit,
+      value: dgd,
+    });
+  },
+
+  toggleOverlay: ({ show, source }) => {
+    const action = show ? ACTIONS.openOverlay : ACTIONS.closeOverlay;
+    const eventParams = {
+      category: CATEGORY,
+      action,
+    };
+
+    if (source) {
+      eventParams.label = `Source: ${source}`;
+    }
+
+    ReactGA.event(eventParams);
+  },
+
+  txn: Analytics.LogTxn(CATEGORY, TXN_LABEL),
+};
+
+export default LogLockDgd;

--- a/src/components/common/blocks/lock-dgd/index.js
+++ b/src/components/common/blocks/lock-dgd/index.js
@@ -26,6 +26,7 @@ import Button from '@digix/gov-ui/components/common/elements/buttons';
 import getContract, { getDGDBalanceContract } from '@digix/gov-ui/utils/contracts';
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import LogLockDgd from '@digix/gov-ui/analytics/lockDgd';
 
 import {
   Container,
@@ -167,6 +168,7 @@ class LockDgd extends React.Component {
     const { dgd } = this.state;
     const addedStake = this.getStake(dgd);
     const addedDgd = Number(dgd);
+    LogLockDgd.submit(addedDgd);
 
     const {
       web3Redux,
@@ -231,6 +233,7 @@ class LockDgd extends React.Component {
       web3Params,
       ui,
       showTxSigningModal: this.props.showTxSigningModal,
+      logTxn: LogLockDgd.txn,
     };
 
     return executeContractFunction(payload);
@@ -296,6 +299,10 @@ class LockDgd extends React.Component {
     }
 
     this.toggleBodyOverflow(lockDgdOverlay);
+    if (!lockDgdOverlay || !lockDgdOverlay.show) {
+      return null;
+    }
+
     return (
       <Container>
         <TransparentOverlay />

--- a/src/components/common/blocks/navbar/wallet.js
+++ b/src/components/common/blocks/navbar/wallet.js
@@ -15,8 +15,12 @@ class WalletButton extends React.Component {
     this.props.showHideWalletOverlay(true);
   };
 
+  showLockDgdOverlay = () => {
+    this.props.showHideLockDgd(true, null, 'Header');
+  };
+
   render() {
-    const { defaultAddress, showHideLockDgd, canLockDgd } = this.props;
+    const { defaultAddress, canLockDgd } = this.props;
 
     return (
       <WalletWrapper>
@@ -37,7 +41,7 @@ class WalletButton extends React.Component {
             primary
             small
             data-digix="Header-LockDgd"
-            onClick={() => showHideLockDgd(true)}
+            onClick={() => this.showLockDgdOverlay()}
           >
             Lock DGD
           </Button>

--- a/src/components/common/blocks/wallet/connected-wallet/index.js
+++ b/src/components/common/blocks/wallet/connected-wallet/index.js
@@ -182,7 +182,7 @@ class ConnectedWallet extends React.Component {
   showLockDgdOverlay = () => {
     const { onClose, showHideLockDgdOverlayAction } = this.props;
     onClose();
-    showHideLockDgdOverlayAction(true);
+    showHideLockDgdOverlayAction(true, null, 'Load Wallet Overlay');
   };
 
   showRenderApproval = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,9 @@ import lightTheme from '@digix/gov-ui/theme/light';
 
 import withHeaderAndPanel from '@digix/gov-ui/hocs/withHeaderAndPanel';
 
+import ReactGA from 'react-ga';
+import Analytics from '@digix/gov-ui/analytics';
+
 registerReducers({
   infoServer: { src: infoServerReducer },
   daoServer: { src: daoServerReducer },
@@ -43,6 +46,11 @@ const AuthenticatedRoute = ({ component: Component, isAuthenticated, ...rest }) 
   />
 );
 export class Governance extends React.Component {
+  componentDidMount() {
+    Analytics.init();
+    ReactGA.pageview(window.location.pathname);
+  }
+
   render() {
     const { isAuthenticated } = this.props;
     return (

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -131,6 +131,10 @@ class Profile extends React.Component {
     });
   }
 
+  showLockDgdOverlay() {
+    this.props.showHideLockDgdOverlay(true, this.onLockDgd, 'Profile Page');
+  }
+
   renderActivitySummary() {
     const { email, kyc } = this.props.userData;
     let currentKycStatus = 'Not Verified';
@@ -316,7 +320,7 @@ class Profile extends React.Component {
                 primary
                 data-digix="Profile-LockMoreDgd-Cta"
                 disabled={hasPendingLockTransaction}
-                onClick={() => this.props.showHideLockDgdOverlay(true, this.onLockDgd)}
+                onClick={() => this.showLockDgdOverlay()}
               >
                 Lock More DGD
               </Button>

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -47,6 +47,10 @@ class Wallet extends React.Component {
     });
   };
 
+  showLockDgdOverlay() {
+    this.props.showHideLockDgdOverlay(true, this.onLockDgd, 'Wallet Page');
+  }
+
   showUnlockDgdOverlay() {
     const { lockedDgd } = this.props;
     this.props.showRightPanel({
@@ -86,7 +90,7 @@ class Wallet extends React.Component {
               primary
               data-digix="Wallet-LockDgd"
               disabled={!canLockDgd}
-              onClick={() => this.props.showHideLockDgdOverlay(true, this.onLockDgd)}
+              onClick={() => this.showLockDgdOverlay()}
             >
               Lock DGD
             </Button>

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -15,7 +15,6 @@ export const actions = {
   SET_AUTHENTICATION_STATUS: `${REDUX_PREFIX}SET_AUTHENTICATION_STATUS`,
 
   SHOW_LEFT_MENU: `${REDUX_PREFIX}SHOW_LEFT_MENU`,
-
 };
 
 function fetchConfig(contract, config, type) {
@@ -41,9 +40,9 @@ export function fetchConfigPreproposalCollateral(contract, config) {
   return fetchConfig(contract, config, actions.GET_CONFIG_PREPROPOSAL_COLLATERAL);
 }
 
-export function showHideLockDgdOverlay(show, onSuccess) {
+export function showHideLockDgdOverlay(show, onSuccess, source) {
   return dispatch => {
-    dispatch({ type: actions.SHOW_LOCK_DGD_OVERLAY, payload: { show, onSuccess } });
+    dispatch({ type: actions.SHOW_LOCK_DGD_OVERLAY, payload: { show, onSuccess, source } });
   };
 }
 

--- a/src/reducers/gov-ui/index.js
+++ b/src/reducers/gov-ui/index.js
@@ -1,4 +1,5 @@
-import { actions } from './actions';
+import LogLockDgd from '@digix/gov-ui/analytics/lockDgd';
+import { actions } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 const defaultState = {
   lockDgdOverlay: {
@@ -24,6 +25,7 @@ const defaultState = {
 export default function(state = defaultState, action) {
   switch (action.type) {
     case actions.SHOW_LOCK_DGD_OVERLAY:
+      LogLockDgd.toggleOverlay(action.payload);
       return {
         ...state,
         lockDgdOverlay: {

--- a/src/utils/web3Helper.js
+++ b/src/utils/web3Helper.js
@@ -13,6 +13,7 @@ export const executeContractFunction = payload => {
     web3Params,
     ui,
     showTxSigningModal,
+    logTxn,
   } = payload;
   const {
     keystore: {
@@ -34,8 +35,13 @@ export const executeContractFunction = payload => {
         network
       ),
       ui,
+      logTxn,
     })
       .then(txHash => {
+        if (logTxn) {
+          logTxn.completeTransaction(true);
+        }
+
         if (typeof onSuccess === 'function') {
           onSuccess(txHash);
         }
@@ -46,6 +52,10 @@ export const executeContractFunction = payload => {
       })
       .catch(error => {
         onFailure(error);
+        if (logTxn) {
+          logTxn.completeTransaction(false, error);
+        }
+
         if (typeof onFinally === 'function') {
           const txHash = Object.keys(error.data)[0];
           onFinally(txHash);
@@ -58,9 +68,14 @@ export const executeContractFunction = payload => {
       .sendTransaction(...params, {
         from: address.address,
         ui,
+        logTxn,
         ...web3Params,
       })
       .then(txHash => {
+        if (logTxn) {
+          logTxn.completeTransaction(true);
+        }
+
         if (typeof onSuccess === 'function') {
           onSuccess(txHash);
         }
@@ -71,6 +86,10 @@ export const executeContractFunction = payload => {
       })
       .catch(error => {
         onFailure(error);
+        if (logTxn) {
+          logTxn.completeTransaction(false, error);
+        }
+
         if (typeof onFinally === 'function') {
           const data = error.data ? Object.keys(error.data) : undefined;
           const txHash = data ? data[0] : undefined;
@@ -82,9 +101,14 @@ export const executeContractFunction = payload => {
     .sendTransaction({
       from: address.address,
       ui,
+      logTxn,
       ...web3Params,
     })
     .then(txHash => {
+      if (logTxn) {
+        logTxn.completeTransaction(true);
+      }
+
       if (typeof onSuccess === 'function') {
         onSuccess(txHash);
       }
@@ -95,6 +119,10 @@ export const executeContractFunction = payload => {
     })
     .catch(error => {
       onFailure(error);
+      if (logTxn) {
+        logTxn.completeTransaction(false, error);
+      }
+
       if (typeof onFinally === 'function') {
         const data = error.data ? Object.keys(error.data) : undefined;
         const txHash = data ? data[0] : undefined;


### PR DESCRIPTION
Ref: [DGDG-299](https://tracker.digixdev.com/agiles/88-14/89-17?issue=DGDG-299). Dependent on [PR#3](https://github.com/DigixGlobal/governance-ui/pull/3) in `governance-ui` repo.

This adds the `react-ga` library which will interface with Google's Universal Analytics API to track pageviews and events.

**Test Plan**
- In the development environment, set `debug` to `true` in `DEFAULT_OPTIONS`. Go through the Lock DGD funnel and verify that the events are being tracked by checking the logs on the console.
- In the staging/production environment, go through the Lock DGD funnel and check that the events are logged into the `Lock DGD Funnel` goal on the Google Analytics website.