### PR TITLE
Add APPROVING status for KYC requests in admin

### DIFF
--- a/src/pages/kyc/officer/constants.js
+++ b/src/pages/kyc/officer/constants.js
@@ -6,8 +6,18 @@ const iconStatus = [
     status: 'PENDING',
     key: 'alarm',
   },
-  { status: 'APPROVED', key: 'check' },
-  { status: 'REJECTED', key: 'close' },
+  {
+    status: 'APPROVING',
+    key: 'alarm',
+  },
+  {
+    status: 'APPROVED',
+    key: 'check',
+  },
+  {
+    status: 'REJECTED',
+    key: 'close',
+  },
 ];
 
 export const showStatusIcon = status => {

--- a/src/pages/kyc/officer/index.js
+++ b/src/pages/kyc/officer/index.js
@@ -123,6 +123,14 @@ class KycOfficerDashboard extends React.Component {
           </TabButton>
           <TabButton
             large
+            onClick={() => this.handleListKycByStatus('APPROVING')}
+            data-digix="Kyc-Admin-Appriving-Requests"
+            active={filter === 'APPROVING'}
+          >
+            Pending Confirmation
+          </TabButton>
+          <TabButton
+            large
             onClick={() => this.handleListKycByStatus('APPROVED')}
             data-digix="Kyc-Admin-Approved-Requests"
             active={filter === 'APPROVED'}


### PR DESCRIPTION
Ref: [DGDG-395](https://tracker.digixdev.com/issue/DGDG-395)

### Code Review Notes
Depends on PR [#27](https://github.com/DigixGlobal/dao-server/pull/27) for `dao-server`.

### Dev Notes
The `Approving` status happens for KYC requests that have been approved by the KYC officer but are still pending confirmation in the blockchain. The status should automatically reflect in the user's profile page, since we're already subscribed to the event. This diff fixes the bug where the admin UI breaks when approving a KYC request (since the icon for `Approving` requests is missing). This also adds the filter for such requests.

### Test Plan
- Set the `BLOCK_CONFIRMATIONS` config on `info_server` to a number greater than zero. This will ensure that we see the `Approving` status, since the transaction won't be confirmed immediately. Make sure to restart the contracts.
- Approve a KYC request on admin. The UI shouldn't break after approving.
- The KYC status on the user's profile should be updated to `Approving`.
- Verify that there is an additional filter in the KYC dashboard for `Approving` requests, titled **Pending Confirmation**.