### PR TITLE
Add countdown page for DigixDao Launch

### DIFF
--- a/src/components/common/blocks/collapsible-menu/index.js
+++ b/src/components/common/blocks/collapsible-menu/index.js
@@ -141,6 +141,10 @@ class CollapsibleMenu extends React.Component {
   );
 
   render() {
+    if (this.props.HasCountdown) {
+      return null;
+    }
+
     const { addressDetails, ChallengeProof, menuItems, showLeftMenu } = this.props;
     const userType = getUserStatus(addressDetails.data);
     const menu = menuItems || DEFAULT_MENU;
@@ -176,7 +180,7 @@ class CollapsibleMenu extends React.Component {
   }
 }
 
-const { array, object, func } = PropTypes;
+const { array, bool, object, func } = PropTypes;
 CollapsibleMenu.propTypes = {
   menuItems: array,
   theme: object,
@@ -185,6 +189,7 @@ CollapsibleMenu.propTypes = {
   location: object.isRequired,
   ChallengeProof: object,
   showHideLeftMenu: func.isRequired,
+  HasCountdown: bool.isRequired,
 };
 
 CollapsibleMenu.defaultProps = {
@@ -199,6 +204,7 @@ const mapStateToProps = state => ({
   addressDetails: state.infoServer.AddressDetails,
   ChallengeProof: state.daoServer.ChallengeProof,
   showLeftMenu: state.govUI.showLeftMenu,
+  HasCountdown: state.govUI.HasCountdown,
 });
 
 export default connect(

--- a/src/components/common/blocks/loader/countdown.js
+++ b/src/components/common/blocks/loader/countdown.js
@@ -1,19 +1,61 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import Countdown from 'react-countdown-now';
 import ScreenLoader from '@digix/gov-ui/components/common/blocks/loader/screen';
+import { getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { showCountdownPage } from '@digix/gov-ui/reducers/gov-ui/actions';
+
 import {
-  Preloaders,
-  CountdownWrapper,
   Content,
-  TimerContainer,
-  Timer,
-  Divider,
+  CountdownWrapper,
   Cta,
+  Divider,
   Label,
   ParticipateButton,
+  Preloaders,
+  Timer,
+  TimerContainer,
 } from '@digix/gov-ui/components/common/blocks/loader/style';
 
-class Countdown extends React.Component {
+const countdownRenderer = props => {
+  // eslint-disable-next-line
+  const { hours, minutes, seconds, completed } = props;
+  if (completed) {
+    // eslint-disable-next-line
+    props.showCountdownPage({ show: false });
+  }
+
+  return (
+    <Timer>
+      <div>
+        <span>{hours}</span>
+        <span>Hours</span>
+      </div>
+      <Divider />
+      <div>
+        <span>{minutes}</span>
+        <span>Minutes</span>
+      </div>
+      <Divider />
+      <div>
+        <span>{seconds}</span>
+        <span>Seconds</span>
+      </div>
+    </Timer>
+  );
+};
+
+class CountdownPage extends React.Component {
+  componentDidMount() {
+    this.props.getDaoDetails();
+  }
+
   render() {
+    let { startOfNextQuarter } = this.props.DaoDetails;
+    startOfNextQuarter *= 1000;
+
     return (
       <Preloaders>
         <CountdownWrapper>
@@ -32,29 +74,20 @@ class Countdown extends React.Component {
             <Label>
               <div />
               <div>
-                Countdown To Launch <span>&middot;</span> 03.28
+                Countdown To Launch <span>&middot;</span> 03.30
               </div>
               <div />
             </Label>
-            <Timer>
-              <div>
-                <span>48</span>
-                <span>Hours</span>
-              </div>
-              <Divider />
-              <div>
-                <span>11</span>
-                <span>Minutes</span>
-              </div>
-              <Divider />
-              <div>
-                <span>34</span>
-                <span>Seconds</span>
-              </div>
-            </Timer>
+            <Countdown
+              daysInHours
+              date={startOfNextQuarter}
+              getDaoDetails={this.props.getDaoDetails}
+              renderer={countdownRenderer}
+              showCountdownPage={this.props.showCountdownPage}
+            />
             <Cta>
               <ParticipateButton reverse large>
-                See Manual on how to participate in DigixDAO
+                View the manual on how to participate in DigixDAO
               </ParticipateButton>
             </Cta>
           </TimerContainer>
@@ -65,4 +98,25 @@ class Countdown extends React.Component {
   }
 }
 
-export default Countdown;
+const { func, object } = PropTypes;
+CountdownPage.propTypes = {
+  DaoDetails: object,
+  getDaoDetails: func.isRequired,
+  showCountdownPage: func.isRequired,
+};
+
+CountdownPage.defaultProps = {
+  DaoDetails: undefined,
+};
+
+const mapStateToProps = ({ infoServer }) => ({
+  DaoDetails: infoServer.DaoDetails.data,
+});
+
+export default connect(
+  mapStateToProps,
+  {
+    getDaoDetails,
+    showCountdownPage,
+  }
+)(CountdownPage);

--- a/src/components/common/blocks/navbar/search.js
+++ b/src/components/common/blocks/navbar/search.js
@@ -19,10 +19,12 @@ const StyledLink = styled.a`
 function Search() {
   return (
     <MenuWrapper>
+      {/*
       <StyledLink href="./" style={{ pointerEvents: 'none' }}>
         <Icon kind="magnifier" />
         <span>Search</span>
       </StyledLink>
+      */}
     </MenuWrapper>
   );
 }

--- a/src/components/common/blocks/navbar/wallet.js
+++ b/src/components/common/blocks/navbar/wallet.js
@@ -38,8 +38,11 @@ class WalletButton extends React.Component {
   };
 
   render() {
-    const { defaultAddress, canLockDgd } = this.props;
+    if (this.props.HasCountdown) {
+      return null;
+    }
 
+    const { defaultAddress, canLockDgd } = this.props;
     return (
       <WalletWrapper>
         {!defaultAddress && (
@@ -93,12 +96,13 @@ class WalletButton extends React.Component {
   }
 }
 
-const { func, string, object, oneOfType } = PropTypes;
+const { bool, func, string, object, oneOfType } = PropTypes;
 WalletButton.propTypes = {
   showHideLockDgd: func.isRequired,
   showHideWalletOverlay: func.isRequired,
   defaultAddress: oneOfType([string, object]),
   canLockDgd: object,
+  HasCountdown: bool.isRequired,
 };
 
 WalletButton.defaultProps = {
@@ -110,6 +114,7 @@ const mapStateToProps = state => ({
   defaultAddress: getDefaultAddress(state),
   addressDetails: state.infoServer.AddressDetails,
   canLockDgd: state.govUI.CanLockDgd,
+  HasCountdown: state.govUI.HasCountdown,
 });
 
 export default connect(

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -9,6 +9,7 @@ export const actions = {
   SHOW_WALLET: `${REDUX_PREFIX}SHOW_WALLET`,
   CAN_LOCK_DGD: `${REDUX_PREFIX}CAN_LOCK_DGD`,
   SHOW_RIGHT_PANEL: `${REDUX_PREFIX}SHOW_RIGHT_PANEL`,
+  SHOW_COUNTDOWN_PAGE: `${REDUX_PREFIX}SHOW_COUNTDOWN_PAGE`,
   GET_CONFIG_PREPROPOSAL_COLLATERAL: `${REDUX_PREFIX}GET_CONFIG_PREPROPOSAL_COLLATERAL`,
   GET_ADDRESS_MAX_ALLOWANCE: `${REDUX_PREFIX}GET_ADDRESS_MAX_ALLOWANCE`,
 
@@ -115,6 +116,12 @@ export function showHideAlert(alert) {
 export function showRightPanel(payload) {
   return dispatch => {
     dispatch({ type: actions.SHOW_RIGHT_PANEL, payload: { ...payload } });
+  };
+}
+
+export function showCountdownPage(payload) {
+  return dispatch => {
+    dispatch({ type: actions.SHOW_COUNTDOWN_PAGE, payload: { ...payload } });
   };
 }
 

--- a/src/reducers/gov-ui/index.js
+++ b/src/reducers/gov-ui/index.js
@@ -10,6 +10,7 @@ const defaultState = {
   SignChallenge: undefined,
   ShowWallet: undefined,
   showLeftMenu: undefined,
+  HasCountdown: false,
   CanLockDgd: undefined,
   ShowRightPanel: {
     show: false,
@@ -86,6 +87,11 @@ export default function(state = defaultState, action) {
       return {
         ...state,
         ShowRightPanel: action.payload,
+      };
+    case actions.SHOW_COUNTDOWN_PAGE:
+      return {
+        ...state,
+        HasCountdown: action.payload.show,
       };
     case actions.GET_CONFIG_PREPROPOSAL_COLLATERAL:
       return {


### PR DESCRIPTION
Ref: [DGDG-438](https://tracker.digixdev.com/issue/DGDG-438)

The countdown is based on `DaoInfo.startOfNextQuarter` when `currentQuarter === 0`. Once the timer ends, it should redirect to the dashboard automatically.

Note that even if the timer ends, `info-server` may take some time to update the value of `currentQuarter`. A workaround for this is setting a `HasCountdown` flag in the `govUI` redux. The flag is set to `false` once the timer ends, so we can redirect to the dashboard without having to wait for `info-server` to update.

This also hides the search bar from the site.

### Test Plan
- Go to `dao-contracts` and run the following command: `START_IN=200 ./scripts/initiate-dao-countdown.sh`. This initializes the countdown based on the current time. You can replace `200` with any duration you prefer (note that this is in seconds).
- Restart `info-server` by running `npm run dev:force`.
- Check the site and verify that the countdown is running.
- When the timer is up, it should redirect you to the dashboard.

**Note:** There are no proposals to show after the countdown ends. Moreover, test accounts do not have DGDs locked, so you will need to trasfer funds via `truffle console` and lock DGDs to use the site.