### PR TITLE
Fix ETH balance validation when creating a project

### DIFF
--- a/src/components/common/blocks/filter/index.js
+++ b/src/components/common/blocks/filter/index.js
@@ -49,7 +49,7 @@ class ProposalCardFilter extends React.Component {
   }
 
   getUnmetCreateRequirements = () => {
-    const { DaoConfig, DaoDetails, client } = this.props;
+    const { DaoDetails, client } = this.props;
     const dataCalls = [
       getUnmetProposalRequirements(client, DaoDetails),
       this.props.getDaoConfig(),
@@ -57,7 +57,7 @@ class ProposalCardFilter extends React.Component {
     ];
 
     return Promise.all(dataCalls).then(([errors, config, ethBalance]) => {
-      const requiredCollateral = Number(DaoConfig.CONFIG_PREPROPOSAL_COLLATERAL);
+      const requiredCollateral = Number(this.props.DaoConfig.CONFIG_PREPROPOSAL_COLLATERAL);
       if (ethBalance < requiredCollateral) {
         errors.push(ProposalErrors.insufficientCollateral(requiredCollateral));
       }


### PR DESCRIPTION
Ref: [DGDG-311](https://tracker.digixdev.com/issue/DGDG-311)

`DaoConfig` is not necessarily updated during the ETH balance check since we're getting the value before the promises are finished. This diff ensures that we're getting the correct value for `DaoConfig` so that we can correctly check for the ETH balance.