### PR TITLE
Fix display for milestone fundings

### DIFF
--- a/src/pages/proposals/fundings.js
+++ b/src/pages/proposals/fundings.js
@@ -1,0 +1,129 @@
+/* eslint-disable react/no-unused-prop-types */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { withFetchProposal } from '@digix/gov-ui/api/graphql-queries/proposal';
+import { Data, InfoItem, ItemTitle } from '@digix/gov-ui/pages/proposals/style';
+
+class ProposalFundings extends React.Component {
+  getMilestonFundDifference(milestoneFunds) {
+    const proposal = this.props.proposalDetails.data;
+    const { milestones } = proposal.changedFundings;
+    let difference = null;
+
+    const updatedMilestoneFunds = milestones.reduce(
+      (acc, milestone) => Number(acc.updated) + Number(milestone.updated)
+    );
+
+    difference = updatedMilestoneFunds - milestoneFunds;
+    if (difference === 0) {
+      return undefined;
+    }
+
+    return truncateNumber(difference);
+  }
+
+  getRewardDifference() {
+    const proposal = this.props.proposalDetails.data;
+    const { updated, original } = proposal.changedFundings.finalReward;
+    let difference = null;
+
+    difference = Number(updated) - Number(original);
+    if (difference === 0) {
+      return undefined;
+    }
+
+    return truncateNumber(difference);
+  }
+
+  getChangedFundings() {
+    const proposal = this.props.proposalDetails.data;
+    if (!proposal.isFundingChanged) {
+      return {
+        milestoneFunds: null,
+        milestoneFundDifference: null,
+        reward: null,
+        rewardDifference: null,
+      };
+    }
+
+    const { finalReward, milestones } = proposal.changedFundings;
+    const milestoneFunds = milestones.reduce(
+      (acc, milestone) => Number(acc.original) + Number(milestone.original)
+    );
+
+    const milestoneFundDifference = this.getMilestonFundDifference(milestoneFunds);
+    const reward = truncateNumber(Number(finalReward.original));
+    const rewardDifference = this.getRewardDifference();
+
+    return {
+      milestoneFunds,
+      milestoneFundDifference,
+      reward,
+      rewardDifference,
+    };
+  }
+
+  render() {
+    const { currentVersion } = this.props;
+    const proposal = this.props.proposalDetails.data;
+    const proposalVersion = proposal.proposalVersions[currentVersion];
+    const { isFundingChanged } = proposal;
+
+    let {
+      milestoneFunds,
+      milestoneFundDifference,
+      reward,
+      rewardDifference,
+    } = this.getChangedFundings();
+
+    if (!isFundingChanged) {
+      const { finalReward, milestoneFundings } = proposalVersion;
+      reward = truncateNumber(finalReward);
+      milestoneFunds = milestoneFundings.reduce((total, milestone) => total + Number(milestone), 0);
+    }
+
+    return (
+      <InfoItem outlined>
+        <ItemTitle>Funding</ItemTitle>
+        <Data>
+          <div className="milestones">
+            <span data-digix="funding-amount-label">{milestoneFunds}</span>
+            {milestoneFundDifference && (
+              <span data-digix="edit-funding-amount-label">
+                {milestoneFundDifference > 0
+                  ? ` + ${milestoneFundDifference}`
+                  : ` - ${Math.abs(milestoneFundDifference)}`}
+              </span>
+            )}
+            &nbsp;ETH
+            <span className="label">&nbsp;Milestones</span>
+          </div>
+          <div className="reward">
+            <span data-digix="reward-amount-label">{reward} </span>
+            {rewardDifference && (
+              <span data-digix="edit-reward-amount-label">
+                {rewardDifference > 0
+                  ? ` + ${rewardDifference} `
+                  : ` - ${Math.abs(rewardDifference)} `}
+              </span>
+            )}
+            &nbsp;ETH
+            <span className="label">&nbsp;Reward</span>
+          </div>
+        </Data>
+      </InfoItem>
+    );
+  }
+}
+
+const { number, object } = PropTypes;
+
+ProposalFundings.propTypes = {
+  currentVersion: number.isRequired,
+  match: object.isRequired,
+  proposalDetails: object.isRequired,
+};
+
+export default withFetchProposal(ProposalFundings);

--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -10,6 +10,7 @@ import Milestones from '@digix/gov-ui/pages/proposals/milestones';
 import ModeratorButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/moderators';
 import ParticipantButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/participants';
 import ProjectDetails from '@digix/gov-ui/pages/proposals/details';
+import ProposalFundings from '@digix/gov-ui/pages/proposals/fundings';
 import ProposalVersionNav from '@digix/gov-ui/pages/proposals/version-nav';
 import SpecialProjectDetails from '@digix/gov-ui/pages/proposals/special-project-details';
 import SpecialProjectVotingResult from '@digix/gov-ui/pages/proposals/special-project-voting-result';
@@ -385,55 +386,6 @@ class Proposal extends React.Component {
       );
   };
 
-  renderProposalFundings() {
-    const proposal = this.props.proposalDetails.data;
-    const proposalVersion = proposal.proposalVersions[this.state.currentVersion];
-    const { isFundingChanged } = proposal;
-
-    let {
-      milestoneFunds,
-      milestoneFundDifference,
-      reward,
-      rewardDifference,
-    } = this.getChangedFundings();
-
-    if (!isFundingChanged) {
-      const { finalReward, milestones } = proposalVersion.dijixObject;
-      reward = truncateNumber(finalReward);
-      milestoneFunds = milestones.reduce((total, milestone) => total + Number(milestone.fund), 0);
-    }
-
-    return (
-      <InfoItem outlined>
-        <ItemTitle>Funding</ItemTitle>
-        <Data>
-          <div className="milestones">
-            <span data-digix="funding-amount-label">{milestoneFunds}</span>
-            {milestoneFundDifference && (
-              <span data-digix="edit-funding-amount-label">
-                {milestoneFundDifference > 0
-                  ? ` + ${milestoneFundDifference}`
-                  : ` - ${Math.abs(milestoneFundDifference)}`}
-              </span>
-            )}
-            {` ETH`} <span className="label">Milestones</span>
-          </div>
-          <div className="reward">
-            <span data-digix="reward-amount-label">{reward} </span>
-            {rewardDifference && (
-              <span data-digix="edit-reward-amount-label">
-                {rewardDifference > 0
-                  ? ` + ${rewardDifference} `
-                  : ` - ${Math.abs(rewardDifference)} `}
-              </span>
-            )}
-            ETH <span className="label">Reward</span>
-          </div>
-        </Data>
-      </InfoItem>
-    );
-  }
-
   renderProposerDidNotPassAlert = () => {
     const {
       proposalDetails: {
@@ -638,7 +590,11 @@ class Proposal extends React.Component {
                 <span data-digix="milestone-label">{dijixObject.milestones.length || 0}</span>
               </Data>
             </InfoItem>
-            {this.renderProposalFundings()}
+            <ProposalFundings
+              currentVersion={currentVersion}
+              match={match}
+              proposalDetails={proposal}
+            />
             <InfoItem>
               <Like
                 hasVoted={liked}
@@ -660,6 +616,7 @@ class Proposal extends React.Component {
         <ProjectDetails project={dijixObject} />
         <Milestones
           milestones={dijixObject.milestones || []}
+          milestoneFundings={proposalVersion.milestoneFundings || []}
           changedFundings={changedFundings ? changedFundings.milestones : undefined}
           fundingChanged={proposal.isFundingChanged}
         />

--- a/src/pages/proposals/milestones.js
+++ b/src/pages/proposals/milestones.js
@@ -10,7 +10,7 @@ export default class Milestones extends React.Component {
   }
 
   renderMilestone(milestone, index) {
-    const { changedFundings, fundingChanged } = this.props;
+    const { changedFundings, fundingChanged, milestoneFundings } = this.props;
 
     let funding;
     let milestoneFund;
@@ -22,7 +22,7 @@ export default class Milestones extends React.Component {
       funding = Number(original);
       milestoneFund = Number(updated) - funding;
     } else {
-      funding = milestone.fund;
+      funding = Number(milestoneFundings[index]);
     }
 
     return (
@@ -53,6 +53,7 @@ export default class Milestones extends React.Component {
 Milestones.propTypes = {
   changedFundings: PropTypes.array,
   fundingChanged: PropTypes.bool.isRequired,
+  milestoneFundings: PropTypes.array.isRequired,
   milestones: PropTypes.array.isRequired,
 };
 


### PR DESCRIPTION
Ref: [DGDG-424](https://tracker.digixdev.com/agiles/88-14/89-17?issue=DGDG-424)

This uses `proposalVersions.milestoneFundings` to get the funding value, instead of relying on the `dijixObject`. The logic has been moved to the `<ProposalFundings/>` component to make it easier to maintain.

### Test Plan
- Create a project and edit the milestone fundings at least three times.
- View the different proposal versions. The values for reward, milestones, and milestone fundings (sum of milestones) should be correct.