### PR TITLE
Show error overlay when user tries to resubmit their KYC.

### DIFF
--- a/src/components/common/blocks/overlay/error-message/index.js
+++ b/src/components/common/blocks/overlay/error-message/index.js
@@ -18,15 +18,19 @@ class ErrorMessageOverlay extends React.Component {
     });
   }
 
-  renderNotification = error => (
-    <Notifications error key={error.title} data-digix="ProjectError-Notification">
-      <Message uppercase data-digix="ProjectError-Notification-Title">
-        {error.title}
-      </Message>
-      <p>{error.description}</p>
-      <p>{error.details}</p>
-    </Notifications>
-  );
+  renderNotification = error => {
+    const { details, description, title } = error;
+
+    return (
+      <Notifications error key={title} data-digix="ProjectError-Notification">
+        <Message uppercase data-digix="ProjectError-Notification-Title">
+          {title}
+        </Message>
+        <p>{description}</p>
+        {details && <p>{details}</p>}
+      </Notifications>
+    );
+  };
 
   render() {
     const { errors, location } = this.props;

--- a/src/constants.js
+++ b/src/constants.js
@@ -104,3 +104,12 @@ export const ProposalErrors = {
     details: "Let's try again when you have enough ETH.",
   }),
 };
+
+export const KycErrors = {
+  resubmit: {
+    title: 'Re-submit KYC',
+    description:
+      'Please contact us via our Zendesk widget for enquiries about changing your KYC information.',
+    details: null,
+  },
+};


### PR DESCRIPTION
Ref: [DGDG-445](https://tracker.digixdev.com/issue/DGDG-445)

Instead of letting the user resubmit their KYC through the site, they should contact us via Zendesk instead.

### Test Plan
- Error overlay should show up when clicking the resubmit button.
- Regression test on the whole KYC flow.