### PR TITLE
Fix UI bugs and refactor rendering of milestones

### DIFF
--- a/src/components/common/elements/accordion/accordion-selection.js
+++ b/src/components/common/elements/accordion/accordion-selection.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Icons from '../../elements/icons/Icons';
-import { AccordionItem, Header, Content, Title, Funding, Amount } from './styles';
+import Icons from '@digix/gov-ui/components/common/elements/icons/Icons';
+import {
+  Amount,
+  AccordionItem,
+  ChevronContainer,
+  Content,
+  Funding,
+  Header,
+  Title,
+} from '@digix/gov-ui/components/common/elements/accordion/styles';
 
 export default class AccordionSelection extends React.Component {
   onClickItemHandler = () => {
@@ -16,27 +24,30 @@ export default class AccordionSelection extends React.Component {
 
     const svgIcon = isOpen ? '#arrow_up' : '#arrow_down';
 
+    let difference = '';
+    if (milestoneFund) {
+      const sign = milestoneFund > 0 ? `+` : `-`;
+      difference = `${sign} ${Math.abs(milestoneFund)}`;
+    }
+
     return (
       <AccordionItem>
         <Header onClick={onClickItemHandler} style={{ cursor: 'pointer' }}>
           <Title>{label}</Title>
           <Funding>
             <Amount>
-              {funding}{' '}
-              {milestoneFund && (
-                <span>
-                  {milestoneFund > 0 ? ` + ${milestoneFund}` : ` - ${Math.abs(milestoneFund)}`}
-                </span>
-              )}
+              {funding}&nbsp;
+              <span>{difference}</span>
+              &nbsp;ETH
             </Amount>
-            <div style={{ width: '18px', height: '18px' }}>
+            <ChevronContainer>
               <Icons />
               <span>
                 <svg>
                   <use xlinkHref={svgIcon} />
                 </svg>
               </span>
-            </div>
+            </ChevronContainer>
           </Funding>
         </Header>
         {isOpen && <Content>{children}</Content>}

--- a/src/components/common/elements/accordion/styles.js
+++ b/src/components/common/elements/accordion/styles.js
@@ -91,3 +91,8 @@ export const Content = styled.div`
   margin-top: 2rem;
   transition: all 0.25s ease-in-out;
 `;
+
+export const ChevronContainer = styled.div`
+  height: 18px;
+  width: 18px;
+`;

--- a/src/pages/proposals/comment/index.js
+++ b/src/pages/proposals/comment/index.js
@@ -272,13 +272,14 @@ class CommentThread extends React.Component {
   render() {
     const { currentUser, sortBy, threads } = this.state;
     const { canComment } = currentUser;
+    const hasComments = threads !== null && threads.edges.length > 0;
 
     return (
       <ThreadedComments>
         <Title>Discussions</Title>
         <CommentTextEditor addComment={this.addThread} canComment={canComment} />
-        {!threads && <p>There are no comments to show.</p>}
-        {threads && (
+        {!hasComments && <p>There are no comments to show.</p>}
+        {hasComments && (
           <section>
             <CommentFilter>
               <Select

--- a/src/pages/proposals/create/index.js
+++ b/src/pages/proposals/create/index.js
@@ -134,7 +134,7 @@ class CreateProposal extends React.Component {
 
   createAttestation = () => {
     const { form } = this.state;
-    const { title, description, details, milestones, proofs } = form;
+    const { title, description, details, finalReward, milestones, proofs } = form;
 
     return dijix
       .create('attestation', {
@@ -143,6 +143,7 @@ class CreateProposal extends React.Component {
           description,
           details,
           milestones,
+          finalReward,
         },
         proofs: proofs && proofs.length > 0 ? [...proofs] : undefined,
       })

--- a/src/pages/proposals/edit/index.js
+++ b/src/pages/proposals/edit/index.js
@@ -81,7 +81,6 @@ class EditProposal extends React.Component {
         ? proposalDetails.data.proposalVersions[proposalDetails.data.proposalVersions.length - 1]
         : {};
       const form = { ...currentVersion.dijixObject };
-      form.finalReward = Number(currentVersion.finalReward);
       this.setState({
         form: { ...form },
         proposalId: proposalDetails.data.proposalId,
@@ -158,7 +157,7 @@ class EditProposal extends React.Component {
 
   createAttestation = () => {
     const { form } = this.state;
-    const { title, description, details, milestones, proofs, images } = form;
+    const { title, description, details, finalReward, milestones, proofs, images } = form;
 
     return dijix
       .create('attestation', {
@@ -167,6 +166,7 @@ class EditProposal extends React.Component {
           description,
           details,
           milestones,
+          finalReward,
         },
         proofs: images && images[0] !== null ? images.concat(proofs) : proofs,
       })

--- a/src/pages/proposals/milestones.js
+++ b/src/pages/proposals/milestones.js
@@ -4,45 +4,54 @@ import Accordion from '@digix/gov-ui/components/common/elements/accordion/index'
 import { MilestonesContainer, SubTitle } from '@digix/gov-ui/pages/proposals/style';
 
 export default class Milestones extends React.Component {
+  constructor(props) {
+    super(props);
+    this.NO_MILESTONE_DESCRIPTION = 'No milestone description has been created yet.';
+  }
+
+  renderMilestone(milestone, index) {
+    const { changedFundings, fundingChanged } = this.props;
+
+    let funding;
+    let milestoneFund;
+    const description = milestone.description || this.NO_MILESTONE_DESCRIPTION;
+    const order = index + 1;
+
+    if (fundingChanged) {
+      const { original, updated } = changedFundings[index];
+      funding = Number(original);
+      milestoneFund = Number(updated) - funding;
+    } else {
+      funding = milestone.fund;
+    }
+
+    return (
+      <div
+        key={`ms-${order}`}
+        label={`Milestone ${order}: ${milestone.title || ''}`}
+        funding={funding}
+        milestoneFund={milestoneFund}
+      >
+        {description}
+      </div>
+    );
+  }
+
   render() {
-    const { milestones, milestoneFundings, changedFundings, fundingChanged } = this.props;
+    const { milestones } = this.props;
+    const milestoneElements = milestones.map((milestone, i) => this.renderMilestone(milestone, i));
 
     return (
       <MilestonesContainer>
         <SubTitle>Milestones</SubTitle>
-        <Accordion allowMultipleOpen>
-          {milestones.map((milestone, i) => {
-            // eslint-disable-next-line
-            const funding = fundingChanged
-              ? Number(changedFundings[i].original)
-              : milestoneFundings
-              ? milestoneFundings[i]
-              : milestones[i].fund;
-            const updatedFunding = fundingChanged ? Number(changedFundings[i].updated) : 0;
-            const milestoneFund = fundingChanged ? updatedFunding - funding : undefined;
-
-            return (
-              <div
-                key={`ms-${i + 1}`}
-                label={`Milestone ${i + 1}: ${milestone.title || ''}`}
-                funding={milestoneFundings ? milestoneFundings[i] : milestones[i].fund}
-                milestoneFund={milestoneFund !== 0 ? milestoneFund : undefined}
-              >
-                {milestone.description
-                  ? milestone.description
-                  : 'No milestone description has been created yet.'}
-              </div>
-            );
-          })}
-        </Accordion>
+        <Accordion allowMultipleOpen>{milestoneElements}</Accordion>
       </MilestonesContainer>
     );
   }
 }
 
 Milestones.propTypes = {
-  milestones: PropTypes.array.isRequired,
-  milestoneFundings: PropTypes.array.isRequired,
   changedFundings: PropTypes.array.isRequired,
   fundingChanged: PropTypes.bool.isRequired,
+  milestones: PropTypes.array.isRequired,
 };


### PR DESCRIPTION
Ref: [DT-83](https://tracker.digixdev.com/issue/DT-83)

This diff implements minor UI fixes for the Project page and refactors how we render milestones.

For the milestone refactor, the logic for change fundings is modularized and moved to the `getChangedFundings` and `renderProposalFundings` methods in the `<Proposal/>` component, to make the logic easier to maintain. `finalReward` is also added to `dijixObject` when we create the attestation, so we can keep track of the reward changes in each project version.

The following are the UI changes:
- Add `ETH` label to milestone accordion in Project page.
- Hide comment filter when there are no comments to show.
- Show previous reward and milestone values when viewing previous versions of the project.
- Reward and milestone differences should show in the project page after the user changes funds (after the project has been approved).
  - Make sure to also test how it looks when there are no changes in the milestone or reward after changing funds.