### PR TITLE
Add GraphQL subscription for KYC status

### DIFF
--- a/src/api/graphql-queries/kyc.js
+++ b/src/api/graphql-queries/kyc.js
@@ -78,6 +78,17 @@ const submitKycMutation = gql`
   }
 `;
 
+export const kycSubscription = gql`
+  subscription {
+    kycUpdated {
+      kyc {
+        id
+        status
+      }
+    }
+  }
+`;
+
 export const withFetchKycFormOptions = Component => props => (
   <Query query={fetchKycFormOptions}>
     {({ loading, error, data }) => {

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -58,6 +58,7 @@ class Profile extends React.Component {
     getDaoDetailsAction();
     getAddressDetailsAction(AddressDetails.data.address);
     this.props.refetchUser();
+    this.props.subscribeToKyc();
   }
 
   onLockDgd = () => {
@@ -117,11 +118,6 @@ class Profile extends React.Component {
 
   showKycOverlay() {
     const { refetchUser } = this.props;
-    const { kyc } = this.props.userData;
-
-    if (kyc && kyc.status === KycStatus.approved) {
-      return;
-    }
 
     this.props.showRightPanel({
       component: <KycOverlay refetchUser={refetchUser} />,
@@ -141,7 +137,7 @@ class Profile extends React.Component {
       currentKycStatus = kyc.status.charAt(0) + kyc.status.slice(1).toLowerCase();
     }
 
-    const kycStatusesForResubmission = [KycStatus.expired, KycStatus.approved, KycStatus.rejected];
+    const kycStatusesForResubmission = [KycStatus.expired, KycStatus.rejected];
     const canResubmitKyc = kyc ? kycStatusesForResubmission.includes(kyc.status) : false;
     const canSubmitKyc = (email && !kyc) || (kyc && kyc.status === KycStatus.pending);
     const showSubmitKycButton = canSubmitKyc || canResubmitKyc;
@@ -350,6 +346,7 @@ Profile.propTypes = {
   refetchUser: func.isRequired,
   showHideLockDgdOverlay: func.isRequired,
   showRightPanel: func.isRequired,
+  subscribeToKyc: func.isRequired,
   userData: shape({
     displayName: string,
     email: string,


### PR DESCRIPTION
Ref: [DGDG-300](https://tracker.digixdev.com/issue/DGDG-300)

---

### Setup

This diff adds new npm packages, so make sure to install them.

Update and use the following branches in each repo:
- `feature/sprint-5` in `governance-ui`
- `feature/DGDG-300` in `dao-server`. See [#33](https://github.com/DigixGlobal/dao-server/pull/33)
- `feature/DGDG-300` in `info-server`. See [#13](https://github.com/DigixGlobal/info-server/pull/13)

---

### Test Plan

- The KYC status on the profile page should automatically update (without reloading the page) when the KYC has been approved or rejected by the KYC admin.

**Note:** Expiration of KYC does not trigger the subscription yet, but the status should update when the page is reloaded.