### PR TITLE
[Fix] - Metamask error

### DIFF
--- a/src/pages/proposals/forms/index.js
+++ b/src/pages/proposals/forms/index.js
@@ -157,6 +157,9 @@ class ProposalForms extends React.Component {
   };
 
   setError = error => {
+    this.setState({
+      renderStep: this.RENDER_STEP.confirm,
+    });
     const message = JSON.stringify(error && error.message) || error;
     this.props.showHideAlert({ message });
   };

--- a/src/utils/web3Helper.js
+++ b/src/utils/web3Helper.js
@@ -56,7 +56,7 @@ export const executeContractFunction = payload => {
           logTxn.completeTransaction(false, error);
         }
 
-        if (typeof onFinally === 'function') {
+        if (typeof onFinally === 'function' && error.data) {
           const txHash = Object.keys(error.data)[0];
           onFinally(txHash);
         }


### PR DESCRIPTION
This fixes an error user Cancel's the transaction when creating/editing a Project and if the User is on different network.

Updated Web3Helper to check if the error object contains `data`
Reverts the Step to `Confirm` when the user Cancel's the transaction or if an error occurs during contract call.