### PR TITLE
Fix showing of proposal versions

### DIFF
--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -1,54 +1,46 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import _ from 'lodash';
+import { connect } from 'react-redux';
 
-import { Button } from '@digix/gov-ui/components/common/elements/index';
+import CommentThread from '@digix/gov-ui/pages/proposals/comment';
 import Like from '@digix/gov-ui/components/common/elements/like';
+import Milestones from '@digix/gov-ui/pages/proposals/milestones';
+import ModeratorButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/moderators';
+import ParticipantButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/participants';
+import ProjectDetails from '@digix/gov-ui/pages/proposals/details';
+import ProposalVersionNav from '@digix/gov-ui/pages/proposals/version-nav';
+import SpecialProjectDetails from '@digix/gov-ui/pages/proposals/special-project-details';
+import SpecialProjectVotingResult from '@digix/gov-ui/pages/proposals/special-project-voting-result';
+import VotingAccordion from '@digix/gov-ui/components/common/elements/accordion/voting-accordion';
+import VotingResult from '@digix/gov-ui/pages/proposals/voting-result';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { Message, Notifications } from '@digix/gov-ui/components/common/common-styles';
+import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { withFetchProposal } from '@digix/gov-ui/api/graphql-queries/proposal';
+import { withFetchUser } from '@digix/gov-ui/api/graphql-queries/users';
+
 import {
+  clearDaoProposalDetails,
   getUserProposalLikeStatus,
   likeProposal,
   unlikeProposal,
-  clearDaoProposalDetails,
 } from '@digix/gov-ui/reducers/dao-server/actions';
 
-import { withFetchProposal } from '@digix/gov-ui/api/graphql-queries/proposal';
-
-import moment from 'moment';
-
-import { truncateNumber } from '@digix/gov-ui/utils/helpers';
-
-import PreviousVersion from '@digix/gov-ui/pages/proposals/previous';
-import NextVersion from '@digix/gov-ui/pages/proposals/next';
-
-import ProjectDetails from '@digix/gov-ui/pages/proposals/details';
-import SpecialProjectDetails from '@digix/gov-ui/pages/proposals/special-project-details';
-import Milestones from '@digix/gov-ui/pages/proposals/milestones';
-
-import ParticipantButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/participants';
-import ModeratorButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/moderators';
-
-import VotingResult from '@digix/gov-ui/pages/proposals/voting-result';
-import SpecialProjectVotingResult from '@digix/gov-ui/pages/proposals/special-project-voting-result';
-import CommentThread from '@digix/gov-ui/pages/proposals/comment';
-import VotingAccordion from '@digix/gov-ui/components/common/elements/accordion/voting-accordion';
-
-import { Notifications, Message } from '@digix/gov-ui/components/common/common-styles';
 import {
-  ProposalsWrapper,
-  VersionHistory,
-  ProjectSummary,
-  Header,
-  Title,
   CallToAction,
+  Data,
   FundingInfo,
+  Header,
   InfoItem,
   ItemTitle,
-  Data,
+  ProjectSummary,
+  ProposalsWrapper,
+  Title,
   WarningIcon,
 } from '@digix/gov-ui/pages/proposals/style';
-import { withFetchUser } from '@digix/gov-ui/api/graphql-queries/users';
 
 const getVotingStruct = proposal => {
   let deadline = Date.now();
@@ -571,10 +563,11 @@ class Proposal extends React.Component {
   renderNormalProposal = () => {
     const { currentVersion, versions } = this.state;
     const {
-      proposalDetails,
       addressDetails,
-      history,
       daoInfo,
+      history,
+      match,
+      proposalDetails,
       userProposalLike,
       userData,
     } = this.props;
@@ -587,28 +580,22 @@ class Proposal extends React.Component {
 
     const proposalVersion = proposal.proposalVersions[currentVersion];
     const { dijixObject } = proposalVersion;
-    const versionCount = versions ? versions.length : 0;
 
     const proposalLikes = userProposalLike.data;
     const liked = proposalLikes ? proposalLikes.liked : false;
     const likes = proposalLikes ? proposalLikes.likes : 0;
     const displayName = proposalLikes ? proposalLikes.user.displayName : '';
+
     return (
       <ProposalsWrapper>
         <ProjectSummary>
-          {versions && versions.length > 1 && (
-            <VersionHistory>
-              <PreviousVersion
-                disabled={currentVersion === 0}
-                onClick={this.handlePreviousVersionClick}
-              />
-              <div>Version {currentVersion + 1} </div>
-              <NextVersion
-                disabled={currentVersion + 1 === versionCount}
-                onClick={this.handleNextVersionClick}
-              />
-            </VersionHistory>
-          )}
+          <ProposalVersionNav
+            currentVersion={currentVersion}
+            handlePreviousVersionClick={this.handlePreviousVersionClick}
+            handleNextVersionClick={this.handleNextVersionClick}
+            match={match}
+            versions={versions}
+          />
           {this.renderPrlAlert(proposal.prl)}
           {this.renderClaimApprovalAlert()}
           {this.renderProposerDidNotPassAlert()}

--- a/src/pages/proposals/version-nav.js
+++ b/src/pages/proposals/version-nav.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import NextVersion from '@digix/gov-ui/pages/proposals/next';
+import PreviousVersion from '@digix/gov-ui/pages/proposals/previous';
+import { ProposalStages } from '@digix/gov-ui/constants';
+import { VersionHistory } from '@digix/gov-ui/pages/proposals/style';
+import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
+import { withFetchProposal } from '@digix/gov-ui/api/graphql-queries/proposal';
+
+class ProposalVersionNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.VERSIONING_ALLOWED = [ProposalStages.idea, ProposalStages.draft];
+  }
+
+  render() {
+    const {
+      currentVersion,
+      handlePreviousVersionClick,
+      handleNextVersionClick,
+      versions,
+    } = this.props;
+
+    const { stage, votingStage } = this.props.proposalDetails.data;
+    const canViewProposalVersions = this.VERSIONING_ALLOWED.includes(stage) && !votingStage;
+    const versionCount = versions ? versions.length : 0;
+
+    if (versions === undefined || versions.length <= 1 || !canViewProposalVersions) {
+      return null;
+    }
+
+    const disablePrevious = currentVersion === 0;
+    const disableNext = currentVersion + 1 === versionCount;
+
+    return (
+      <VersionHistory>
+        <PreviousVersion disabled={disablePrevious} onClick={handlePreviousVersionClick} />
+        <div>Version {currentVersion + 1}</div>
+        <NextVersion disabled={disableNext} onClick={handleNextVersionClick} />
+      </VersionHistory>
+    );
+  }
+}
+
+const { array, func, number, object } = PropTypes;
+
+ProposalVersionNav.propTypes = {
+  currentVersion: number.isRequired,
+  handlePreviousVersionClick: func.isRequired,
+  handleNextVersionClick: func.isRequired,
+  proposalDetails: object.isRequired,
+  versions: array.isRequired,
+};
+
+export default withFetchAddress(withFetchProposal(ProposalVersionNav));


### PR DESCRIPTION
This creates the `<ProposalVersionNav/>` component, which will handle the logic of navigating between proposal versions.

### Test Plan
- User can only view previous versions if the project has not been finalized yet.
- When viewing previous proposal versions, the correct funding and reward values should be shown.