### PR TITLE
allow forumAdmin to sign in transaction to digixDao

### DIFF
--- a/src/components/common/blocks/address-watcher/index.js
+++ b/src/components/common/blocks/address-watcher/index.js
@@ -45,7 +45,7 @@ class AddressWatcher extends React.PureComponent {
       getAddressDetailsVanilla(address)
         .then(({ json: { result } }) => result)
         .then(details => {
-          if (!details.isParticipant && !details.isKycOfficer) {
+          if (!details.isParticipant && !details.isKycOfficer && !details.isForumAdmin) {
             this.props.setUserAddress(address);
             this.setState({ verifyingUser: false });
 


### PR DESCRIPTION
Issue: 
- forumAdmin address can't sign in to system

Solution:
- add `isForumAdmin` as one of the attribute to show the sign in modal