### PR TITLE
Add error overlay for project actions

### DIFF
--- a/src/pages/proposals/proposal-buttons/abort.js
+++ b/src/pages/proposals/proposal-buttons/abort.js
@@ -91,6 +91,11 @@ class AbortProjectButton extends React.PureComponent {
     };
     return executeContractFunction(payload);
   };
+
+  abortProject() {
+    this.props.checkProposalRequirements(this.handleSubmit);
+  }
+
   render() {
     const { stage, isProposer, finalVersionIpfsDoc } = this.props;
     const stagesThatCanAbort = [ProposalStages.idea, ProposalStages.draft];
@@ -103,7 +108,12 @@ class AbortProjectButton extends React.PureComponent {
     }
 
     return (
-      <Button kind="round" large onClick={this.handleSubmit}>
+      <Button
+        kind="round"
+        large
+        data-digix="ProposalAction-Abort"
+        onClick={() => this.abortProject()}
+      >
         Abort
       </Button>
     );
@@ -119,6 +129,7 @@ AbortProjectButton.propTypes = {
   isProposer: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/claim-approval.js
+++ b/src/pages/proposals/proposal-buttons/claim-approval.js
@@ -95,6 +95,10 @@ class ClaimApprovalButton extends React.Component {
     return executeContractFunction(payload);
   };
 
+  claimApproval() {
+    this.props.checkProposalRequirements(this.handleSubmit);
+  }
+
   render() {
     const { draftVoting, isProposer, votingStage, daoConfig } = this.props;
     const voteClaimingDeadline = daoConfig.data.CONFIG_VOTE_CLAIMING_DEADLINE;
@@ -110,8 +114,8 @@ class ClaimApprovalButton extends React.Component {
       <Button
         kind="round"
         large
-        onClick={this.handleSubmit}
-        data-digix="Create-Proposal-Claim-Approval"
+        data-digix="ProposalAction-Approval"
+        onClick={() => this.claimApproval()}
       >
         Claim Approval
       </Button>
@@ -127,6 +131,7 @@ ClaimApprovalButton.propTypes = {
   daoConfig: object.isRequired,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   getDaoConfig: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/claim-funding.js
+++ b/src/pages/proposals/proposal-buttons/claim-funding.js
@@ -12,11 +12,16 @@ import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import getContract from '@digix/gov-ui/utils/contracts';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE, ProposalStages } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import Button from '@digix/gov-ui/components/common/elements/buttons/index';
+import {
+  DEFAULT_GAS,
+  DEFAULT_GAS_PRICE,
+  ProposalErrors,
+  ProposalStages,
+} from '@digix/gov-ui/constants';
 
 registerUIs({ txVisualization: { component: TxVisualization } });
 
@@ -92,6 +97,17 @@ class ClaimFundingButton extends React.PureComponent {
     };
     return executeContractFunction(payload);
   };
+
+  claimFunding() {
+    const errors = [];
+    const { proposal } = this.props;
+    if (proposal.prl) {
+      errors.push(ProposalErrors.blockedByPRL);
+    }
+
+    this.props.checkProposalRequirements(this.handleSubmit, errors);
+  }
+
   render() {
     const { isProposer, proposal } = this.props;
     if (
@@ -102,7 +118,12 @@ class ClaimFundingButton extends React.PureComponent {
       return null;
 
     return (
-      <Button kind="round" large onClick={this.handleSubmit}>
+      <Button
+        kind="round"
+        large
+        data-digix="ProposalAction-ClaimFunding"
+        onClick={() => this.claimFunding()}
+      >
         Claim Funding
       </Button>
     );
@@ -116,6 +137,7 @@ ClaimFundingButton.propTypes = {
   isProposer: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/claim-results.js
+++ b/src/pages/proposals/proposal-buttons/claim-results.js
@@ -100,6 +100,10 @@ class ClaimResultsButton extends React.PureComponent {
     return executeContractFunction(payload);
   };
 
+  claimResults() {
+    this.props.checkProposalRequirements(this.handleSubmit);
+  }
+
   render() {
     const {
       isProposer,
@@ -129,10 +133,10 @@ class ClaimResultsButton extends React.PureComponent {
     return (
       <Button
         disabled={claimed}
-        data-digix="Propsal-Claim-Results"
         kind="round"
         large
-        onClick={this.handleSubmit}
+        data-digix="ProposalAction-Results"
+        onClick={() => this.claimResults()}
       >
         Claim Results
       </Button>
@@ -147,6 +151,7 @@ ClaimResultsButton.propTypes = {
   isProposer: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   daoConfig: object.isRequired,
   showHideAlert: func.isRequired,
   getDaoConfig: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/edit-funding.js
+++ b/src/pages/proposals/proposal-buttons/edit-funding.js
@@ -21,6 +21,10 @@ class EditFundingButton extends React.PureComponent {
     });
   };
 
+  editFunding() {
+    this.props.checkProposalRequirements(this.showOverlay);
+  }
+
   render() {
     const { isProposer, proposal } = this.props;
     const canEdit = proposal.stage === ProposalStages.ongoing && isProposer;
@@ -31,7 +35,12 @@ class EditFundingButton extends React.PureComponent {
     if (!canEdit || !hasUnfinishedMilestones) return null;
 
     return (
-      <Button kind="round" large onClick={() => this.showOverlay()}>
+      <Button
+        kind="round"
+        large
+        data-digix="ProposalAction-EditFunding"
+        onClick={() => this.editFunding()}
+      >
         Edit Funding
       </Button>
     );
@@ -41,6 +50,7 @@ class EditFundingButton extends React.PureComponent {
 const { bool, func, object } = PropTypes;
 
 EditFundingButton.propTypes = {
+  checkProposalRequirements: func.isRequired,
   isProposer: bool,
   proposal: object.isRequired,
   history: object.isRequired,

--- a/src/pages/proposals/proposal-buttons/finalize.js
+++ b/src/pages/proposals/proposal-buttons/finalize.js
@@ -106,6 +106,11 @@ class FinalizeProjectButton extends React.PureComponent {
     };
     return executeContractFunction(payload);
   };
+
+  finalizeProposal() {
+    this.props.checkProposalRequirements(this.handleSubmit);
+  }
+
   render() {
     const { stage, endorser, isProposer, timeCreated, finalVersionIpfsDoc, daoConfig } = this.props;
 
@@ -126,7 +131,12 @@ class FinalizeProjectButton extends React.PureComponent {
     }
 
     return (
-      <Button kind="round" large onClick={this.handleSubmit} data-digix="Create-Proposal-Finalize">
+      <Button
+        kind="round"
+        large
+        data-digix="ProposalAction-Finalize"
+        onClick={() => this.finalizeProposal()}
+      >
         Finalize
       </Button>
     );
@@ -144,6 +154,7 @@ FinalizeProjectButton.propTypes = {
   web3Redux: object.isRequired,
   daoConfig: object.isRequired,
   challengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   getDaoConfig: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/milestone-completed.js
+++ b/src/pages/proposals/proposal-buttons/milestone-completed.js
@@ -90,6 +90,11 @@ class CompleteMilestoneButton extends React.PureComponent {
     };
     return executeContractFunction(payload);
   };
+
+  completeMilestone() {
+    this.props.checkProposalRequirements(this.handleSubmit);
+  }
+
   render() {
     const { isProposer, proposal } = this.props;
     if (
@@ -105,7 +110,12 @@ class CompleteMilestoneButton extends React.PureComponent {
     if (!withinDeadline) return null;
 
     return (
-      <Button kind="round" large onClick={this.handleSubmit}>
+      <Button
+        kind="round"
+        large
+        data-digix="ProposalAction-CompleteMilestone"
+        onClick={() => this.completeMilestone()}
+      >
         My Milestone is completed
       </Button>
     );
@@ -119,6 +129,7 @@ CompleteMilestoneButton.propTypes = {
   isProposer: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/participants/index.js
+++ b/src/pages/proposals/proposal-buttons/participants/index.js
@@ -1,7 +1,9 @@
+/* eslint-disable react/jsx-no-bind */
+
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-
-import { ProposalStages } from '@digix/gov-ui/constants';
+import { connect } from 'react-redux';
+import { withApollo } from 'react-apollo';
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/index';
 import AbortButton from '@digix/gov-ui/pages/proposals/proposal-buttons/abort';
@@ -13,17 +15,46 @@ import ClaimFundingButton from '@digix/gov-ui/pages/proposals/proposal-buttons/c
 import VoteCommitButton from '@digix/gov-ui/pages/proposals/proposal-buttons/vote-commit';
 import RevealButton from '@digix/gov-ui/pages/proposals/proposal-buttons/reveal-button';
 import EditFundingButton from '@digix/gov-ui/pages/proposals/proposal-buttons/edit-funding';
+import ErrorMessageOverlay from '@digix/gov-ui/components/common/blocks/overlay/error-message';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { getUnmetProposalRequirements } from '@digix/gov-ui/utils/helpers';
+import { ProposalStages } from '@digix/gov-ui/constants';
+import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 
-class ParticantButtons extends React.Component {
+class ParticipantButtons extends React.Component {
   constructor(props) {
     super(props);
     this.STAGES_THAT_CAN_EDIT = [ProposalStages.idea, ProposalStages.draft];
   }
 
-  handleEditClick = () => {
+  showErrorOverlay(errors) {
+    this.props.showRightPanel({
+      component: <ErrorMessageOverlay errors={errors} />,
+      show: true,
+    });
+  }
+
+  checkUnmetRequirements(proposalAction, customErrors) {
+    const { client, DaoDetails } = this.props;
+
+    getUnmetProposalRequirements(client, DaoDetails).then(errors => {
+      let totalErrors = errors;
+      if (customErrors) {
+        totalErrors = errors.concat(customErrors);
+      }
+
+      if (totalErrors.length) {
+        this.showErrorOverlay(totalErrors);
+      } else {
+        proposalAction();
+      }
+    });
+  }
+
+  editProject() {
     const { history, proposal } = this.props;
     history.push(`/proposals/edit/${proposal.data.proposalId}`);
-  };
+  }
 
   render() {
     const {
@@ -33,6 +64,8 @@ class ParticantButtons extends React.Component {
       addressDetails,
     } = this.props;
 
+    const checkProposalRequirements = this.checkUnmetRequirements.bind(this);
+    const editAction = this.editProject.bind(this);
     const showEditButton =
       isProposer && this.STAGES_THAT_CAN_EDIT.includes(data.stage) && !data.votingStage;
 
@@ -44,9 +77,10 @@ class ParticantButtons extends React.Component {
           proposalId={data.proposalId}
           finalVersionIpfsDoc={data.finalVersionIpfsDoc}
           history={history}
+          checkProposalRequirements={checkProposalRequirements}
         />
         {showEditButton && (
-          <Button kind="round" onClick={this.handleEditClick}>
+          <Button kind="round" onClick={() => checkProposalRequirements(editAction)}>
             Edit
           </Button>
         )}
@@ -56,6 +90,7 @@ class ParticantButtons extends React.Component {
           proposalId={data.proposalId}
           history={history}
           isProposer={isProposer}
+          checkProposalRequirements={checkProposalRequirements}
         />
         <FinalizeButton
           endorser={data.endorser}
@@ -65,6 +100,7 @@ class ParticantButtons extends React.Component {
           finalVersionIpfsDoc={data.finalVersionIpfsDoc}
           history={history}
           timeCreated={data.timeCreated}
+          checkProposalRequirements={checkProposalRequirements}
         />
         <ClaimApprovalButton
           isProposer={isProposer}
@@ -72,6 +108,7 @@ class ParticantButtons extends React.Component {
           history={history}
           votingStage={data.votingStage}
           proposalId={data.proposalId}
+          checkProposalRequirements={checkProposalRequirements}
         />
         <VoteCommitButton
           isParticipant={addressDetails.data.isParticipant}
@@ -89,9 +126,24 @@ class ParticantButtons extends React.Component {
           votingStage={data.votingStage}
           votes={addressDetails.data.votes}
         />
-        <ClaimResultsButton isProposer={isProposer} proposal={data} history={history} />
-        <ClaimFundingButton isProposer={isProposer} proposal={data} history={history} />
-        <MilestoneCompletedButton isProposer={isProposer} proposal={data} history={history} />
+        <ClaimResultsButton
+          checkProposalRequirements={checkProposalRequirements}
+          isProposer={isProposer}
+          history={history}
+          proposal={data}
+        />
+        <ClaimFundingButton
+          checkProposalRequirements={checkProposalRequirements}
+          isProposer={isProposer}
+          history={history}
+          proposal={data}
+        />
+        <MilestoneCompletedButton
+          checkProposalRequirements={checkProposalRequirements}
+          isProposer={isProposer}
+          history={history}
+          proposal={data}
+        />
       </Fragment>
     );
   }
@@ -99,16 +151,32 @@ class ParticantButtons extends React.Component {
 
 const { object, bool, func } = PropTypes;
 
-ParticantButtons.propTypes = {
-  proposal: object.isRequired,
-  isProposer: bool.isRequired,
+ParticipantButtons.propTypes = {
   addressDetails: object.isRequired,
-  onCompleted: func,
+  client: object.isRequired,
+  DaoDetails: object.isRequired,
   history: object.isRequired,
+  isProposer: bool.isRequired,
+  onCompleted: func,
+  proposal: object.isRequired,
+  showRightPanel: func.isRequired,
 };
 
-ParticantButtons.defaultProps = {
+ParticipantButtons.defaultProps = {
   onCompleted: undefined,
 };
 
-export default ParticantButtons;
+const mapStateToProps = ({ infoServer }) => ({
+  DaoDetails: infoServer.DaoDetails.data,
+});
+
+export default withApollo(
+  web3Connect(
+    connect(
+      mapStateToProps,
+      {
+        showRightPanel,
+      }
+    )(ParticipantButtons)
+  )
+);


### PR DESCRIPTION
Ref: [DGDG-352](https://tracker.digixdev.com/issue/DGDG-352), [DGDG-311](https://tracker.digixdev.com/issue/DGDG-311)

This checks that the user meets the requirements needed for triggering a proposal action.

**Test Plan**

When clicking a proposal action button, the error overlay should appear if any of the following conditions are met:
- User is not KYC verified.
- User clicks during the locking phase.
- `proposal.prl` is not `true` (applies only for the **Claim Funding** action)

The error messages should stack in the overlay if the user meets more than one condition. If none of these conditions are met, the proposal action should continue as expected.

The following are the actions that should be checked for. All of these actions can be done by a participant i.e. no moderator actions are checked for errors.
- Abort
- Edit
- Finalize
- Claim Voting
- Claim Funding
- Change Funding
- Finish Milestone