### PR TITLE
Added subscription for Proposal details Page

### DIFF
--- a/src/api/graphql-queries/proposal.js
+++ b/src/api/graphql-queries/proposal.js
@@ -1,0 +1,345 @@
+/* eslint-disable react/display-name, react/prop-types */
+
+import React from 'react';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+
+export const fetchProposal = gql`
+  query findProposal($proposalId: String!) {
+    fetchProposal(proposalId: $proposalId) {
+      id
+      proposalId
+      proposer
+      endorser
+      stage
+      timeCreated
+      finalVersionIpfsDoc
+      prl
+      title
+      isDigix
+      isActive
+      isSpecial
+      claimableFunding
+      currentMilestone
+      currentVotingRound
+      isFundingChanged
+      uintConfigs {
+        CONFIG_LOCKING_PHASE_DURATION
+        CONFIG_QUARTER_DURATION
+        CONFIG_VOTING_COMMIT_PHASE
+        CONFIG_VOTING_PHASE_TOTAL
+        CONFIG_INTERIM_COMMIT_PHASE
+        CONFIG_INTERIM_PHASE_TOTAL
+        CONFIG_DRAFT_QUORUM_FIXED_PORTION_NUMERATOR
+        CONFIG_DRAFT_QUORUM_FIXED_PORTION_DENOMINATOR
+        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_NUMERATOR
+        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_DENOMINATOR
+        CONFIG_VOTING_QUORUM_FIXED_PORTION_NUMERATOR
+        CONFIG_VOTING_QUORUM_FIXED_PORTION_DENOMINATOR
+        CONFIG_VOTING_QUORUM_SCALING_FACTOR_NUMERATOR
+        CONFIG_VOTING_QUORUM_SCALING_FACTOR_DENOMINATOR
+        CONFIG_DRAFT_QUOTA_NUMERATOR
+        CONFIG_DRAFT_QUOTA_DENOMINATOR
+        CONFIG_VOTING_QUOTA_NUMERATOR
+        CONFIG_VOTING_QUOTA_DENOMINATOR
+        CONFIG_QUARTER_POINT_DRAFT_VOTE
+        CONFIG_QUARTER_POINT_VOTE
+        CONFIG_QUARTER_POINT_INTERIM_VOTE
+        CONFIG_MINIMAL_QUARTER_POINT
+        CONFIG_QUARTER_POINT_MILESTONE_COMPLETION_PER_10000ETH
+        CONFIG_BONUS_REPUTATION_NUMERATOR
+        CONFIG_BONUS_REPUTATION_DENOMINATOR
+        CONFIG_SPECIAL_PROPOSAL_COMMIT_PHASE
+        CONFIG_SPECIAL_PROPOSAL_PHASE_TOTAL
+        CONFIG_SPECIAL_QUOTA_NUMERATOR
+        CONFIG_SPECIAL_QUOTA_DENOMINATOR
+        CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR
+        CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
+        CONFIG_MAXIMUM_REPUTATION_DEDUCTION
+        CONFIG_PUNISHMENT_FOR_NOT_LOCKING
+        CONFIG_REPUTATION_PER_EXTRA_QP_NUM
+        CONFIG_REPUTATION_PER_EXTRA_QP_DEN
+        CONFIG_QUARTER_POINT_SCALING_FACTOR
+        CONFIG_REPUTATION_POINT_SCALING_FACTOR
+        CONFIG_MODERATOR_MINIMAL_QUARTER_POINT
+        CONFIG_MODERATOR_QUARTER_POINT_SCALING_FACTOR
+        CONFIG_MODERATOR_REPUTATION_POINT_SCALING_FACTOR
+        CONFIG_PORTION_TO_MODERATORS_NUM
+        CONFIG_PORTION_TO_MODERATORS_DEN
+        CONFIG_DRAFT_VOTING_PHASE
+        CONFIG_REPUTATION_POINT_BOOST_FOR_BADGE
+        CONFIG_FINAL_REWARD_SCALING_FACTOR_NUMERATOR
+        CONFIG_FINAL_REWARD_SCALING_FACTOR_DENOMINATOR
+        CONFIG_MAXIMUM_MODERATOR_REPUTATION_DEDUCTION
+        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_NUM
+        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_DEN
+        CONFIG_VOTE_CLAIMING_DEADLINE
+        CONFIG_MINIMUM_LOCKED_DGD
+        CONFIG_MINIMUM_DGD_FOR_MODERATOR
+        CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR
+        CONFIG_PREPROPOSAL_COLLATERAL
+        CONFIG_MAX_FUNDING_FOR_NON_DIGIX
+        CONFIG_MAX_MILESTONES_FOR_NON_DIGIX
+        CONFIG_NON_DIGIX_PROPOSAL_CAP_PER_QUARTER
+        CONFIG_PROPOSAL_DEAD_DURATION
+        CONFIG_CARBON_VOTE_REPUTATION_BONUS
+      }
+      changedFundings {
+        milestones {
+          original
+          updated
+        }
+        finalReward {
+          original
+          updated
+        }
+      }
+      draftVoting {
+        startTime
+        votingDeadline
+        totalVoterStake
+        totalVoterCount
+        yes
+        no
+        quorum
+        quota
+        passed
+        claimed
+        funded
+        currentClaimStep
+      }
+      proposalVersions {
+        docIpfsHash
+        created
+        milestoneFundings
+        finalReward
+        moreDocs
+        totalFunding
+        dijixObject {
+          title
+          description
+          details
+          milestones {
+            title
+            fund
+            description
+          }
+          finalReward
+          images
+        }
+      }
+      votingStage
+      votingRounds {
+        startTime
+        commitDeadline
+        revealDeadline
+        quorum
+        quota
+        totalCommitCount
+        totalVoterCount
+        totalVoterStake
+        yes
+        no
+        claimed
+        passed
+        funded
+        currentClaimStep
+      }
+      currentMilestoneIndex
+      currentMilestoneStart
+    }
+  }
+`;
+
+const proposalSubscription = gql`
+  subscription {
+    proposalUpdated {
+      id
+      proposalId
+      proposer
+      endorser
+      stage
+      timeCreated
+      finalVersionIpfsDoc
+      prl
+      title
+      isDigix
+      isActive
+      isSpecial
+      claimableFunding
+      currentMilestone
+      currentVotingRound
+      isFundingChanged
+      uintConfigs {
+        CONFIG_LOCKING_PHASE_DURATION
+        CONFIG_QUARTER_DURATION
+        CONFIG_VOTING_COMMIT_PHASE
+        CONFIG_VOTING_PHASE_TOTAL
+        CONFIG_INTERIM_COMMIT_PHASE
+        CONFIG_INTERIM_PHASE_TOTAL
+        CONFIG_DRAFT_QUORUM_FIXED_PORTION_NUMERATOR
+        CONFIG_DRAFT_QUORUM_FIXED_PORTION_DENOMINATOR
+        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_NUMERATOR
+        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_DENOMINATOR
+        CONFIG_VOTING_QUORUM_FIXED_PORTION_NUMERATOR
+        CONFIG_VOTING_QUORUM_FIXED_PORTION_DENOMINATOR
+        CONFIG_VOTING_QUORUM_SCALING_FACTOR_NUMERATOR
+        CONFIG_VOTING_QUORUM_SCALING_FACTOR_DENOMINATOR
+        CONFIG_DRAFT_QUOTA_NUMERATOR
+        CONFIG_DRAFT_QUOTA_DENOMINATOR
+        CONFIG_VOTING_QUOTA_NUMERATOR
+        CONFIG_VOTING_QUOTA_DENOMINATOR
+        CONFIG_QUARTER_POINT_DRAFT_VOTE
+        CONFIG_QUARTER_POINT_VOTE
+        CONFIG_QUARTER_POINT_INTERIM_VOTE
+        CONFIG_MINIMAL_QUARTER_POINT
+        CONFIG_QUARTER_POINT_MILESTONE_COMPLETION_PER_10000ETH
+        CONFIG_BONUS_REPUTATION_NUMERATOR
+        CONFIG_BONUS_REPUTATION_DENOMINATOR
+        CONFIG_SPECIAL_PROPOSAL_COMMIT_PHASE
+        CONFIG_SPECIAL_PROPOSAL_PHASE_TOTAL
+        CONFIG_SPECIAL_QUOTA_NUMERATOR
+        CONFIG_SPECIAL_QUOTA_DENOMINATOR
+        CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR
+        CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
+        CONFIG_MAXIMUM_REPUTATION_DEDUCTION
+        CONFIG_PUNISHMENT_FOR_NOT_LOCKING
+        CONFIG_REPUTATION_PER_EXTRA_QP_NUM
+        CONFIG_REPUTATION_PER_EXTRA_QP_DEN
+        CONFIG_QUARTER_POINT_SCALING_FACTOR
+        CONFIG_REPUTATION_POINT_SCALING_FACTOR
+        CONFIG_MODERATOR_MINIMAL_QUARTER_POINT
+        CONFIG_MODERATOR_QUARTER_POINT_SCALING_FACTOR
+        CONFIG_MODERATOR_REPUTATION_POINT_SCALING_FACTOR
+        CONFIG_PORTION_TO_MODERATORS_NUM
+        CONFIG_PORTION_TO_MODERATORS_DEN
+        CONFIG_DRAFT_VOTING_PHASE
+        CONFIG_REPUTATION_POINT_BOOST_FOR_BADGE
+        CONFIG_FINAL_REWARD_SCALING_FACTOR_NUMERATOR
+        CONFIG_FINAL_REWARD_SCALING_FACTOR_DENOMINATOR
+        CONFIG_MAXIMUM_MODERATOR_REPUTATION_DEDUCTION
+        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_NUM
+        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_DEN
+        CONFIG_VOTE_CLAIMING_DEADLINE
+        CONFIG_MINIMUM_LOCKED_DGD
+        CONFIG_MINIMUM_DGD_FOR_MODERATOR
+        CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR
+        CONFIG_PREPROPOSAL_COLLATERAL
+        CONFIG_MAX_FUNDING_FOR_NON_DIGIX
+        CONFIG_MAX_MILESTONES_FOR_NON_DIGIX
+        CONFIG_NON_DIGIX_PROPOSAL_CAP_PER_QUARTER
+        CONFIG_PROPOSAL_DEAD_DURATION
+        CONFIG_CARBON_VOTE_REPUTATION_BONUS
+      }
+      changedFundings {
+        milestones {
+          original
+          updated
+        }
+        finalReward {
+          original
+          updated
+        }
+      }
+      draftVoting {
+        startTime
+        votingDeadline
+        totalVoterStake
+        totalVoterCount
+        yes
+        no
+        quorum
+        quota
+        passed
+        claimed
+        funded
+        currentClaimStep
+      }
+      proposalVersions {
+        docIpfsHash
+        created
+        milestoneFundings
+        finalReward
+        moreDocs
+        totalFunding
+        dijixObject {
+          title
+          description
+          details
+          milestones {
+            title
+            fund
+            description
+          }
+          finalReward
+          images
+        }
+      }
+      votingStage
+      votingRounds {
+        startTime
+        commitDeadline
+        revealDeadline
+        quorum
+        quota
+        totalCommitCount
+        totalVoterCount
+        totalVoterStake
+        yes
+        no
+        claimed
+        passed
+        funded
+        currentClaimStep
+      }
+      currentMilestoneIndex
+      currentMilestoneStart
+    }
+  }
+`;
+
+export const withFetchProposal = Component => props => {
+  const {
+    match: { params },
+  } = props;
+
+  const { id } = params;
+  return (
+    <Query
+      query={fetchProposal}
+      fetchPolicy="network-only"
+      variables={{
+        proposalId: id,
+      }}
+    >
+      {({ loading, error, data, refetch, subscribeToMore }) => {
+        if (loading || error) {
+          return <div>Fetching Proposal Details</div>;
+        }
+
+        const subscribeToProposal = () => {
+          subscribeToMore({
+            document: proposalSubscription,
+            updateQuery: (cache, { subscriptionData }) => {
+              const newData = subscriptionData.data;
+              if (!newData) {
+                return cache;
+              }
+              cache.fetchProposal = newData.proposalUpdated;
+              return { ...cache };
+            },
+          });
+        };
+
+        return (
+          <Component
+            {...props}
+            proposalDetails={{ data: data.fetchProposal }}
+            refetchProposal={refetch}
+            subscribeToProposal={subscribeToProposal}
+          />
+        );
+      }}
+    </Query>
+  );
+};

--- a/src/api/graphql-queries/transaction.js
+++ b/src/api/graphql-queries/transaction.js
@@ -1,0 +1,77 @@
+/* eslint-disable react/display-name, react/prop-types */
+
+import React from 'react';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+
+const searchTransactions = gql`
+  query getTransactions($proposalId: String) {
+    searchTransactions(proposalId: $proposalId) {
+      edges {
+        node {
+          blockNumber
+          id
+          txhash
+          status
+          title
+          project
+          transactionType
+        }
+      }
+    }
+  }
+`;
+
+const transactionSubscription = gql`
+  subscription getTransactionupdate($proposalId: String!) {
+    transactionUpdated(proposalId: $proposalId) {
+      blockNumber
+      id
+      txhash
+      status
+      title
+      project
+      transactionType
+    }
+  }
+`;
+
+export const withSearchTransactions = Component => props => {
+  const {
+    match: { params },
+  } = props;
+  const { id } = params;
+
+  return (
+    <Query query={searchTransactions} variables={{ proposalId: id }} fetchPolicy="network-only">
+      {({ loading, error, data, refetch, subscribeToMore }) => {
+        if (loading || error) {
+          return null;
+        }
+
+        const subscribeToTransaction = () => {
+          subscribeToMore({
+            document: transactionSubscription,
+            variables: { proposalId: id },
+            updateQuery: (cache, { subscriptionData }) => {
+              const newData = subscriptionData.data;
+              if (!newData) {
+                return cache;
+              }
+              cache.searchTransactions = newData.transactionUpdated;
+              return { ...cache };
+            },
+          });
+        };
+        return (
+          <Component
+            {...props}
+            transactions={data.searchTransactions}
+            refetchTransactions={refetch}
+            subscribeToTransaction={subscribeToTransaction}
+          />
+        );
+      }}
+    </Query>
+  );
+};

--- a/src/components/common/blocks/overlay/change-funding/index.js
+++ b/src/components/common/blocks/overlay/change-funding/index.js
@@ -25,7 +25,6 @@ import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
-import { getProposalDetails } from '@digix/gov-ui/reducers/info-server/actions';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 const network = SpectrumConfig.defaultNetworks[0];
@@ -46,22 +45,20 @@ class ChangeFundingOverlay extends React.Component {
   }
 
   componentWillMount = () => {
-    const { proposalId, proposalDetails } = this.props;
-    if (proposalId) this.props.getProposalDetails(proposalId);
+    const { proposalDetails } = this.props;
     const { form } = this.state;
     if (proposalDetails) {
       if (!proposalDetails.isFundingChanged) {
         const currentVersion =
           proposalDetails.proposalVersions[proposalDetails.proposalVersions.length - 1];
         form.expectedReward = currentVersion.finalReward;
-
         form.milestoneFundings = currentVersion.milestoneFundings;
-        this.setState({ form: { ...form } });
       } else {
         const { changedFundings } = proposalDetails;
         form.expectedReward = changedFundings.finalReward.updated;
         form.milestoneFundings = changedFundings.milestones.map(ms => ms.updated);
       }
+      this.setState({ form: { ...form } });
     }
   };
 
@@ -283,17 +280,15 @@ class ChangeFundingOverlay extends React.Component {
   }
 }
 
-const { array, func, object, string } = PropTypes;
+const { array, func, object } = PropTypes;
 
 ChangeFundingOverlay.propTypes = {
   addresses: array.isRequired,
   daoConfig: object.isRequired,
   ChallengeProof: object.isRequired,
   history: object.isRequired,
-  proposalId: string.isRequired,
   proposalDetails: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
-  getProposalDetails: func.isRequired,
   showHideAlertAction: func.isRequired,
   showRightPanelAction: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -304,7 +299,6 @@ ChangeFundingOverlay.propTypes = {
 const mapStateToProps = state => ({
   ChallengeProof: state.daoServer.ChallengeProof,
   daoConfig: state.infoServer.DaoConfig,
-  proposalDetails: state.infoServer.ProposalDetails.data,
   addresses: getAddresses(state),
 });
 
@@ -315,7 +309,6 @@ export default web3Connect(
       sendTransactionToDaoServer,
       showHideAlertAction: showHideAlert,
       showRightPanelAction: showRightPanel,
-      getProposalDetails,
       showTxSigningModal,
     }
   )(ChangeFundingOverlay)

--- a/src/components/common/elements/accordion/voting-result.js
+++ b/src/components/common/elements/accordion/voting-result.js
@@ -54,9 +54,9 @@ class VotingResult extends React.Component {
     const totalModeratorLockedDgds = parseBigNumber(daoInfo.totalModeratorLockedDgds, 0, false);
     const totalVoterStake = parseBigNumber(voting.totalVoterStake, 0, false);
 
-    const votes = voting.totalVoterCount;
-    const yesVotes = voting.yes;
-    const noVotes = voting.no;
+    const votes = Number(voting.totalVoterCount);
+    const yesVotes = Number(voting.yes);
+    const noVotes = Number(voting.no);
 
     const minimumQuorum = formatPercentage(quorum / totalModeratorLockedDgds);
     const quorumProgress = formatPercentage(totalVoterStake / totalModeratorLockedDgds);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 
-import { HashRouter, Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
 import registerReducers from 'spectrum-lightsuite/src/helpers/registerReducers';
@@ -57,56 +57,54 @@ export class Governance extends React.Component {
     const { isAuthenticated } = this.props;
     return (
       <GraphqlProvider>
-        <HashRouter>
-          <ThemeProvider theme={lightTheme}>
-            <Switch>
-              <AuthenticatedRoute
-                path="/proposals/create"
-                component={withHeaderAndPanel(CreateProposals)}
-                isAuthenticated={isAuthenticated}
-              />
-              <AuthenticatedRoute
-                path="/proposals/edit"
-                component={withHeaderAndPanel(EditProposal)}
-                isAuthenticated={isAuthenticated}
-              />
-              <AuthenticatedRoute
-                path="/proposals"
-                component={withHeaderAndPanel(Proposals)}
-                isAuthenticated={isAuthenticated}
-              />
-              <AuthenticatedRoute
-                path="/wallet"
-                component={withHeaderAndPanel(Wallet)}
-                isAuthenticated={isAuthenticated}
-              />
+        <ThemeProvider theme={lightTheme}>
+          <Switch>
+            <AuthenticatedRoute
+              path="/proposals/create"
+              component={withHeaderAndPanel(CreateProposals)}
+              isAuthenticated={isAuthenticated}
+            />
+            <AuthenticatedRoute
+              path="/proposals/edit/:id"
+              component={withHeaderAndPanel(EditProposal)}
+              isAuthenticated={isAuthenticated}
+            />
+            <AuthenticatedRoute
+              path="/proposals/:id"
+              component={withHeaderAndPanel(Proposals)}
+              isAuthenticated={isAuthenticated}
+            />
+            <AuthenticatedRoute
+              path="/wallet"
+              component={withHeaderAndPanel(Wallet)}
+              isAuthenticated={isAuthenticated}
+            />
 
-              <AuthenticatedRoute
-                path="/kyc/admin"
-                component={withHeaderAndPanel(KycOfficerDashboard)}
-                isAuthenticated={isAuthenticated}
-              />
-              <AuthenticatedRoute
-                path="/forum/admin"
-                component={withHeaderAndPanel(ForumOfficerDashboard)}
-                isAuthenticated={isAuthenticated}
-              />
-              <AuthenticatedRoute
-                path="/profile"
-                component={withHeaderAndPanel(Profile)}
-                isAuthenticated={isAuthenticated}
-              />
+            <AuthenticatedRoute
+              path="/kyc/admin"
+              component={withHeaderAndPanel(KycOfficerDashboard)}
+              isAuthenticated={isAuthenticated}
+            />
+            <AuthenticatedRoute
+              path="/forum/admin"
+              component={withHeaderAndPanel(ForumOfficerDashboard)}
+              isAuthenticated={isAuthenticated}
+            />
+            <AuthenticatedRoute
+              path="/profile"
+              component={withHeaderAndPanel(Profile)}
+              isAuthenticated={isAuthenticated}
+            />
 
-              <AuthenticatedRoute
-                path="/history"
-                component={withHeaderAndPanel(TransactionHistory)}
-                isAuthenticated={isAuthenticated}
-              />
-              <Route path="/help" component={withHeaderAndPanel(Help)} />
-              <Route path="/" component={withHeaderAndPanel(LandingPage)} />
-            </Switch>
-          </ThemeProvider>
-        </HashRouter>
+            <AuthenticatedRoute
+              path="/history"
+              component={withHeaderAndPanel(TransactionHistory)}
+              isAuthenticated={isAuthenticated}
+            />
+            <Route path="/help" component={withHeaderAndPanel(Help)} />
+            <Route path="/" component={withHeaderAndPanel(LandingPage)} />
+          </Switch>
+        </ThemeProvider>
       </GraphqlProvider>
     );
   }
@@ -124,5 +122,3 @@ export default withRouter(
     {}
   )(Governance)
 );
-
-// export default Governance;

--- a/src/pages/proposals/edit/index.js
+++ b/src/pages/proposals/edit/index.js
@@ -17,9 +17,9 @@ import getContract from '@digix/gov-ui/utils/contracts';
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
-import { getProposalDetails } from '@digix/gov-ui/reducers/info-server/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
+import { withFetchProposal } from '@digix/gov-ui/api/graphql-queries/proposal';
 
 import Details from '@digix/gov-ui/pages/proposals/forms/details';
 import Milestones from '@digix/gov-ui/pages/proposals/forms/milestones';
@@ -62,19 +62,8 @@ class EditProposal extends React.Component {
   }
 
   componentWillMount = () => {
-    const {
-      getProposalDetailsAction,
-      ChallengeProof,
-      history,
-      location,
-      proposalDetails,
-    } = this.props;
+    const { ChallengeProof, history, proposalDetails } = this.props;
     if (!ChallengeProof.data) history.push('/');
-    if (location.pathname) {
-      const path = location.pathname.split('/');
-      const proposalId = path[path.length - 1];
-      if (proposalId) getProposalDetailsAction(proposalId);
-    }
 
     if (proposalDetails.data.proposalId) {
       const currentVersion = proposalDetails.data.proposalVersions
@@ -350,13 +339,11 @@ EditProposal.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   proposalDetails: object.isRequired,
-  location: object.isRequired,
   history: object.isRequired,
   daoConfig: object.isRequired,
   addresses: array,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
-  getProposalDetailsAction: func.isRequired,
   showTxSigningModal: func.isRequired,
 };
 
@@ -366,7 +353,6 @@ EditProposal.defaultProps = {
 const mapStateToProps = state => ({
   ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
-  proposalDetails: state.infoServer.ProposalDetails,
   daoConfig: state.infoServer.DaoConfig,
 });
 
@@ -376,8 +362,7 @@ export default web3Connect(
     {
       showHideAlert,
       sendTransactionToDaoServer,
-      getProposalDetailsAction: getProposalDetails,
       showTxSigningModal,
     }
-  )(EditProposal)
+  )(withFetchProposal(EditProposal))
 );

--- a/src/pages/proposals/forms/milestones.js
+++ b/src/pages/proposals/forms/milestones.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { ErrorCaption, Notifications } from '@digix/gov-ui/components/common/common-styles';
+import { ErrorCaption } from '@digix/gov-ui/components/common/common-styles';
 import { TextArea, Input, Select } from '@digix/gov-ui/components/common/elements/index';
 import {
   Fieldset,

--- a/src/pages/proposals/proposal-buttons/edit-funding.js
+++ b/src/pages/proposals/proposal-buttons/edit-funding.js
@@ -9,14 +9,19 @@ import { ProposalStages } from '@digix/gov-ui/constants';
 
 class EditFundingButton extends React.PureComponent {
   onPanelClose = () => {
-    this.props.onCompleted();
     this.props.showRightPanelAction({ show: false });
   };
 
   showOverlay = () => {
-    const { history, showRightPanelAction } = this.props;
+    const { history, proposal, showRightPanelAction } = this.props;
     showRightPanelAction({
-      component: <ChangeFundingOverlay history={history} onCompleted={this.onPanelClose} />,
+      component: (
+        <ChangeFundingOverlay
+          history={history}
+          proposalDetails={proposal}
+          onCompleted={this.onPanelClose}
+        />
+      ),
       show: true,
     });
   };
@@ -55,7 +60,6 @@ EditFundingButton.propTypes = {
   isProposer: bool,
   proposal: object.isRequired,
   history: object.isRequired,
-  onCompleted: func.isRequired,
   showRightPanelAction: func.isRequired,
 };
 

--- a/src/pages/proposals/proposal-buttons/milestone-completed.js
+++ b/src/pages/proposals/proposal-buttons/milestone-completed.js
@@ -97,6 +97,7 @@ class CompleteMilestoneButton extends React.PureComponent {
 
   render() {
     const { isProposer, proposal } = this.props;
+
     if (
       !isProposer ||
       !proposal ||

--- a/src/pages/proposals/proposal-buttons/participants/index.js
+++ b/src/pages/proposals/proposal-buttons/participants/index.js
@@ -110,6 +110,7 @@ class ParticipantButtons extends React.Component {
           votingStage={data.votingStage}
           proposalId={data.proposalId}
           checkProposalRequirements={checkProposalRequirements}
+          match={this.props.match}
         />
         <VoteCommitButton
           isParticipant={addressDetails.data.isParticipant}
@@ -130,6 +131,7 @@ class ParticipantButtons extends React.Component {
         <ClaimResultsButton
           checkProposalRequirements={checkProposalRequirements}
           onCompleted={this.props.onCompleted}
+          match={this.props.match}
           isProposer={isProposer}
           history={history}
           proposal={data}
@@ -159,6 +161,7 @@ ParticipantButtons.propTypes = {
   DaoDetails: object.isRequired,
   history: object.isRequired,
   isProposer: bool.isRequired,
+  match: object.isRequired,
   onCompleted: func,
   proposal: object.isRequired,
   showRightPanel: func.isRequired,


### PR DESCRIPTION
[Feature] Auto refreshing of DOM view (Proposal Details Page)

Ref: [DGDG-300](https://tracker.digixdev.com/agiles/88-14/89-17?issue=DGDG-300)

Added subscriptions to Proposal Details page and call to Action Buttons in the Proposal Details Page
- Replaced retrieving of Proposal details from Info-server to Graphql
- Updated Claim Approval Button
- Updated Claim Result Button
- Update Edit Funding Button
- Updated Edit Page

Test Plan:
 - Login to different accounts, Participant and Moderator on a different tab or window
 - Using a Participant account, create a Proposal
 - Ensure you have two accounts logged-in on different windows or tab
 - Using a Moderator account, perform Actions (Approve, Commit, Reveal and etc.)
 - The content, call to action buttons should change as you update or perform an action to the proposal