### PR TITLE
Clean up console warnings in Wallet Page

### DIFF
--- a/src/components/common/blocks/overlay/unlock-dgd/style.js
+++ b/src/components/common/blocks/overlay/unlock-dgd/style.js
@@ -20,6 +20,11 @@ export const TextBox = styled(Input)`
   border: 0;
   outline: 0;
 
+  &:focus {
+    border: none;
+    box-shadow: none;
+  }
+
   ::placeholder {
     text-align: right;
     transition: opacity 0.5s 0.5s ease;

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -42,7 +42,7 @@ class VotingStake extends React.Component {
   showUnlockDgdOverlay() {
     const { lockedDgd } = this.props.AddressDetails;
     this.props.showRightPanel({
-      component: <UnlockDgdOverlay maxAmount={lockedDgd} />,
+      component: <UnlockDgdOverlay maxAmount={Number(lockedDgd)} />,
       show: true,
     });
   }


### PR DESCRIPTION
As titled. This also fixes the CSS for the input element on the Unlock DGD overlay (hides the border that shows up in the middle).

### Test Plan
- Regression tests on the page should pass and should not show console warnings.
- Visual inspection on the Unlock DGD overlay should pass.