### PR TITLE
downgrade react-apollo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",
     "react": "^16.5.2",
-    "react-apollo": "^2.3.3",
+    "react-apollo": "2.1.4",
     "react-burger-menu": "^2.6.2",
     "react-countdown-now": "^1.3.0",
     "react-dom": "^16.5.2",


### PR DESCRIPTION
Issue:
- kyc admin is loading infinitely. KYCOfficer need to double click the button/tab twice to show the table content

Solution:
- downgrade react-apollo version from `2.3.3` to `2.1.4`