### PR TITLE
[Fix] - Metamask wallet

### DIFF
--- a/src/components/common/blocks/wallet/metamask/index.js
+++ b/src/components/common/blocks/wallet/metamask/index.js
@@ -30,6 +30,7 @@ class Metamask extends React.Component {
           form={KeystoreCreationForm}
           creatingKeyStore
           data={{ type: 'metamask', updateDefaultAddress: true }}
+          keystoreType="metamask"
           header="Load MetaMask Wallet"
           hideSelector
           allowedKeystoreTypes={['metamask']}


### PR DESCRIPTION
Added a `keystoreType` prop for Metamask wallet which will be used by `governance-ui` to handle metamask wallet separately as it requires consent from the user.