### PR TITLE
Fix/dgdg 344

### DIFF
--- a/src/components/common/blocks/user-DAO-stats/index.js
+++ b/src/components/common/blocks/user-DAO-stats/index.js
@@ -12,6 +12,7 @@ import {
 class UserDAOStats extends React.Component {
   render() {
     const { stats } = this.props;
+    const lockedDgd = truncateNumber(stats.data.lockedDgd);
     const stake = truncateNumber(stats.data.lockedDgdStake || 0);
     if (!stats.data.address) return null;
     return (
@@ -29,7 +30,7 @@ class UserDAOStats extends React.Component {
         <Item>
           <Label>My Stake</Label>
           <Data data-digix="Dashboard-Stats-Stake">
-            <span>{stake}</span> <span className="equiv">({stats.data.lockedDgd} DGD LOCKED)</span>
+            <span>{stake}</span> <span className="equiv">({lockedDgd} DGD LOCKED)</span>
           </Data>
         </Item>
       </UserStats>

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -221,6 +221,7 @@ class Profile extends React.Component {
     const { hasPendingLockTransaction } = this.state;
 
     const address = AddressDetails.data;
+    const lockedDgd = truncateNumber(AddressDetails.data.lockedDgd);
     let stake = Number(address.lockedDgdStake);
     const usernameIsSet = this.props.userData.username;
 
@@ -291,7 +292,7 @@ class Profile extends React.Component {
             <Label>My Stake</Label>
             <Data data-digix="Profile-Stake">
               <span>{stake}</span>
-              <span className="equiv">({AddressDetails.data.lockedDgd} DGD LOCKED)</span>
+              <span className="equiv">({lockedDgd} DGD LOCKED)</span>
             </Data>
           </Item>
         </UserStats>

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -63,7 +63,7 @@ class Wallet extends React.Component {
     const { hasPendingLockTransaction, hasPendingUnlockTransaction } = this.state;
     const stake = truncateNumber(this.props.stake);
     const DaoDetails = this.props.DaoDetails.data;
-
+    const lockedDgd = truncateNumber(this.props.lockedDgd);
     const canLockDgd = this.props.CanLockDgd.show && !hasPendingLockTransaction;
 
     const currentTime = Date.now() / 1000;
@@ -78,8 +78,8 @@ class Wallet extends React.Component {
         <Detail>
           <Label>Your Current Lock-up</Label>
           <Data>
-            <span data-digix="Wallet-Stake">{stake}</span>
-            <span>&nbsp;Stake</span>
+            <span data-digix="Wallet-Locked-DGD">{lockedDgd}</span>
+            <span>&nbsp;DGD</span>
           </Data>
           <Desc>
             You can lock more DGD to increase your voting power or unlock after a quarter to move


### PR DESCRIPTION
Target:
- Replace `Stake` label to `DGD` label on Your Locked DGD card in Wallet Page
- Instead of showing `Stake` value, show `DGD` value on Your Locked DGD card in Wallet Page
- Truncate floating value when rendering DGD value on Dashboard, Profile, and Wallet Page.