### PR TITLE
Show loading screen for uploding docs to IPFS while submitting projects

### DIFF
--- a/src/components/common/blocks/loader/spinner.js
+++ b/src/components/common/blocks/loader/spinner.js
@@ -16,7 +16,7 @@ class Spinner extends React.Component {
           <Content>
             <Loader />
             <h1>Please wait.</h1>
-            <p>Hold tight while your proposal is being uploaded to IPFS.</p>
+            <p>Hold tight while your project is being uploaded to IPFS.</p>
           </Content>
         </SpinnerWrapper>
         <ScreenLoader />


### PR DESCRIPTION
Ref: [DGDG-393](https://tracker.digixdev.com/issue/DGDG-393)

As titled. The loading screen will show up behind the transaction modal when you try to submit a project.

This also does a bit of refactoring on the logic for rendering the `<CreateProposal/>` component. `state.renderStep` indicates what to render on the browser, making it easier to follow what conditions are needed for the different parts of the form.

The same has been implemented in the `<EditProposal/>` component.

### Test Plan
- Submit a project and verify that the loading screen shows up.
- Regression test for the navigation buttons on the **Create Project** flow should pass.
- The same two tests above should pass for editing a project.