### PR TITLE
temporary disable kyc validation when creating proposals

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -87,9 +87,9 @@ export const getUnmetProposalRequirements = (apolloClient, DaoDetails) => {
   const errors = [];
 
   return isKycApproved(apolloClient).then(kycApproved => {
-    if (!kycApproved) {
-      errors.push(ProposalErrors.invalidKyc);
-    }
+    // if (!kycApproved) {
+    //   errors.push(ProposalErrors.invalidKyc);
+    // }
 
     if (inLockingPhase(DaoDetails)) {
       errors.push(ProposalErrors.inLockingPhase);


### PR DESCRIPTION
this is will temporary push to sprint-5 so we can create proposal without kyc approved. 