### PR TITLE
Fix milestone display across project versions

### DIFF
--- a/src/pages/proposals/milestones.js
+++ b/src/pages/proposals/milestones.js
@@ -9,8 +9,9 @@ export default class Milestones extends React.Component {
     this.NO_MILESTONE_DESCRIPTION = 'No milestone description has been created yet.';
   }
 
-  renderMilestone(milestone, index) {
-    const { changedFundings, fundingChanged, milestoneFundings } = this.props;
+  renderMilestone(milestoneFunding, index) {
+    const { changedFundings, fundingChanged, milestones } = this.props;
+    const milestone = milestones[index];
 
     let funding;
     let milestoneFund;
@@ -22,7 +23,7 @@ export default class Milestones extends React.Component {
       funding = Number(original);
       milestoneFund = Number(updated) - funding;
     } else {
-      funding = Number(milestoneFundings[index]);
+      funding = Number(milestoneFunding);
     }
 
     return (
@@ -38,8 +39,10 @@ export default class Milestones extends React.Component {
   }
 
   render() {
-    const { milestones } = this.props;
-    const milestoneElements = milestones.map((milestone, i) => this.renderMilestone(milestone, i));
+    const { milestoneFundings } = this.props;
+    const milestoneElements = milestoneFundings.map((milestoneFunding, i) =>
+      this.renderMilestone(milestoneFunding, i)
+    );
 
     return (
       <Content>


### PR DESCRIPTION
Ref: [DGDG-479](https://tracker.digixdev.com/issue/DGDG-479), [DGDG-424](https://tracker.digixdev.com/issue/DGDG-424)

If you add a milestone to a project, the milestone will be shown as `0` while the edit project transaction is still pending confirmation from the blockchain. Although we are using `milestoneFundings` for the values to display (see PR #147), we are still basing the number of milestones to display on `dijixObject.milestones`. This diff fixes that by using `milestoneFundings` as the basis for the correct milestones to show.

### Test Plan
- Set `BLOCK_CONFIRMATIONS` to `2` on `info-server`. Restart your contracts.
- Create a project with one milestone. You can run the `create-special-proposal` script on `dao-server` to create more transactions and confirm yours.
- Edit the project and add another milestone. Before confirming your transaction, verify that viewing the project displays only one milestone and that there is only one version of the project.
- Confirm the transaction and view the project. It should now show two milestones. If you go to the previous version, it should correctly show the first milestone you created.