### PR TITLE
Add error overlay for Create Project button

### DIFF
--- a/src/components/common/blocks/filter/index.js
+++ b/src/components/common/blocks/filter/index.js
@@ -1,53 +1,118 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import Category from './category';
-import Icon from '../../elements/icons/Plus';
+import { connect } from 'react-redux';
+import { withApollo } from 'react-apollo';
 
-import { Button, Select } from '../../index';
+import Category from '@digix/gov-ui/components/common/blocks/filter/category.js';
+import ErrorMessageOverlay from '@digix/gov-ui/components/common/blocks/overlay/error-message';
+import Icon from '@digix/gov-ui/components/common/elements/icons/Plus';
+import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { getDaoConfig } from '@digix/gov-ui/reducers/info-server/actions';
+import { getUnmetProposalRequirements } from '@digix/gov-ui/utils/helpers';
+import { H1 } from '@digix/gov-ui/components/common/common-styles';
+import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
+import { ProposalErrors } from '@digix/gov-ui/constants';
+import { Select } from '@digix/gov-ui/components/common/elements/index';
+import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
+import {
+  CreateProjectBtn,
+  Heading,
+  Filter,
+  FilterWrapper,
+  Pulldown,
+} from '@digix/gov-ui/components/common/blocks/filter/style';
 
-import { Heading, FilterWrapper, Filter, Pulldown } from './style';
-import { H1 } from '../../common-styles';
+const network = SpectrumConfig.defaultNetworks[0];
 
-export default class ProposalCardFilter extends React.Component {
+class ProposalCardFilter extends React.Component {
+  constructor(props) {
+    super(props);
+    this.FILTERS = [
+      {
+        text: 'Latest',
+        value: 'latest',
+      },
+      {
+        text: 'Oldest',
+        value: 'oldest',
+      },
+    ];
+  }
+
+  getEthBalance() {
+    const { AddressDetails, web3Redux } = this.props;
+    const { web3 } = web3Redux.networks[network];
+    return web3.eth
+      .getBalance(AddressDetails.data.address)
+      .then(balance => parseBigNumber(balance, 18, false));
+  }
+
+  getUnmetCreateRequirements = () => {
+    const { DaoConfig, DaoDetails, client } = this.props;
+    const dataCalls = [
+      getUnmetProposalRequirements(client, DaoDetails),
+      this.props.getDaoConfig(),
+      this.getEthBalance(),
+    ];
+
+    return Promise.all(dataCalls).then(([errors, config, ethBalance]) => {
+      const requiredCollateral = Number(DaoConfig.CONFIG_PREPROPOSAL_COLLATERAL);
+      if (ethBalance < requiredCollateral) {
+        errors.push(ProposalErrors.insufficientCollateral(requiredCollateral));
+      }
+
+      return errors;
+    });
+  };
+
   handleChange = e => {
     const { onOrderChange } = this.props;
-    if (onOrderChange) onOrderChange(e.target.value);
+    if (onOrderChange) {
+      onOrderChange(e.target.value);
+    }
   };
+
+  redirectToCreateProposal() {
+    this.getUnmetCreateRequirements().then(errors => {
+      if (errors.length) {
+        this.showErrorOverlay(errors);
+      } else {
+        this.props.history.push('/proposals/create');
+      }
+    });
+  }
+
+  showErrorOverlay(errors) {
+    this.props.showRightPanel({
+      component: <ErrorMessageOverlay errors={errors} location="Dashboard" />,
+      show: true,
+    });
+  }
+
   render() {
-    const { addressDetails } = this.props;
-    const canCreate = addressDetails && addressDetails.data.isParticipant;
+    const { AddressDetails } = this.props;
+    const canCreate = AddressDetails && AddressDetails.data.isParticipant;
     return (
       <FilterWrapper>
         <Heading>
           <H1>Projects</H1>
           {canCreate && (
-            <Link
-              to="/proposals/create"
-              href="/proposals/create"
-              style={{ display: 'inline-block' }}
+            <CreateProjectBtn
+              kind="round"
+              primary
+              showIcon
+              onClick={() => this.redirectToCreateProposal()}
             >
-              <Button
-                kind="round"
-                primary
-                showIcon
-                style={{ paddingLeft: '2rem', paddingRight: '2rem' }}
-              >
-                <Icon kind="plus" />
-                Create
-              </Button>
-            </Link>
+              <Icon kind="plus" />
+              Create
+            </CreateProjectBtn>
           )}
         </Heading>
         <Filter>
           <Category {...this.props} />
           <Pulldown>
-            <Select
-              small
-              id="test"
-              items={[{ text: 'Latest', value: 'latest' }, { text: 'Oldest', value: 'oldest' }]}
-              onChange={this.handleChange}
-            />
+            <Select small id="test" items={this.FILTERS} onChange={this.handleChange} />
           </Pulldown>
         </Filter>
       </FilterWrapper>
@@ -58,6 +123,30 @@ export default class ProposalCardFilter extends React.Component {
 const { func, object } = PropTypes;
 
 ProposalCardFilter.propTypes = {
+  AddressDetails: object.isRequired,
+  client: object.isRequired,
+  DaoConfig: object.isRequired,
+  DaoDetails: object.isRequired,
+  getDaoConfig: func.isRequired,
+  history: object.isRequired,
   onOrderChange: func.isRequired,
-  addressDetails: object.isRequired,
+  showRightPanel: func.isRequired,
+  web3Redux: object.isRequired,
 };
+
+const mapStateToProps = ({ infoServer }) => ({
+  DaoConfig: infoServer.DaoConfig.data,
+  DaoDetails: infoServer.DaoDetails.data,
+});
+
+export default withApollo(
+  web3Connect(
+    connect(
+      mapStateToProps,
+      {
+        getDaoConfig,
+        showRightPanel,
+      }
+    )(ProposalCardFilter)
+  )
+);

--- a/src/components/common/blocks/filter/style.js
+++ b/src/components/common/blocks/filter/style.js
@@ -1,4 +1,9 @@
 import styled, { css } from 'styled-components';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+
+export const CreateProjectBtn = styled(Button)`
+  padding: 1rem 2rem;
+`;
 
 export const FilterWrapper = styled.div`
   margin-bottom: 3em;

--- a/src/components/common/blocks/lock-dgd/index.js
+++ b/src/components/common/blocks/lock-dgd/index.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { connect } from 'react-redux';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import PropTypes, { array } from 'prop-types';
-import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { inLockingPhase, truncateNumber } from '@digix/gov-ui/utils/helpers';
 import DaoStakeLocking from '@digix/dao-contracts/build/contracts/DaoStakeLocking.json';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
@@ -243,10 +243,7 @@ class LockDgd extends React.Component {
   renderLockDgd = () => {
     const { dgd, disableLockDgdButton, openError, error } = this.state;
     const { daoDetails } = this.props;
-
-    const currentTime = Date.now() / 1000;
-    const inLockingPhase = currentTime < Number(daoDetails.startOfMainphase);
-    const phase = inLockingPhase ? 'Staking' : 'Main';
+    const phase = inLockingPhase(daoDetails) ? 'Staking' : 'Main';
 
     const stake = truncateNumber(this.getStake(dgd));
 

--- a/src/components/common/blocks/overlay/error-message/index.js
+++ b/src/components/common/blocks/overlay/error-message/index.js
@@ -1,35 +1,65 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import { Button } from '@digix/gov-ui/components/common/elements/index';
-
 import {
   IntroContainer,
   OverlayHeader as Header,
   Notifications,
 } from '@digix/gov-ui/components/common/common-styles';
+import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 class ErrorMessageOverlay extends React.Component {
+  closeOverlay() {
+    this.props.showRightPanel({
+      show: false,
+    });
+  }
+
+  renderNotification = error => (
+    <Notifications error key={error.title} data-digix="ProjectError-Notification">
+      <h3 data-digix="ProjectError-Notification-Title">{error.title}</h3>
+      <p>{error.description}</p>
+      <p>{error.details}</p>
+    </Notifications>
+  );
+
   render() {
+    const { errors, location } = this.props;
     return (
       <IntroContainer>
         <Header uppercase>&nbsp;</Header>
-        <Notifications error>
-          <h3>Not Enough Collateral!</h3>
-          <p>
-            It looks like there is insufficient ETH in your wallet. You will need 2 ETH for your
-            project as collateral.
-          </p>
-          <p>Let's try again when you have enough ETH.</p>
-        </Notifications>
-
-        <Button secondary fluid large onClick={this.handleButtonClick}>
-          Return to Dashboard
+        {errors.map(item => this.renderNotification(item))}
+        <Button
+          fluid
+          large
+          secondary
+          data-digix="ProjectError-Return"
+          onClick={() => this.closeOverlay()}
+        >
+          Return to {location}
         </Button>
       </IntroContainer>
     );
   }
 }
 
-ErrorMessageOverlay.propTypes = {};
+const { array, func, string } = PropTypes;
+ErrorMessageOverlay.propTypes = {
+  errors: array.isRequired,
+  location: string,
+  showRightPanel: func.isRequired,
+};
 
-export default ErrorMessageOverlay;
+ErrorMessageOverlay.defaultProps = {
+  location: 'Project',
+};
+
+const mapStateToProps = () => ({});
+export default connect(
+  mapStateToProps,
+  {
+    showRightPanel,
+  }
+)(ErrorMessageOverlay);

--- a/src/constants.js
+++ b/src/constants.js
@@ -71,3 +71,31 @@ export const KycStatus = {
   expired: 'EXPIRED',
   approved: 'APPROVED',
 };
+
+export const ProposalErrors = {
+  blockedByPRL: {
+    title: 'Funding Is Stopped by PRL',
+    description: 'The project funding has been stopped due to Policy, Regulatory or Legal reasons.',
+    details: 'Please contact us if you have any enquiries.',
+  },
+
+  invalidKyc: {
+    title: 'KYC Is Not Valid',
+    description:
+      "It looks like you don't have a valid KYC yet. You can check your KYC status in the Profile tab.",
+    details: "Let's try again when your KYC has been approved.",
+  },
+
+  inLockingPhase: {
+    title: 'Not Main Phase Yet!',
+    description:
+      "Looks like it's still the Locking phase now. You need to wait until the Main phase to do any governance activity.",
+    details: "Let's try again when it's the Main phase again.",
+  },
+
+  insufficientCollateral: requiredCollateral => ({
+    title: 'Not Enough Collateral!',
+    description: `It looks like there is insufficient ETH in your wallet. You will need ${requiredCollateral} ETH for your project as collateral.`,
+    details: "Let's try again when you have enough ETH.",
+  }),
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -147,7 +147,8 @@ class LandingPage extends React.PureComponent {
         <ProposalFilter
           onStageChange={this.getProposals}
           onOrderChange={this.onOrderChange}
-          addressDetails={AddressDetails}
+          AddressDetails={AddressDetails}
+          history={history}
         />
         {hasProposals &&
           orderedProposals.map(proposal => (

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -13,7 +13,7 @@ import {
   getDaoConfig,
   getDaoDetails,
 } from '@digix/gov-ui/reducers/info-server/actions';
-import { getUserStatus, truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { getUserStatus, inLockingPhase, truncateNumber } from '@digix/gov-ui/utils/helpers';
 import { showHideLockDgdOverlay, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { withFetchUser } from '@digix/gov-ui/api/graphql-queries/users';
 
@@ -70,12 +70,11 @@ class Profile extends React.Component {
     const { DaoDetails } = this.props;
     const { startOfMainphase, startOfNextQuarter } = DaoDetails.data;
 
-    const currentTime = Date.now() / 1000;
-    const inLockingPhase = currentTime < startOfMainphase;
-    if (inLockingPhase) {
+    if (inLockingPhase(DaoDetails.data)) {
       return DEFAULT_STAKE_PER_DGD;
     }
 
+    const currentTime = Date.now() / 1000;
     return (startOfNextQuarter - currentTime) / (startOfNextQuarter - startOfMainphase);
   };
 

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -11,7 +11,7 @@ import {
   showRightPanel,
   showHideLockDgdOverlay,
 } from '@digix/gov-ui/reducers/gov-ui/actions';
-import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { inLockingPhase, truncateNumber } from '@digix/gov-ui/utils/helpers';
 
 import {
   QtrParticipation,
@@ -66,11 +66,9 @@ class Wallet extends React.Component {
 
     const canLockDgd = this.props.CanLockDgd.show && !hasPendingLockTransaction;
 
-    const currentTime = Date.now() / 1000;
     const isGlobalRewardsSet = DaoDetails ? DaoDetails.isGlobalRewardsSet : false;
-    const inLockingPhase = currentTime < DaoDetails.startOfMainphase;
     const canUnlockDgd =
-      inLockingPhase && stake > 0 && isGlobalRewardsSet && !hasPendingUnlockTransaction;
+      inLockingPhase(DaoDetails) && stake > 0 && isGlobalRewardsSet && !hasPendingUnlockTransaction;
 
     return (
       <QtrParticipation>

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,6 +1,7 @@
 import multihash from '@digix/multi-hash';
+import { fetchUserQuery } from '@digix/gov-ui/api/graphql-queries/users';
+import { KycStatus, ProposalErrors, UserStatus } from '@digix/gov-ui/constants';
 import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
-import { UserStatus } from '@digix/gov-ui/constants';
 
 export function encodeHash(hash) {
   // eslint-disable-line import/prefer-default-export
@@ -68,4 +69,32 @@ export const getUserStatus = addressDetails => {
   }
 
   return UserStatus.guest;
+};
+
+export const isKycApproved = apolloClient =>
+  apolloClient.query({ query: fetchUserQuery }).then(response => {
+    const { kyc } = response.data.currentUser;
+    return kyc && kyc.status === KycStatus.approved;
+  });
+
+export const inLockingPhase = DaoDetails => {
+  const currentTime = Date.now() / 1000;
+  return currentTime < Number(DaoDetails.startOfMainphase);
+};
+
+// checks general conditions that should be met when doing any proposal action
+export const getUnmetProposalRequirements = (apolloClient, DaoDetails) => {
+  const errors = [];
+
+  return isKycApproved(apolloClient).then(kycApproved => {
+    if (!kycApproved) {
+      errors.push(ProposalErrors.invalidKyc);
+    }
+
+    if (inLockingPhase(DaoDetails)) {
+      errors.push(ProposalErrors.inLockingPhase);
+    }
+
+    return errors;
+  });
 };


### PR DESCRIPTION
Ref: [DGDG-352](https://tracker.digixdev.com/issue/DGDG-352), [DGDG-311](https://tracker.digixdev.com/issue/DGDG-311)

This checks that the user meets the requirements needed for creating a project.

**Dev Notes**

The helper method `getUnmetProposalRequirements` checks the general conditions that should be met when doing any project action. This will be used in future commits when the error overlay will be applied to other project actions.

The method `inLockingPhase` is also added as a helper. As a consequence of this, other components that check for the current phase has been changed to use the same helper method, for easier maintenance in the future.

**Test Plan**

*Feature Test*

When clicking the `Create` button on the dashboard, the error overlay should appear if any of the following conditions are met:
- User is not KYC verified.
- User clicks during the locking phase.
- User's ETH balance is less than `DaoConfigs.CONFIG_PREPROPOSAL_COLLATERAL` (at the time of this writing, this is equal to 2 DGD).

The error messages should stack in the overlay if the user meets more than one condition.

If none of these conditions are met, the user should be redirected to the **Create Project** page.

*Regression Test*

The following should still work:
- When locking DGD, the correct stake is shown on the overlay. If in the locking phase, 1 DGD = 1 stake; otherwise, we calculate based on the current time.
- The correct phase is shown on the notification on top of the Lock DGD overlay i.e. the message `You are now locking in the ___ phase`.
- **Unlock DGD** button on the Wallet page should only be visible during the locking phase.