### PR TITLE
Refactor comments to use GraphQL queries

### DIFF
--- a/src/api/comments.js
+++ b/src/api/comments.js
@@ -66,25 +66,56 @@ export const CommentsApi = {
    */
 
   generateNewThread: comment => ({
-    hasMore: false,
-    data: [comment],
+    edges: [comment],
+    endCursor: '',
+    hasNextPage: false,
+    __typename: 'CommentEdge',
   }),
 
-  getUniqueUsers(users, threads) {
-    const { data } = threads;
-    if (!threads || data.length === 0) {
-      return users;
+  generateNewComment: (node, currentUser, parentId) => {
+    const { address, displayName } = currentUser;
+
+    return {
+      node: {
+        body: node.body,
+        createdAt: node.createdAt,
+        id: String(node.id),
+        liked: node.liked,
+        likes: 0,
+        parentId: String(parentId),
+
+        user: {
+          address,
+          displayName,
+          __typename: 'User',
+        },
+        replies: {
+          edges: [],
+          endCursor: '',
+          hasNextPage: false,
+          __typename: 'CommentConnection',
+        },
+        __typename: 'Comment',
+      },
+      __typename: 'CommentEdge',
+    };
+  },
+
+  getUniqueUsers(userAddresses, threads) {
+    if (!threads || !threads.edges.length) {
+      return userAddresses;
     }
 
-    data.forEach(thread => {
-      if (!users.includes(thread.user.address)) {
-        users.push(thread.user.address);
+    threads.edges.forEach(thread => {
+      const { address } = thread.node.user;
+      if (!userAddresses.includes(address)) {
+        userAddresses.push(address);
       }
 
-      this.getUniqueUsers(users, thread.replies);
+      this.getUniqueUsers(userAddresses, thread.replies);
     });
 
-    return users;
+    return userAddresses;
   },
 
   ERROR_MESSAGES: {

--- a/src/api/graphql-queries/comments.js
+++ b/src/api/graphql-queries/comments.js
@@ -1,0 +1,153 @@
+import gql from 'graphql-tag';
+
+const fragments = {
+  comment: gql`
+    fragment comment on Comment {
+      body
+      createdAt
+      id
+      liked
+      likes
+      parentId
+      user {
+        address
+        displayName
+      }
+    }
+  `,
+};
+
+export const fetchThreadsQuery = gql`
+  query fetchThreads(
+    $commentCount: Int
+    $endCursor: String
+    $proposalId: String
+    $replyCount: Int
+    $sortBy: ThreadSortByEnum
+    $threadCount: Int
+  ) {
+    commentThreads(
+      after: $endCursor
+      first: $threadCount
+      proposalId: $proposalId
+      sortBy: $sortBy
+    ) {
+      edges {
+        node {
+          ...comment
+          replies(first: $replyCount) {
+            edges {
+              node {
+                ...comment
+                replies(first: $commentCount) {
+                  edges {
+                    node {
+                      ...comment
+                      replies(first: 0) {
+                        edges {
+                          node {
+                            body
+                          }
+                        }
+                        endCursor
+                        hasNextPage
+                      }
+                    }
+                  }
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+      endCursor
+      hasNextPage
+    }
+  }
+
+  ${fragments.comment}
+`;
+
+export const fetchRepliesQuery = gql`
+  query fetchReplies(
+    $commentCount: Int
+    $proposalId: String
+    $endCursor: String
+    $replyCount: Int
+    $sortBy: ThreadSortByEnum
+  ) {
+    commentThreads(
+      after: $endCursor
+      first: $replyCount
+      proposalId: $proposalId
+      sortBy: $sortBy
+    ) {
+      edges {
+        node {
+          ...comment
+          replies(first: $commentCount) {
+            edges {
+              node {
+                ...comment
+                replies(first: 0) {
+                  edges {
+                    node {
+                      body
+                    }
+                  }
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+      endCursor
+      hasNextPage
+    }
+  }
+
+  ${fragments.comment}
+`;
+
+export const fetchCommentsQuery = gql`
+  query fetchReplies(
+    $sortBy: ThreadSortByEnum
+    $commentCount: Int
+    $endCursor: String
+    $proposalId: String
+  ) {
+    commentThreads(
+      after: $endCursor
+      first: $commentCount
+      proposalId: $proposalId
+      sortBy: $sortBy
+    ) {
+      edges {
+        node {
+          ...comment
+          replies(first: 0) {
+            edges {
+              node {
+                body
+              }
+            }
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+      endCursor
+      hasNextPage
+    }
+  }
+
+  ${fragments.comment}
+`;

--- a/src/pages/proposals/comment/comment.js
+++ b/src/pages/proposals/comment/comment.js
@@ -19,7 +19,7 @@ class Comment extends React.Component {
       comment: this.props.comment,
     };
 
-    this.DELETE_MESSAGE = 'This message has been removed by the user.';
+    this.DELETE_MESSAGE = 'This message has been removed.';
   }
 
   deleteComment() {
@@ -55,11 +55,13 @@ class Comment extends React.Component {
   };
 
   render() {
-    const { toggleEditor, uid, userPoints } = this.props;
+    const { currentUser, toggleEditor, userPoints } = this.props;
     const { comment } = this.state;
     const { body, liked, likes, user } = comment;
-    const isAuthor = uid === user.address;
+
+    const isAuthor = user && currentUser.address === user.address;
     const isDeleted = !body;
+    const likeLabel = likes === 1 ? 'Like' : 'Likes';
 
     return (
       <article className="comment">
@@ -79,7 +81,9 @@ class Comment extends React.Component {
                 onClick={() => this.toggleLike()}
               >
                 <Icon active={liked} kind="like" />
-                <span>{likes}&nbsp;Likes</span>
+                <span>
+                  {likes}&nbsp;{likeLabel}
+                </span>
               </ActionCommentButton>
               {isAuthor && (
                 <ActionCommentButton kind="text" small onClick={() => this.deleteComment()}>
@@ -99,10 +103,10 @@ const { func, object, string } = PropTypes;
 
 Comment.propTypes = {
   comment: object.isRequired,
+  currentUser: object.isRequired,
   ChallengeProof: object,
   setError: func.isRequired,
   toggleEditor: func,
-  uid: string.isRequired,
   userPoints: object.isRequired,
 };
 

--- a/src/pages/proposals/comment/index.js
+++ b/src/pages/proposals/comment/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withApollo } from 'react-apollo';
 
 import { Button, Select } from '@digix/gov-ui/components/common/elements/index';
 import {
@@ -14,6 +15,8 @@ import CommentTextEditor from '@digix/gov-ui/pages/proposals/comment/editor';
 import ParentThread from '@digix/gov-ui/pages/proposals/comment/thread';
 
 import { CommentsApi } from '@digix/gov-ui/api/comments';
+import { fetchDisplayName } from '@digix/gov-ui/api/graphql-queries/users';
+import { fetchThreadsQuery } from '@digix/gov-ui/api/graphql-queries/comments';
 import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
 import { getDaoProposalDetails } from '@digix/gov-ui/reducers/dao-server/actions';
 import { initializePayload } from '@digix/gov-ui/api';
@@ -24,8 +27,7 @@ class CommentThread extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      lastSeenId: 0,
-      sortBy: 'latest',
+      sortBy: 'LATEST',
       threads: null,
       userAddresses: [],
       userPoints: {},
@@ -34,112 +36,143 @@ class CommentThread extends React.Component {
     this.FILTERS = [
       {
         text: 'Latest',
-        value: 'latest',
+        value: 'LATEST',
       },
       {
         text: 'Oldest',
-        value: 'oldest',
+        value: 'OLDEST',
       },
     ];
+
+    // to be defined in componentDidMount
+    this.currentUser = {
+      address: undefined,
+      displayName: undefined,
+    };
+
+    // for invalidating comments cache in apollo
+    this.CACHED_COMMENT_KEYS = /^(Comment|\$Comment|commentThreads|\$ROOT_QUERY\.commentThreads)/;
+
+    this.THREAD_COUNT = 10;
+    this.REPLY_COUNT = 5;
+    this.COMMENT_COUNT = 3;
   }
 
   componentDidMount() {
-    const { ChallengeProof, getDaoProposalDetailsActions, proposalId } = this.props;
+    const { sortBy } = this.state;
+    const { ChallengeProof, proposalId, uid } = this.props;
+    const apollo = this.props.client;
+
+    this.fetchThreads({ sortBy });
+    this.fetchUserPoints(this.state.threads);
+    const cache = apollo.readQuery({ query: fetchDisplayName });
+    this.currentUser = {
+      address: uid,
+      displayName: cache.currentUser.displayName,
+    };
+
     if (!ChallengeProof.data) {
       return;
     }
 
-    const { sortBy } = this.state;
     const payload = initializePayload(ChallengeProof);
-    getDaoProposalDetailsActions({ proposalId, ...payload })
-      .then(() => {
-        this.fetchThreads({ sort_by: sortBy }, true);
-      })
-      .catch(() => {
-        this.setError(CommentsApi.ERROR_MESSAGES.fetch);
-      });
+    this.props.getDaoProposalDetails({ proposalId, ...payload }).catch(() => {
+      this.setError(CommentsApi.ERROR_MESSAGES.fetch);
+    });
+  }
+
+  // NOTE: there's no method for partial cache invalidation in apollo so we have to do it manually here.
+  // Ref: https://github.com/apollographql/apollo-feature-requests/issues/4
+  componentWillUnmount() {
+    const apollo = this.props.client;
+    const cache = apollo.store.cache.data;
+    if (!cache || !cache.data) {
+      return;
+    }
+
+    Object.keys(cache.data).forEach(key => {
+      if (key.match(this.CACHED_COMMENT_KEYS)) {
+        cache.delete(key);
+      }
+    });
+  }
+
+  getQueryVariables(vars) {
+    const { proposalId } = this.props;
+
+    return {
+      proposalId,
+      threadCount: this.THREAD_COUNT,
+      replyCount: this.REPLY_COUNT,
+      commentCount: this.COMMENT_COUNT,
+      ...vars,
+    };
   }
 
   setError = error => {
-    const message = JSON.stringify((error && error.message) || error);
+    const message = JSON.stringify(error && error.message) || error;
     this.props.showHideAlert({ message });
-    document.body.scrollTop = 0;
   };
 
   handleFilterChange = e => {
     const sortBy = e.target.value;
-    this.fetchThreads({ sort_by: sortBy }, true);
+    this.fetchThreads({ sortBy });
     this.setState({ sortBy });
   };
 
   addThread = body => {
-    let threads = { ...this.state.threads };
     const { ChallengeProof, rootCommentId } = this.props;
-
     if (!ChallengeProof || !rootCommentId) {
+      this.setError(CommentsApi.ERROR_MESSAGES.createComment);
       return;
     }
 
+    let { threads } = this.state;
+    const { sortBy } = this.state;
     const payload = initializePayload(ChallengeProof);
+
     CommentsApi.create(rootCommentId, body, payload)
-      .then(newComment => {
-        if (!threads) {
+      .then(node => {
+        const newComment = CommentsApi.generateNewComment(node, this.currentUser, rootCommentId);
+        if (!threads || !threads.edges.length) {
           threads = CommentsApi.generateNewThread(newComment);
+        } else if (sortBy === 'OLDEST') {
+          threads.edges.push(newComment);
+          window.scrollTo(0, document.body.scrollHeight);
         } else {
-          threads.data.push(newComment);
+          threads.edges.unshift(newComment);
         }
 
         this.setState({ threads });
-        window.scrollTo(0, document.body.scrollHeight);
       })
       .catch(() => {
         this.setError(CommentsApi.ERROR_MESSAGES.createComment);
       });
   };
 
-  fetchThreads = (fetchParams, reset = false) => {
-    const { ChallengeProof, rootCommentId } = this.props;
-    if (!ChallengeProof.data || !rootCommentId) {
-      return;
-    }
+  fetchThreads(vars) {
+    const apollo = this.props.client;
+    const variables = this.getQueryVariables(vars);
 
-    const payload = initializePayload(ChallengeProof);
-    CommentsApi.getThread(rootCommentId, fetchParams, payload)
-      .then(newThreads => {
-        let { threads } = this.state;
-        const newComments = newThreads.data;
-        const lastSeenId =
-          newThreads && newComments.length > 0
-            ? newComments[newComments.length - 1].id
-            : this.state.lastSeenId;
-
-        if (reset || !threads) {
-          threads = newThreads;
-        } else {
-          threads = {
-            ...threads,
-            hasMore: newThreads.hasMore,
-            data: threads.data.concat(newComments),
-          };
-        }
-
-        this.setState({ lastSeenId, threads });
+    apollo
+      .query({
+        fetchPolicy: 'network-only',
+        query: fetchThreadsQuery,
+        variables,
       })
-      .then(() => {
-        this.fetchUserPoints();
-      })
-      .catch(() => {
-        this.setError(CommentsApi.ERROR_MESSAGES.fetch);
+      .then(result => {
+        const threads = result.data.commentThreads;
+        this.setState({ threads });
       });
-  };
+  }
 
-  fetchUserPoints = () => {
-    const { threads, userAddresses } = this.state;
-    const { ChallengeProof, getAddressDetailsAction, uid } = this.props;
+  fetchUserPoints = threads => {
+    const { userAddresses } = this.state;
+    const { ChallengeProof, uid } = this.props;
 
-    // reputation points for first-time commenters
-    // are not available in the previous endpoint
-    getAddressDetailsAction(uid);
+    // reputation points for first-time commenters are not available in the previous endpoint
+    // so we need to call this to update the current user's data in case they haven't commented yet
+    this.props.getAddressDetails(uid);
 
     if (!ChallengeProof.data) {
       return;
@@ -147,7 +180,7 @@ class CommentThread extends React.Component {
 
     const previousUniqueAddressesCount = userAddresses.length;
     const newUniqueAddresses = CommentsApi.getUniqueUsers(userAddresses, threads);
-    if (threads.length && previousUniqueAddressesCount === newUniqueAddresses.length) {
+    if (previousUniqueAddressesCount === newUniqueAddresses.length) {
       return;
     }
 
@@ -169,58 +202,74 @@ class CommentThread extends React.Component {
       });
   };
 
-  loadMoreComments = () => {
-    const { lastSeenId, sortBy } = this.state;
-    this.fetchThreads({
-      last_seen_id: lastSeenId,
-      sort_by: sortBy,
+  loadMore = endCursor => {
+    const { sortBy, threads } = this.state;
+    const apollo = this.props.client;
+    const variables = this.getQueryVariables({
+      endCursor,
+      sortBy,
     });
+
+    apollo
+      .query({
+        fetchPolicy: 'network-only',
+        query: fetchThreadsQuery,
+        variables,
+      })
+      .then(result => {
+        const data = result.data.commentThreads;
+        threads.edges = threads.edges.concat(data.edges);
+        threads.hasNextPage = data.hasNextPage;
+        threads.endCursor = data.endCursor;
+        this.setState({ threads });
+      });
   };
 
-  renderThreads = threads => {
-    const { uid } = this.props;
-    const { sortBy, userPoints } = this.state;
+  renderThreads(threadList) {
+    const { userPoints } = this.state;
 
-    return threads.data.map(thread => (
-      <ParentThread
-        key={thread.id}
-        fetchUserPoints={this.fetchUserPoints}
-        setError={this.setError}
-        sortBy={sortBy}
-        thread={thread}
-        uid={uid}
-        userPoints={userPoints}
-      />
-    ));
-  };
+    return threadList.edges.map(thread => {
+      const comment = thread.node;
+
+      return (
+        <ParentThread
+          currentUser={this.currentUser}
+          key={comment.id}
+          queryVariables={this.getQueryVariables()}
+          setError={this.setError}
+          thread={comment}
+          userPoints={userPoints}
+        />
+      );
+    });
+  }
 
   render() {
-    const { rootCommentId } = this.props;
-    const { threads } = this.state;
-    const noComments = !rootCommentId || !threads || threads.data.length === 0;
+    const { sortBy, threads } = this.state;
 
     return (
       <ThreadedComments>
         <Title>Discussions</Title>
         <CommentTextEditor addComment={this.addThread} />
-        {noComments && <p>There are no comments to show.</p>}
-        {!noComments && (
-          <div>
+        {!threads && <p>There are no comments to show.</p>}
+        {threads && (
+          <section>
             <CommentFilter>
               <Select
                 small
                 id="comment-filter"
                 items={this.FILTERS}
+                value={sortBy}
                 onChange={this.handleFilterChange}
               />
             </CommentFilter>
             <CommentList>{this.renderThreads(threads)}</CommentList>
-          </div>
-        )}
-        {threads && threads.hasMore && (
-          <Button kind="text" xsmall onClick={() => this.loadMoreComments()}>
-            Load more comments...
-          </Button>
+            {threads.hasNextPage && (
+              <Button kind="text" xsmall onClick={() => this.loadMore(threads.endCursor)}>
+                Load more comments...
+              </Button>
+            )}
+          </section>
         )}
       </ThreadedComments>
     );
@@ -232,8 +281,9 @@ const { func, number, object, string } = PropTypes;
 CommentThread.propTypes = {
   addressDetails: object,
   ChallengeProof: object,
-  getAddressDetailsAction: func.isRequired,
-  getDaoProposalDetailsActions: func.isRequired,
+  client: object.isRequired,
+  getAddressDetails: func.isRequired,
+  getDaoProposalDetails: func.isRequired,
   proposalId: string.isRequired,
   rootCommentId: number,
   showHideAlert: func.isRequired,
@@ -245,6 +295,7 @@ CommentThread.defaultProps = {
     reputationPoint: 0,
     quarterPoint: 0,
   },
+
   ChallengeProof: undefined,
   rootCommentId: 0,
   uid: '',
@@ -256,11 +307,13 @@ const mapStateToProps = ({ daoServer, infoServer }) => ({
   rootCommentId: daoServer.ProposalDaoDetails.data.commentId,
 });
 
-export default connect(
-  mapStateToProps,
-  {
-    getAddressDetailsAction: getAddressDetails,
-    getDaoProposalDetailsActions: getDaoProposalDetails,
-    showHideAlert,
-  }
-)(CommentThread);
+export default withApollo(
+  connect(
+    mapStateToProps,
+    {
+      getAddressDetails,
+      getDaoProposalDetails,
+      showHideAlert,
+    }
+  )(CommentThread)
+);

--- a/src/pages/proposals/comment/reply.js
+++ b/src/pages/proposals/comment/reply.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withApollo } from 'react-apollo';
 
 import Comment from '@digix/gov-ui/pages/proposals/comment/comment';
 import CommentTextEditor from '@digix/gov-ui/pages/proposals/comment/editor';
-// import { Button } from '@digix/gov-ui/components/common/elements/index';
-import { CommentReplyPost, LoadMoreButton } from '@digix/gov-ui/pages/proposals/comment/style';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import { CommentReplyPost } from '@digix/gov-ui/pages/proposals/comment/style';
 import { CommentsApi } from '@digix/gov-ui/api/comments';
+import { fetchCommentsQuery } from '@digix/gov-ui/api/graphql-queries/comments';
 import { initializePayload } from '@digix/gov-ui/api';
 
 class CommentReply extends React.Component {
@@ -14,36 +16,34 @@ class CommentReply extends React.Component {
     super(props);
     const { comment } = this.props;
 
-    let lastSeenId = comment.id;
-    const replies = comment.replies.data;
-    if (comment.replies && replies.length > 0) {
-      lastSeenId = replies[replies.length - 1].id;
-    }
-
     this.state = {
       comment,
-      lastSeenId,
       showEditor: false,
     };
   }
 
   addReply = body => {
     const comment = { ...this.state.comment };
-    const { ChallengeProof, setError } = this.props;
+    const { ChallengeProof, currentUser, setError } = this.props;
 
     if (!ChallengeProof.data) {
+      setError(CommentsApi.ERROR_MESSAGES.createComment);
       return;
     }
 
     const payload = initializePayload(ChallengeProof);
     CommentsApi.create(comment.id, body, payload)
-      .then(newComment => {
-        if (!comment.replies) {
-          comment.replies = CommentsApi.generateNewThread(newComment);
+      .then(node => {
+        const newComment = CommentsApi.generateNewComment(node, currentUser, comment.id);
+        let replyList = comment.replies.edges;
+
+        if (!replyList) {
+          replyList = CommentsApi.generateNewThread(newComment);
         } else {
-          comment.replies.data.push(newComment);
+          replyList.push(newComment);
         }
 
+        comment.replies.edges = replyList;
         this.setState({ comment });
       })
       .catch(() => {
@@ -51,55 +51,9 @@ class CommentReply extends React.Component {
       });
   };
 
-  fetchThreads = fetchParams => {
-    const { ChallengeProof, fetchUserPoints } = this.props;
-    if (!ChallengeProof.data) {
-      return null;
-    }
-
-    const { comment } = this.state;
-    const payload = initializePayload(ChallengeProof);
-
-    CommentsApi.getThread(comment.id, fetchParams, payload)
-      .then(newComments => {
-        const newReplies = newComments.data;
-        const lastSeenId =
-          newComments && newReplies.length > 0
-            ? newReplies[newReplies.length - 1].id
-            : this.state.lastSeenId;
-
-        comment.replies = {
-          ...comment.replies,
-          hasMore: newComments.hasMore,
-          data: comment.replies.data.concat(newReplies),
-        };
-
-        this.setState({ lastSeenId, comment });
-        return newComments;
-      })
-      .then(() => {
-        fetchUserPoints();
-      })
-      .catch(() => {
-        this.setError(CommentsApi.ERROR_MESSAGES.fetch);
-      });
-
-    return null;
-  };
-
   hideEditor = () => {
     this.setState({
       showEditor: false,
-    });
-  };
-
-  loadMoreReplies = () => {
-    const { lastSeenId } = this.state;
-    const { sortBy } = this.props;
-
-    this.fetchThreads({
-      last_seen_id: lastSeenId,
-      sort_by: sortBy,
     });
   };
 
@@ -110,8 +64,32 @@ class CommentReply extends React.Component {
     });
   };
 
+  loadMore = endCursor => {
+    const { comment } = this.state;
+    const apollo = this.props.client;
+    const variables = {
+      ...this.props.queryVariables,
+      endCursor,
+      sortBy: 'OLDEST',
+    };
+
+    apollo
+      .query({
+        fetchPolicy: 'network-only',
+        query: fetchCommentsQuery,
+        variables,
+      })
+      .then(result => {
+        const data = result.data.commentThreads;
+        comment.replies.edges = comment.replies.edges.concat(data.edges);
+        comment.replies.hasNextPage = data.hasNextPage;
+        comment.replies.endCursor = data.endCursor;
+        this.setState({ comment });
+      });
+  };
+
   render() {
-    const { renderThreadReplies, setError, uid, userPoints } = this.props;
+    const { currentUser, renderThreadReplies, setError, userPoints } = this.props;
     const { comment, showEditor } = this.state;
 
     if (!comment) {
@@ -119,29 +97,32 @@ class CommentReply extends React.Component {
     }
 
     const { replies } = comment;
-    const hasMoreChildren = replies.data && replies.data.length === 0 && replies.hasMore;
+    const hasChildren = replies && replies.hasNextPage && !replies.edges.length;
 
     return (
       <section>
-        <CommentReplyPost>
-          <Comment
-            comment={comment}
-            setError={setError}
-            toggleEditor={this.toggleEditor}
-            uid={uid}
-            userPoints={userPoints}
-          />
-          {showEditor && (
-            <CommentTextEditor addComment={this.addReply} callback={this.hideEditor} />
-          )}
-
-          {renderThreadReplies(comment.replies)}
-        </CommentReplyPost>
-        {hasMoreChildren && (
+        {comment.id && (
           <CommentReplyPost>
-            <LoadMoreButton kind="text" tertiary xsmall onClick={() => this.loadMoreReplies()}>
-              Load more replies...
-            </LoadMoreButton>
+            <Comment
+              comment={comment}
+              currentUser={currentUser}
+              setError={setError}
+              toggleEditor={this.toggleEditor}
+              userPoints={userPoints}
+            />
+            {showEditor && (
+              <CommentTextEditor addComment={this.addReply} callback={this.hideEditor} />
+            )}
+            {replies && renderThreadReplies(replies)}
+          </CommentReplyPost>
+        )}
+        {hasChildren && (
+          <CommentReplyPost>
+            <CommentReplyPost>
+              <Button kind="text" tertiary xsmall onClick={() => this.loadMore(replies.endCursor)}>
+                Load more comments...
+              </Button>
+            </CommentReplyPost>
           </CommentReplyPost>
         )}
       </section>
@@ -149,16 +130,16 @@ class CommentReply extends React.Component {
   }
 }
 
-const { func, object, string } = PropTypes;
+const { func, object } = PropTypes;
 
 CommentReply.propTypes = {
   ChallengeProof: object,
+  client: object.isRequired,
   comment: object.isRequired,
-  fetchUserPoints: func.isRequired,
+  currentUser: object.isRequired,
+  queryVariables: object.isRequired,
   renderThreadReplies: func.isRequired,
   setError: func.isRequired,
-  sortBy: string.isRequired,
-  uid: string.isRequired,
   userPoints: object.isRequired,
 };
 
@@ -170,7 +151,9 @@ const mapStateToProps = state => ({
   ChallengeProof: state.daoServer.ChallengeProof,
 });
 
-export default connect(
-  mapStateToProps,
-  {}
-)(CommentReply);
+export default withApollo(
+  connect(
+    mapStateToProps,
+    {}
+  )(CommentReply)
+);

--- a/src/pages/proposals/comment/style.js
+++ b/src/pages/proposals/comment/style.js
@@ -105,7 +105,3 @@ export const CommentReplyPost = styled.div`
   margin-left: 5rem;
   margin-top: 1rem;
 `;
-
-export const LoadMoreButton = styled(Button)`
-  margin-left: -2rem;
-`;


### PR DESCRIPTION
Ref: [DGDG-301](https://tracker.digixdev.com/issue/DGDG-301). Depends on [PR#28](https://github.com/DigixGlobal/dao-server/pull/28) for the `dao-server`

**Dev Notes**

`apollographql` does not have an existing API for invalidating parts of the cache. Thus, a workaround is provided in the `componentWillUnmount` method of the `<CommentThread/>` component to invalidate the comments cache. This is needed since we update the cache manually with new data whenever the user adds a comment, and that data may not necessarily be compatible with the server data. This also forces a refetch whenever we load the project page, ensuring that the data is always updated.

For more information, see the following github issue: https://github.com/apollographql/apollo-feature-requests/issues/4.

**Test Plan**

Regression test on comments. Make sure that the following still works:
- Add, delete, like, unlike comments. Make sure these changes persist when we reload the page.
- Loading more comments. Test on at least three levels of nested comments.
- Sorting comments.