### PR TITLE
Subscribe to changes in total stake and render them in the dashboard timeline

### DIFF
--- a/src/api/graphql-queries/dao.js
+++ b/src/api/graphql-queries/dao.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+
+export const fetchDaoQuery = gql`
+  query fetchDao {
+    fetchDao {
+      isGlobalRewardsSet
+      currentQuarter
+      startOfQuarter
+      startOfMainphase
+      startOfNextQuarter
+      totalLockedDgds
+      totalModeratorLockedDgds
+      nModerators
+      nParticipants
+    }
+  }
+`;
+
+export const daoSubscription = gql`
+  subscription {
+    daoUpdated {
+      isGlobalRewardsSet
+      currentQuarter
+      startOfQuarter
+      startOfMainphase
+      startOfNextQuarter
+      totalLockedDgds
+      totalModeratorLockedDgds
+      nModerators
+      nParticipants
+    }
+  }
+`;
+
+export const withFetchDaoInfo = Component => props => (
+  <Query query={fetchDaoQuery}>
+    {({ loading, error, data, subscribeToMore }) => {
+      if (loading || error) {
+        return <Component {...props} />;
+      }
+
+      const subscribeToDao = () => {
+        subscribeToMore({
+          document: daoSubscription,
+          updateQuery: (cache, { subscriptionData }) => {
+            const newData = subscriptionData.data;
+            if (!newData) {
+              return;
+            }
+
+            cache.fetchDao = { ...newData.daoUpdated };
+            return { ...cache };
+          },
+        });
+      };
+
+      return (
+        <Component
+          {...props}
+          daoInfo={data.fetchDao}
+          subscribeToDao={subscribeToDao}
+        />
+      );
+    }}
+  </Query>
+);

--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -121,9 +121,9 @@ const infoSocketLink = new ApolloLink((operation, _forward) => {
   return null;
 });
 
-const infoSubscriptions = new RegExp(['proposalUpdated', 'userUpdated'].join('|'));
+const infoSubscriptions = new RegExp(['proposalUpdated', 'userUpdated', 'daoUpdated'].join('|'));
 
-const infoQueries = new RegExp(['fetchProposal', 'fetchCurrentUser'].join('|'));
+const infoQueries = new RegExp(['fetchProposal', 'fetchCurrentUser', 'fetchDao'].join('|'));
 
 const apiLink = split(
   ({


### PR DESCRIPTION
This adds the subscription to `daoInfo` changes.

### Test Plan
- Load any wallet and lock some DGD.
- The total stake on the dashboard timeline should update once the transaction has been confirmed.