### PR TITLE
More proper handling of uploading images when editing projects

### DIFF
--- a/src/pages/proposals/confirm/media.js
+++ b/src/pages/proposals/confirm/media.js
@@ -23,7 +23,7 @@ export default class MediaAssets extends React.PureComponent {
 
   componentDidMount = () => {
     const { images } = this.props.form;
-    fetchImages(images).then(files => this.setState({ files }));
+    if (images) fetchImages(images).then(files => this.setState({ files }));
   };
 
   showHideImage = source => () => {

--- a/src/pages/proposals/details.js
+++ b/src/pages/proposals/details.js
@@ -20,8 +20,7 @@ export default class ProjectDetails extends React.Component {
 
   componentDidMount = () => {
     const { images } = this.props.project;
-
-    fetchImages(images).then(files => this.setState({ files }));
+    if (images) fetchImages(images).then(files => this.setState({ files }));
   };
 
   componentWillReceiveProps = nextProps => {

--- a/src/pages/proposals/edit/index.js
+++ b/src/pages/proposals/edit/index.js
@@ -103,7 +103,6 @@ class EditProposal extends React.Component {
       form[e.target.id] = e.target.value;
     } else if (e && value) {
       form[e] = value;
-      console.log({ e, value, form });
     }
 
     this.setState({ form: { ...form } }, () => {

--- a/src/pages/proposals/forms/multimedia.js
+++ b/src/pages/proposals/forms/multimedia.js
@@ -30,7 +30,7 @@ class Multimedia extends React.Component {
 
   componentDidMount = () => {
     const { images } = this.props.form;
-    fetchImages(images).then(files => this.setState({ files }));
+    if (images) fetchImages(images).then(files => this.setState({ files }));
   };
 
   showHideImage = source => () => {
@@ -42,10 +42,10 @@ class Multimedia extends React.Component {
     const { proofs } = this.props.form;
     if (index < 0 || (!thumbnails && !proofs)) return;
 
-    if (thumbnails) {
-      thumbnails.splice(index, 1);
-    }
+    if (thumbnails) thumbnails.splice(index, 1);
+
     if (proofs) proofs.splice(index, 1);
+
     this.setState({ thumbnails: thumbnails || proofs }, () => {
       this.props.onChange('proofs', proofs);
     });
@@ -146,14 +146,14 @@ class Multimedia extends React.Component {
         source = `${dijix.config.httpEndpoint}/${img.src}`;
       }
       return (
-        <div>
+        <div key={`img-${i + 1}`}>
           <Button
             onClick={existing ? this.handleDeleteExisting(i) : this.handleDeleteNewlyUploaded(i)}
           >
             Delete
           </Button>
           {/* eslint-disable*/}
-          <img key={`img-${i + 1}`} alt="" onClick={this.showHideImage(source)} src={source} />;
+          <img  alt="" onClick={this.showHideImage(source)} src={source} />;
           {/* eslint-enable */}
         </div>
       );

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -87,9 +87,9 @@ export const getUnmetProposalRequirements = (apolloClient, DaoDetails) => {
   const errors = [];
 
   return isKycApproved(apolloClient).then(kycApproved => {
-    // if (!kycApproved) {
-    //   errors.push(ProposalErrors.invalidKyc);
-    // }
+    if (!kycApproved) {
+      errors.push(ProposalErrors.invalidKyc);
+    }
 
     if (inLockingPhase(DaoDetails)) {
       errors.push(ProposalErrors.inLockingPhase);


### PR DESCRIPTION
Update Creating and Editing Proposal to allow users to remove an uploaded image.

Ref [DGDG-431](https://tracker.digixdev.com/agiles/88-14/89-21?issue=DGDG-431)

This change has updates to Create, Edit, Preview and Confirm Screens

Test Plan
 - Create a Proposal, you may add images or do it later on edit
 - Edit a Proposal, try to add/remove images
 - Click Preview to confirm images are showing properly
 - When you confirm adding/editing a proposal, verify that images are showing properly

Note: `Delete` button still needs to be updated to show `X` button instead