### PR TITLE
Subscribe to DGX and DGD balances in Wallet page

### DIFF
--- a/src/pages/user/wallet/sections/wallet-currencies.js
+++ b/src/pages/user/wallet/sections/wallet-currencies.js
@@ -25,11 +25,14 @@ import {
 const network = SpectrumConfig.defaultNetworks[0];
 
 class WalletCurrencies extends React.Component {
-  state = {
-    dgdBalance: 0,
-    dgxBalance: 0,
-    ethBalance: 0,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      dgdBalance: 0,
+      dgxBalance: 0,
+      ethBalance: 0,
+    };
+  }
 
   componentDidMount() {
     const { address } = this.props.AddressDetails;
@@ -46,8 +49,45 @@ class WalletCurrencies extends React.Component {
       const ethBalance = result[1];
       const dgdBalance = result[2];
       const dgxBalance = result[3];
+
       this.setState({ ethBalance, dgdBalance, dgxBalance });
+      this.props.subscribeToAddress();
     });
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    let shouldUpdate = false;
+
+    const currentLockedDgd = this.props.AddressDetails.lockedDgd;
+    const nextLockedDgd = nextProps.AddressDetails.lockedDgd;
+    if (currentLockedDgd !== nextLockedDgd) {
+      shouldUpdate = true;
+      this.getDgdBalance().then(dgdBalance => {
+        this.setState({
+          dgdBalance,
+        });
+      });
+    }
+
+    const currentClaimableDgx = this.props.AddressDetails.claimableDgx;
+    const nextClaimableDgx = nextProps.AddressDetails.claimableDgx;
+    if (currentClaimableDgx !== nextClaimableDgx) {
+      shouldUpdate = true;
+      this.getDgxBalance().then(dgxBalance => {
+        this.setState({
+          dgxBalance,
+        });
+      });
+    }
+
+    const changeInDgd = this.state.dgdBalance !== nextState.dgdBalance;
+    const changeInDgx = this.state.dgxBalance !== nextState.dgxBalance;
+    const changeInEth = this.state.ethBalance !== nextState.ethBalance;
+    if (changeInDgd || changeInDgx || changeInEth) {
+      shouldUpdate = true;
+    }
+
+    return shouldUpdate;
   }
 
   getDgdBalance() {
@@ -159,6 +199,7 @@ WalletCurrencies.propTypes = {
   AddressDetails: object.isRequired,
   getDaoDetails: func.isRequired,
   tokenUsdValues: object.isRequired,
+  subscribeToAddress: func.isRequired,
   web3Redux: object.isRequired,
 };
 


### PR DESCRIPTION
Ref: [DGDG-300](https://tracker.digixdev.com/issue/DGDG-300).

This adds the address subscription to `<WalletCurrencies/>`, so we can update the balances in real time whenever there are changes related to the DGD and DGX balance.

### Test Plan
- The DGD balance should update when you lock or unlock DGD
- The DGX balance should update after claiming your reward