### PR TITLE
Grant forum admin permission to view projects

### DIFF
--- a/src/api/graphql-queries/users.js
+++ b/src/api/graphql-queries/users.js
@@ -107,7 +107,7 @@ export const UserMutations = {
 export const renderDisplayName = dataDigixAttribute => (
   <Query query={fetchDisplayName}>
     {({ loading, error, data }) => {
-      if (loading || error) {
+      if (loading || error || !data.currentUser) {
         return null;
       }
 

--- a/src/components/common/blocks/collapsible-menu/index.js
+++ b/src/components/common/blocks/collapsible-menu/index.js
@@ -118,7 +118,7 @@ class CollapsibleMenu extends React.Component {
   };
 
   renderAdminMenuItem = menu => (
-    <Query query={fetchUserQuery}>
+    <Query query={fetchUserQuery} key={menu.title}>
       {({ loading, error, data }) => {
         const isAllowed = data.currentUser && data.currentUser[menu.requirement];
         if (loading || error || !isAllowed) {

--- a/src/components/common/blocks/wallet/connected-wallet/index.js
+++ b/src/components/common/blocks/wallet/connected-wallet/index.js
@@ -51,6 +51,8 @@ class ConnectedWallet extends React.Component {
       ethBalance: 0,
       showLockDgd: false,
     };
+
+    this._isMounted = false;
   }
 
   componentDidMount() {
@@ -121,7 +123,11 @@ class ConnectedWallet extends React.Component {
     }
   }
 
-  _isMounted = false;
+  setError = error => {
+    this.props.showHideAlert({
+      message: JSON.stringify(error && error.message) || error,
+    });
+  };
 
   handleApprove = () => {
     const { web3Redux, challengeProof, addresses } = this.props;

--- a/src/components/proposal-card/proposal.js
+++ b/src/components/proposal-card/proposal.js
@@ -24,6 +24,7 @@ import {
   unlikeProposal,
   getUserProposalLikeStatus,
 } from '@digix/gov-ui/reducers/dao-server/actions';
+import { withFetchUser } from '@digix/gov-ui/api/graphql-queries/users';
 
 class Proposal extends React.PureComponent {
   toggleLike = () => {
@@ -64,7 +65,17 @@ class Proposal extends React.PureComponent {
   };
 
   render() {
-    const { details, userDetails, likes, liked, userProposalLike, displayName, title } = this.props;
+    const {
+      details,
+      displayName,
+      liked,
+      likes,
+      title,
+      userData,
+      userDetails,
+      userProposalLike,
+    } = this.props;
+
     const likeStatus =
       userProposalLike.data && userProposalLike.data.proposalId === details.proposalId
         ? userProposalLike.data
@@ -74,8 +85,10 @@ class Proposal extends React.PureComponent {
       details.proposalVersions && details.proposalVersions.length > 0
         ? details.proposalVersions[details.proposalVersions.length - 1]
         : undefined;
+
     const canCreate = userDetails && userDetails.data.isParticipant;
     const canLike = userDetails && userDetails.data.address;
+    const isForumAdmin = userData && userData.isForumAdmin;
 
     return (
       <ProposaDetaillWrapper>
@@ -88,24 +101,13 @@ class Proposal extends React.PureComponent {
           <Description>
             <H2>{proposalVersion ? proposalVersion.dijixObject.title : title}</H2>
             <p>{proposalVersion ? proposalVersion.dijixObject.description : ''}</p>
-
-            {canCreate ? (
-              <ProposalLink
-                href={`/proposals/${details.proposalId}`}
-                to={`/proposals/${details.proposalId}`}
-              >
-                View Project
-              </ProposalLink>
-            ) : (
-              <ProposalLink
-                disabled
-                href={`/proposals/${details.proposalId}`}
-                to={`/proposals/${details.proposalId}`}
-                style={{ pointerEvents: 'none' }}
-              >
-                View Project
-              </ProposalLink>
-            )}
+            <ProposalLink
+              disabled={!canCreate && !isForumAdmin}
+              href={`/proposals/${details.proposalId}`}
+              to={`/proposals/${details.proposalId}`}
+            >
+              View Project
+            </ProposalLink>
           </Description>
           <ProposalFooter>
             <PostedBy>
@@ -139,6 +141,7 @@ Proposal.propTypes = {
   likeProposalAction: func.isRequired,
   unlikeProposalAction: func.isRequired,
   getUserProposalLikeStatusAction: func.isRequired,
+  userData: object,
   userDetails: object.isRequired,
   userProposalLike: object.isRequired,
 };
@@ -153,13 +156,16 @@ Proposal.defaultProps = {
   liked: false,
   likes: undefined,
   title: '',
+  userData: undefined,
 };
 
-export default connect(
-  mapStateToProps,
-  {
-    likeProposalAction: likeProposal,
-    unlikeProposalAction: unlikeProposal,
-    getUserProposalLikeStatusAction: getUserProposalLikeStatus,
-  }
-)(Proposal);
+export default withFetchUser(
+  connect(
+    mapStateToProps,
+    {
+      likeProposalAction: likeProposal,
+      unlikeProposalAction: unlikeProposal,
+      getUserProposalLikeStatusAction: getUserProposalLikeStatus,
+    }
+  )(Proposal)
+);

--- a/src/components/proposal-card/style.js
+++ b/src/components/proposal-card/style.js
@@ -62,6 +62,7 @@ export const ProposalLink = styled(Link)`
       props.disabled
         ? props.theme.linkDefaultColor.light.toString()
         : props.theme.linkPrimaryColor.default.toString()};
+    pointer-events: ${props => (props.disabled ? 'none' : 'auto')};
   }
 
   &:hover {


### PR DESCRIPTION
Ref: [DGDG-301](https://tracker.digixdev.com/issue/DGDG-301)

Forum Admin accounts should be able to view projects so they can individually ban/unban comments. Project action buttons (e.g. Abort, Edit, etc.) will not be available for these users.

**Test Plan**
- Load `account15` and check that they can view projects and add comments.
- Regression test: Verify that `participant` and `moderator` accounts can still view projects and do project actions on them.