### PR TITLE
Clean up console errors in Profile page

### DIFF
--- a/src/components/common/blocks/overlay/kyc/form-step.js
+++ b/src/components/common/blocks/overlay/kyc/form-step.js
@@ -254,6 +254,7 @@ class KycFormStep extends React.Component {
       accept="image/*"
       dataDigix={`KycForm-${fieldName}`}
       fluid
+      id={fieldName}
       kind="upload"
       large
       name={fieldName}
@@ -292,6 +293,7 @@ class KycFormStep extends React.Component {
 
     return (
       <Select
+        id={fieldName}
         items={formOptions[fieldName]}
         data-digix={`KycForm-${fieldName}`}
         error={rules[fieldName].hasError}

--- a/src/components/common/blocks/overlay/kyc/steps/photo-upload.js
+++ b/src/components/common/blocks/overlay/kyc/steps/photo-upload.js
@@ -319,6 +319,7 @@ class KycOverlayPhotoUpload extends KycFormStep {
             <Label>Photo Proof Method</Label>
             <Select
               fluid
+              id="photo-upload"
               item="upload"
               items={this.PHOTO_PROOF_METHODS}
               onChange={this.changeProofMethod}

--- a/src/components/common/blocks/overlay/profile-email/index.js
+++ b/src/components/common/blocks/overlay/profile-email/index.js
@@ -99,13 +99,19 @@ class EmailOverlay extends React.Component {
 }
 
 const { func, string } = PropTypes;
+
 EmailOverlay.propTypes = {
-  currentEmail: string.isRequired,
+  currentEmail: string,
   showHideAlert: func.isRequired,
   showRightPanel: func.isRequired,
 };
 
+EmailOverlay.defaultProps = {
+  currentEmail: '',
+};
+
 const mapStateToProps = () => ({});
+
 export default web3Connect(
   connect(
     mapStateToProps,

--- a/src/components/common/blocks/overlay/profile-username/update-username.js
+++ b/src/components/common/blocks/overlay/profile-username/update-username.js
@@ -27,12 +27,13 @@ class UpdateUsernameButton extends React.Component {
 const { bool, func, string } = PropTypes;
 
 UpdateUsernameButton.propTypes = {
-  changeUsername: func.isRequired,
+  changeUsername: func,
   disable: bool.isRequired,
   username: string,
 };
 
 UpdateUsernameButton.defaultProps = {
+  changeUsername: undefined,
   username: undefined,
 };
 

--- a/src/components/common/elements/select/index.js
+++ b/src/components/common/elements/select/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import StyledSelect from './style';
+import StyledSelect from '@digix/gov-ui/components/common/elements/select/style';
 
 class Select extends React.Component {
   render() {
@@ -9,7 +8,7 @@ class Select extends React.Component {
     return (
       <StyledSelect id={id} {...rest}>
         {showPlaceholder && (
-          <option disabled selected value="">
+          <option disabled value="">
             Please select option
           </option>
         )}

--- a/src/pages/user/profile/sections/moderator-requirements.js
+++ b/src/pages/user/profile/sections/moderator-requirements.js
@@ -4,10 +4,9 @@ import { connect } from 'react-redux';
 
 import RedeemBadge from '@digix/gov-ui/pages/user/profile/buttons/redeem-badge';
 import { Button, Icon } from '@digix/gov-ui/components/common/elements';
-import { DEFAULT_STAKE_PER_DGD } from '@digix/gov-ui/constants';
-import { getDaoConfig, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
-import { inLockingPhase, truncateNumber } from '@digix/gov-ui/utils/helpers';
+import { getDaoConfig } from '@digix/gov-ui/reducers/info-server/actions';
 import { showHideLockDgdOverlay } from '@digix/gov-ui/reducers/gov-ui/actions';
+import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
 
 import {
@@ -24,21 +23,8 @@ import {
 class ModeratorRequirements extends React.Component {
   componentDidMount() {
     this.props.getDaoConfig();
-    this.props.getDaoDetails();
     this.props.subscribeToAddress();
   }
-
-  getStakePerDgd = () => {
-    const DaoDetails = this.props.DaoDetails.data;
-    const { startOfMainphase, startOfNextQuarter } = DaoDetails;
-
-    if (inLockingPhase(DaoDetails)) {
-      return DEFAULT_STAKE_PER_DGD;
-    }
-
-    const currentTime = Date.now() / 1000;
-    return (startOfNextQuarter - currentTime) / (startOfNextQuarter - startOfMainphase);
-  };
 
   getModeratorRequirements = () => {
     const { DaoConfig } = this.props;
@@ -51,8 +37,7 @@ class ModeratorRequirements extends React.Component {
 
     const currentStake = Number(lockedDgdStake);
     const minStake = Number(config.CONFIG_MINIMUM_DGD_FOR_MODERATOR);
-    const stakePerDgd = this.getStakePerDgd();
-    const requiredStake = Math.max(0, (minStake - currentStake) / stakePerDgd);
+    const requiredStake = Math.max(0, minStake - currentStake);
 
     const requirements = {
       reputation: truncateNumber(requiredReputation),
@@ -113,17 +98,14 @@ const { func, object } = PropTypes;
 ModeratorRequirements.propTypes = {
   AddressDetails: object.isRequired,
   DaoConfig: object,
-  DaoDetails: object,
   history: object.isRequired,
   getDaoConfig: func.isRequired,
-  getDaoDetails: func.isRequired,
   showHideLockDgdOverlay: func.isRequired,
   subscribeToAddress: func.isRequired,
 };
 
 ModeratorRequirements.defaultProps = {
   DaoConfig: undefined,
-  DaoDetails: undefined,
 };
 
 const mapStateToProps = ({ infoServer }) => ({
@@ -136,7 +118,6 @@ export default withFetchAddress(
     mapStateToProps,
     {
       getDaoConfig,
-      getDaoDetails,
       showHideLockDgdOverlay,
     }
   )(ModeratorRequirements)


### PR DESCRIPTION
This fixes unused or missing props in the components used on the Profile page. Moreover, the forumla for the remaining stake needed to become a moderator has been fixed (by removing the `getStakePerDgd` method).

### Test Plan
- Regression tests should pass and should not show conosole errors.
- The remaining stake needed to become a moderator should be correct.