### PR TITLE
[fix] Throw error when requesting queries with no authorization

### DIFF
--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { createHttpLink } from 'apollo-link-http';
-import { ApolloLink, split } from 'apollo-link';
+import { ApolloLink, split, from } from 'apollo-link';
 import { setContext } from 'apollo-link-context';
 import { getMainDefinition } from 'apollo-utilities';
 
@@ -40,21 +40,26 @@ const infoHttpLink = createHttpLink({
   credentials: 'same-origin',
 });
 
-// eslint-disable-next-line
-const daoAuthHttpLink = setContext((_previous, { headers }) => ({
-  headers: {
-    ...headers,
-    ...(daoAuthorization || {}),
-  },
-})).concat(daoHttpLink);
+const httpAuthorizedLink = fetchAuth =>
+  new ApolloLink((operation, forward) => {
+    const authorization = fetchAuth();
 
-// eslint-disable-next-line
-const infoAuthHttpLink = setContext((_previous, { headers }) => ({
-  headers: {
-    ...headers,
-    ...(infoAuthorization || {}),
-  },
-})).concat(infoHttpLink);
+    if (!authorization) {
+      throw new Error('Not authorized');
+    }
+
+    operation.setContext((_previous, __options) => ({
+      headers: {
+        ...(authorization || {}),
+      },
+    }));
+
+    return forward(operation);
+  });
+
+const daoAuthHttpLink = from([httpAuthorizedLink(() => daoAuthorization), daoHttpLink]);
+
+const infoAuthHttpLink = from([httpAuthorizedLink(() => infoAuthorization), infoHttpLink]);
 
 let daoCableLink = null;
 let daoCable = null;
@@ -133,11 +138,7 @@ const apiLink = split(
         source: { body },
       },
     },
-  }) => {
-    const x = infoQueries.test(body);
-
-    return infoQueries.test(body);
-  },
+  }) => infoQueries.test(body),
   infoAuthHttpLink,
   daoAuthHttpLink
 );

--- a/src/components/common/blocks/collapsible-menu/index.js
+++ b/src/components/common/blocks/collapsible-menu/index.js
@@ -119,8 +119,13 @@ class CollapsibleMenu extends React.Component {
   renderAdminMenuItem = menu => (
     <Query query={fetchUserQuery} key={menu.title}>
       {({ loading, error, data }) => {
+        if (loading || error) {
+          return null;
+        }
+
         const isAllowed = data.currentUser && data.currentUser[menu.requirement];
-        if (loading || error || !isAllowed) {
+
+        if (!isAllowed) {
           return null;
         }
 


### PR DESCRIPTION
Throw error when requesting queries with no authorization

This resolves the extraneous API call when no wallet is loaded.