### PR TITLE
Refactor Wallet page and use address subscriptions

### DIFF
--- a/src/api/graphql-queries/address.js
+++ b/src/api/graphql-queries/address.js
@@ -6,6 +6,7 @@ export const fetchAddressQuery = gql`
   query fetchAddress {
     fetchCurrentUser {
       address
+      claimableDgx
       id
       isModerator
       isParticipant
@@ -21,6 +22,7 @@ export const addressSubscription = gql`
   subscription {
     userUpdated {
       address
+      claimableDgx
       id
       isModerator
       isParticipant

--- a/src/components/common/blocks/overlay/unlock-dgd/index.js
+++ b/src/components/common/blocks/overlay/unlock-dgd/index.js
@@ -112,7 +112,6 @@ class UnlockDgdOverlay extends React.Component {
       });
 
       this.props.showRightPanel({ show: false });
-      this.props.onSuccess(unlockAmount);
     };
 
     const payload = {
@@ -232,7 +231,6 @@ UnlockDgdOverlay.propTypes = {
   DaoConfig: object.isRequired,
   getDaoConfig: func.isRequired,
   maxAmount: number.isRequired,
-  onSuccess: func.isRequired,
   showRightPanel: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlert: func.isRequired,

--- a/src/pages/user/wallet/index.js
+++ b/src/pages/user/wallet/index.js
@@ -1,235 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
-import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
-import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
-
-import ParticipationReward from '@digix/gov-ui/pages/user/wallet/sections/participation-reward';
-import VotingStake from '@digix/gov-ui/pages/user/wallet/sections/voting-stake';
-import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
-import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getAddressDetails, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
-
-import { getDGDBalanceContract, getDGXBalanceContract } from '@digix/gov-ui/utils/contracts';
-
-import {
-  showHideAlert,
-  showRightPanel,
-  showHideLockDgdOverlay,
-} from '@digix/gov-ui/reducers/gov-ui/actions';
-
-import {
-  WalletWrapper,
-  Heading,
-  Address,
-  WalletDetails,
-  Item,
-  Amount,
-  QtrSummary,
-  QtrParticipation,
-  Title,
-  Detail,
-  Label,
-  Data,
-  Desc,
-  Actions,
-} from '@digix/gov-ui/pages/user/wallet/style';
-
-const network = SpectrumConfig.defaultNetworks[0];
+import QuarterSummary from '@digix/gov-ui/pages/user/wallet/sections/quarter-summary';
+import WalletCurrencies from '@digix/gov-ui/pages/user/wallet/sections/wallet-currencies';
+import { Address, Heading, WalletWrapper } from '@digix/gov-ui/pages/user/wallet/style';
+import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
 
 class Wallet extends React.Component {
-  state = {
-    ethBalance: 0,
-    dgdBalance: 0,
-    dgxBalance: 0,
-  };
-
-  componentDidMount() {
-    const { AddressDetails } = this.props;
-    if (AddressDetails.data && AddressDetails.data.address) {
-      Promise.all([
-        this.props.getDaoDetails(),
-        this.props.getAddressDetails(AddressDetails.data.address),
-        this.getEthBalance(),
-        this.getDgdBalance(),
-        this.getDgxBalance(),
-      ]).then(result => {
-        const ethBalance = result[2]; // Refers to the call to get eth balance
-        const dgdBalance = result[3]; // Refers to the call to get the dgd balance
-        const dgxBalance = result[4]; // Refers to the call to get the dgx balance
-        this.setState({ ethBalance, dgdBalance, dgxBalance });
-      });
-    }
-  }
-
-  getDgdBalance() {
-    const { AddressDetails, web3Redux } = this.props;
-    const { address: contractAddress, abi } = getDGDBalanceContract(network);
-    const { web3 } = web3Redux.networks[network];
-    const contract = web3.eth.contract(abi).at(contractAddress);
-
-    return contract.balanceOf.call(AddressDetails.data.address).then(balance => {
-      const parsedBalance = parseBigNumber(balance, 9);
-      return parsedBalance;
-    });
-  }
-
-  getDgxBalance() {
-    const { AddressDetails, web3Redux } = this.props;
-    const { address: contractAddress, abi } = getDGXBalanceContract(network);
-    const { web3 } = web3Redux.networks[network];
-    const contract = web3.eth.contract(abi).at(contractAddress);
-
-    return contract.balanceOf.call(AddressDetails.data.address).then(balance => {
-      const parsedBalance = parseBigNumber(balance, 9);
-      return parsedBalance;
-    });
-  }
-
-  getEthBalance() {
-    const { AddressDetails, web3Redux } = this.props;
-    const { web3 } = web3Redux.networks[network];
-    if (AddressDetails && AddressDetails.data.address) {
-      return web3.eth
-        .getBalance(AddressDetails.data.address)
-        .then(balance => parseBigNumber(balance, 18));
-    }
-  }
-
   render() {
-    const {
-      AddressDetails,
-      tokenUsdValues: { data: tokensInUsd },
-    } = this.props;
-
-    const { ethBalance, dgdBalance, dgxBalance } = this.state;
-    const address = AddressDetails.data;
-    let dgdInUsd = dgdBalance !== 0 ? dgdBalance.replace(',', '') : dgdBalance;
-    let dgxInUsd = dgxBalance !== 0 ? dgxBalance.replace(',', '') : dgxBalance;
-    let ethInUsd = ethBalance !== 0 ? ethBalance.replace(',', '').replace('...', '') : ethBalance;
-    if (dgdInUsd > 0 && tokensInUsd && tokensInUsd.DGD)
-      dgdInUsd = Number(dgdInUsd) * Number(tokensInUsd.DGD.USD);
-
-    if (dgxInUsd > 0 && tokensInUsd && tokensInUsd.DGX)
-      dgxInUsd = Number(dgxInUsd) * Number(tokensInUsd.DGX.USD);
-
-    if (ethInUsd > 0 && tokensInUsd && tokensInUsd.ETH)
-      ethInUsd = Number(ethInUsd) * Number(tokensInUsd.ETH.USD);
-
-    const eth = 0;
-    const claimableDgx = Number(address.claimableDgx);
-    const lockedDgd = Number(address.lockedDgd);
-    const stake = Number(address.lockedDgdStake);
+    const { address } = this.props.AddressDetails;
 
     return (
       <WalletWrapper>
         <Heading>Wallet</Heading>
         <Address>
           <span>Address:</span>
-          <span data-digix="Wallet-Address">{address.address}</span>
+          <span data-digix="Wallet-Address">{address}</span>
         </Address>
-        <WalletDetails>
-          <Item>
-            <Icon kind="dgd" width="5rem" />
-            <Amount>
-              <div>
-                <span data-digix="Wallet-DGD-Balance">{dgdBalance}</span> DGD
-              </div>
-              <div data-digix="Wallet-DgdUsd-Balance">
-                {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
-                  dgdInUsd
-                )}{' '}
-                USD
-              </div>
-            </Amount>
-          </Item>
-          <Item>
-            <Icon kind="dgx" width="5rem" />
-
-            <Amount>
-              <div>
-                <span data-digix="Wallet-DGX-Balance">{dgxBalance}</span> DGX
-              </div>
-              <div data-digix="Wallet-DgxUsd-Balance">
-                {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
-                  dgxInUsd
-                )}{' '}
-                USD
-              </div>
-            </Amount>
-          </Item>
-          <Item>
-            <Icon kind="ethereum" width="5rem" />
-            <Amount>
-              <div>
-                <span data-digix="Wallet-ETH-Balance">{ethBalance}</span> ETH
-              </div>
-              <div data-digix="Wallet-EthUsd-Balance">
-                {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
-                  ethInUsd
-                )}{' '}
-                USD
-              </div>
-            </Amount>
-          </Item>
-        </WalletDetails>
-        <QtrSummary>
-          <VotingStake lockedDgd={lockedDgd} stake={stake} />
-          <ParticipationReward claimableDgx={claimableDgx} />
-          <QtrParticipation>
-            <Title>DigixDAO Project Funding</Title>
-            <Detail>
-              <Label>Your Funding Amount</Label>
-              <Data>
-                <span data-digix="Wallet-EthFund">{eth}</span>
-                <span>&nbsp;ETH</span>
-              </Data>
-              <Desc>
-                You can claim funding from DigixDAO after your project successfully passes a vote.
-              </Desc>
-              <Actions>
-                <Button primary disabled={!eth} data-digix="Wallet-ClaimFunding">
-                  Claim Funding
-                </Button>
-              </Actions>
-            </Detail>
-          </QtrParticipation>
-        </QtrSummary>
+        <WalletCurrencies />
+        <QuarterSummary />
       </WalletWrapper>
     );
   }
 }
 
-const { func, object } = PropTypes;
-
+const { object } = PropTypes;
 Wallet.propTypes = {
   AddressDetails: object.isRequired,
-  getAddressDetails: func.isRequired,
-  getDaoDetails: func.isRequired,
-  tokenUsdValues: object.isRequired,
-  web3Redux: object.isRequired,
 };
 
-const mapStateToProps = state => ({
-  addresses: getAddresses(state),
-  AddressDetails: state.infoServer.AddressDetails,
-  tokenUsdValues: state.govUI.tokenUsdValues,
-  CanLockDgd: state.govUI.CanLockDgd,
-  ChallengeProof: state.daoServer.ChallengeProof,
-  DaoDetails: state.infoServer.DaoDetails,
-});
-
-export default web3Connect(
-  connect(
-    mapStateToProps,
-    {
-      getAddressDetails,
-      getDaoDetails,
-      showHideAlert,
-      showRightPanel,
-      showHideLockDgdOverlay,
-    }
-  )(Wallet)
-);
+export default withFetchAddress(Wallet);

--- a/src/pages/user/wallet/sections/participation-reward.js
+++ b/src/pages/user/wallet/sections/participation-reward.js
@@ -18,6 +18,7 @@ import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/ac
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
 
 import {
   QtrParticipation,
@@ -36,10 +37,10 @@ class ParticipationReward extends React.Component {
   constructor(props) {
     super(props);
     this.MIN_CLAIMABLE_DGX = 0.001;
+  }
 
-    this.state = {
-      hasPendingTransaction: false,
-    };
+  componentDidMount() {
+    this.props.subscribeToAddress();
   }
 
   setError = error => {
@@ -87,8 +88,6 @@ class ParticipationReward extends React.Component {
         message: 'DGX Claimed',
         txHash,
       });
-
-      this.setState({ hasPendingTransaction: true });
     };
 
     const payload = {
@@ -110,12 +109,10 @@ class ParticipationReward extends React.Component {
 
   render() {
     const { DaoDetails } = this.props;
-    const { hasPendingTransaction } = this.state;
-    let { claimableDgx } = this.props;
+    let { claimableDgx } = this.props.AddressDetails;
 
     const isGlobalRewardsSet = DaoDetails ? DaoDetails.data.isGlobalRewardsSet : false;
-    const canClaimDgx =
-      claimableDgx > this.MIN_CLAIMABLE_DGX && isGlobalRewardsSet && !hasPendingTransaction;
+    const canClaimDgx = claimableDgx > this.MIN_CLAIMABLE_DGX && isGlobalRewardsSet;
 
     claimableDgx = truncateNumber(claimableDgx);
 
@@ -147,28 +144,28 @@ class ParticipationReward extends React.Component {
   }
 }
 
-const { array, func, number, object } = PropTypes;
+const { array, func, object } = PropTypes;
 
 ParticipationReward.propTypes = {
+  AddressDetails: object.isRequired,
   addresses: array.isRequired,
-  claimableDgx: number.isRequired,
   ChallengeProof: object.isRequired,
   DaoDetails: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlert: func.isRequired,
   showTxSigningModal: func.isRequired,
+  subscribeToAddress: func.isRequired,
   web3Redux: object.isRequired,
 };
 
 const mapStateToProps = state => ({
   addresses: getAddresses(state),
-  AddressDetails: state.infoServer.AddressDetails,
   CanLockDgd: state.govUI.CanLockDgd,
   ChallengeProof: state.daoServer.ChallengeProof,
   DaoDetails: state.infoServer.DaoDetails,
 });
 
-export default web3Connect(
+const ParticipationRewardComponent = web3Connect(
   connect(
     mapStateToProps,
     {
@@ -180,3 +177,5 @@ export default web3Connect(
     }
   )(ParticipationReward)
 );
+
+export default withFetchAddress(ParticipationRewardComponent);

--- a/src/pages/user/wallet/sections/quarter-summary.js
+++ b/src/pages/user/wallet/sections/quarter-summary.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import ParticipationReward from '@digix/gov-ui/pages/user/wallet/sections/participation-reward';
+import VotingStake from '@digix/gov-ui/pages/user/wallet/sections/voting-stake';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+import {
+  Actions,
+  Data,
+  Desc,
+  Detail,
+  Label,
+  QtrSummary,
+  QtrParticipation,
+  Title,
+} from '@digix/gov-ui/pages/user/wallet/style';
+
+class QuarterSummary extends React.Component {
+  render() {
+    const eth = 0;
+
+    return (
+      <QtrSummary>
+        <VotingStake />
+        <ParticipationReward />
+        <QtrParticipation>
+          <Title>DigixDAO Project Funding</Title>
+          <Detail>
+            <Label>Your Funding Amount</Label>
+            <Data>
+              <span data-digix="Wallet-EthFund">{eth}</span>
+              <span>&nbsp;ETH</span>
+            </Data>
+            <Desc>
+              You can claim funding from DigixDAO after your project successfully passes a vote.
+            </Desc>
+            <Actions>
+              <Button primary disabled={!eth} data-digix="Wallet-ClaimFunding">
+                Claim Funding
+              </Button>
+            </Actions>
+          </Detail>
+        </QtrParticipation>
+      </QtrSummary>
+    );
+  }
+}
+
+export default QuarterSummary;

--- a/src/pages/user/wallet/sections/wallet-currencies.js
+++ b/src/pages/user/wallet/sections/wallet-currencies.js
@@ -1,0 +1,184 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { getDGDBalanceContract, getDGXBalanceContract } from '@digix/gov-ui/utils/contracts';
+import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
+import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
+
+import {
+  Amount,
+  Item,
+  WalletDetails,
+  WalletCurrencyIcon,
+} from '@digix/gov-ui/pages/user/wallet/style';
+
+import {
+  showHideAlert,
+  showRightPanel,
+  showHideLockDgdOverlay,
+} from '@digix/gov-ui/reducers/gov-ui/actions';
+
+const network = SpectrumConfig.defaultNetworks[0];
+
+class WalletCurrencies extends React.Component {
+  state = {
+    dgdBalance: 0,
+    dgxBalance: 0,
+    ethBalance: 0,
+  };
+
+  componentDidMount() {
+    const { address } = this.props.AddressDetails;
+    if (!address) {
+      return;
+    }
+
+    Promise.all([
+      this.props.getDaoDetails(),
+      this.getEthBalance(),
+      this.getDgdBalance(),
+      this.getDgxBalance(),
+    ]).then(result => {
+      const ethBalance = result[1];
+      const dgdBalance = result[2];
+      const dgxBalance = result[3];
+      this.setState({ ethBalance, dgdBalance, dgxBalance });
+    });
+  }
+
+  getDgdBalance() {
+    const { address } = this.props.AddressDetails;
+    const { address: contractAddress, abi } = getDGDBalanceContract(network);
+    const { web3 } = this.props.web3Redux.networks[network];
+    const contract = web3.eth.contract(abi).at(contractAddress);
+
+    return contract.balanceOf.call(address).then(balance => parseBigNumber(balance, 9));
+  }
+
+  getDgxBalance() {
+    const { address } = this.props.AddressDetails;
+    const { address: contractAddress, abi } = getDGXBalanceContract(network);
+    const { web3 } = this.props.web3Redux.networks[network];
+    const contract = web3.eth.contract(abi).at(contractAddress);
+
+    return contract.balanceOf.call(address).then(balance => parseBigNumber(balance, 9));
+  }
+
+  getEthBalance() {
+    const { address } = this.props.AddressDetails;
+    const { web3 } = this.props.web3Redux.networks[network];
+
+    return web3.eth.getBalance(address).then(balance => parseBigNumber(balance, 18));
+  }
+
+  getBalanceInUsd(balance, currency) {
+    const {
+      tokenUsdValues: { data: tokensInUsd },
+    } = this.props;
+
+    let usdValue = balance;
+    if (balance !== 0) {
+      if (currency === 'ETH') {
+        usdValue = balance.replace(',', '').replace('...', '');
+      } else {
+        usdValue = balance.replace(',', '');
+      }
+    }
+
+    if (usdValue > 0 && tokensInUsd && tokensInUsd[currency]) {
+      usdValue = Number(usdValue) * Number(tokensInUsd[currency].USD);
+    }
+
+    const currencyFormat = new Intl.NumberFormat('en-US', {
+      currency: 'USD',
+      style: 'currency',
+    });
+
+    return currencyFormat.format(usdValue);
+  }
+
+  render() {
+    const { ethBalance, dgdBalance, dgxBalance } = this.state;
+    const dgdInUsd = this.getBalanceInUsd(dgdBalance, 'DGD');
+    const dgxInUsd = this.getBalanceInUsd(dgxBalance, 'DGX');
+    const ethInUsd = this.getBalanceInUsd(ethBalance, 'ETH');
+
+    return (
+      <WalletDetails>
+        <Item>
+          <WalletCurrencyIcon kind="dgd" />
+          <Amount>
+            <div>
+              <span data-digix="Wallet-DGD-Balance">{dgdBalance}</span>
+              &nbsp;DGD
+            </div>
+            <div data-digix="Wallet-DgdUsd-Balance">
+              {dgdInUsd}
+              &nbsp;USD
+            </div>
+          </Amount>
+        </Item>
+        <Item>
+          <WalletCurrencyIcon kind="dgx" />
+          <Amount>
+            <div>
+              <span data-digix="Wallet-DGX-Balance">{dgxBalance}</span>
+              &nbsp;DGX
+            </div>
+            <div data-digix="Wallet-DgxUsd-Balance">
+              {dgxInUsd}
+              &nbsp;USD
+            </div>
+          </Amount>
+        </Item>
+        <Item>
+          <WalletCurrencyIcon kind="ethereum" />
+          <Amount>
+            <div>
+              <span data-digix="Wallet-ETH-Balance">{ethBalance}</span>
+              &nbsp;ETH
+            </div>
+            <div data-digix="Wallet-EthUsd-Balance">
+              {ethInUsd}
+              &nbsp;USD
+            </div>
+          </Amount>
+        </Item>
+      </WalletDetails>
+    );
+  }
+}
+
+const { func, object } = PropTypes;
+
+WalletCurrencies.propTypes = {
+  AddressDetails: object.isRequired,
+  getDaoDetails: func.isRequired,
+  tokenUsdValues: object.isRequired,
+  web3Redux: object.isRequired,
+};
+
+const mapStateToProps = ({ daoServer, govUI, infoServer }) => ({
+  CanLockDgd: govUI.CanLockDgd,
+  ChallengeProof: daoServer.ChallengeProof,
+  DaoDetails: infoServer.DaoDetails,
+  tokenUsdValues: govUI.tokenUsdValues,
+});
+
+const WalletCurrenciesComponent = web3Connect(
+  connect(
+    mapStateToProps,
+    {
+      getDaoDetails,
+      showHideAlert,
+      showHideLockDgdOverlay,
+      showRightPanel,
+    }
+  )(WalletCurrencies)
+);
+
+export default withFetchAddress(WalletCurrenciesComponent);

--- a/src/pages/user/wallet/style.js
+++ b/src/pages/user/wallet/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { H1, Card } from '@digix/gov-ui/components/common/common-styles';
+import { Icon } from '@digix/gov-ui/components/common/elements/index';
 import { media } from '@digix/gov-ui/components/common/breakpoints';
 
 export const WalletWrapper = styled.div``;
@@ -88,32 +89,42 @@ export const QtrParticipation = styled.div`
     margin-right: 0;
   `}
 `;
+
 export const Title = styled.div`
   color: ${props => props.theme.textColor.primary.base.toString()};
   font-family: 'Futura PT Book', sans-serif;
   font-size: 2rem;
   margin-bottom: 1rem;
 `;
+
 export const Detail = styled(Card)`
   flex-direction: column;
   flex: 1 0 auto;
 `;
+
 export const Label = styled.div`
   text-transform: uppercase;
   margin-top: 1rem;
 `;
+
 export const Data = styled.div`
   color: ${props => props.theme.textColor.primary.light.toString()};
   font-size: 3.6rem;
   margin: 1rem 0 0;
   text-transform: uppercase;
 `;
+
 export const Desc = styled.p`
   margin-top: 1rem;
 `;
+
 export const Actions = styled.div`
   margin-top: 2rem;
   & > button:first-child {
     margin-left: 0;
   }
+`;
+
+export const WalletCurrencyIcon = styled(Icon)`
+  width: 5rem;
 `;


### PR DESCRIPTION
Ref: [DGDG-300](https://tracker.digixdev.com/issue/DGDG-300).

### Code Review Notes

Depends on PR #131.

**Note:** This PR is rebased on top of PR #131 (which, in turn, is based on PR #130) to show the proper diff. Please change the base to `feature/sprint-5` once the dependencies have been merged.

### Dev Notes

This refactor modularizes the Wallet page by separating (and updating) its sections into the following components: `<WalletCurrencies>`, `<QuarterSummary`, `<VotingStake>`, and `<ParticipationReward>`. This should make it easier to maintain and to see which data is relevant for each section.

All components now use GraphQL queries and subscriptions to check for changes in the locked DGD and unclaimed DGX.

### Test Plan

- Locked DGD should refresh when the user locks DGD or unlocks DGD.
- Claimable DGX should refresh when the user claims their reward.

Regression tests for the Wallet page should pass.