### PR TITLE
[TRANSLATIONS] Add translations to Profile page

### DIFF
--- a/src/components/common/blocks/overlay/profile-email/index.js
+++ b/src/components/common/blocks/overlay/profile-email/index.js
@@ -24,12 +24,7 @@ class EmailOverlay extends React.Component {
 
     // eslint-disable-next-line
     this.EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-    this.ERROR_MESSAGES = {
-      invalid: `Please enter a valid email address.`,
-      unchanged: `Please enter an email address that is different from your current email.`,
-      connectionError: `Unable to update email. Please try again.`,
-    };
+    this.ERROR_MESSAGES = { ...props.translations.Errors };
   }
 
   onEmailUpdate = response => {
@@ -41,7 +36,7 @@ class EmailOverlay extends React.Component {
 
     this.props.showRightPanel({ show: false });
     this.props.showHideAlert({
-      message: 'Email updated',
+      message: this.props.translations.txnSuccess,
     });
   };
 
@@ -75,14 +70,15 @@ class EmailOverlay extends React.Component {
   };
 
   render() {
+    const t = this.props.translations;
     const { email, error } = this.state;
     const invalidInput = !!error && error !== this.ERROR_MESSAGES.connectionError;
     const disableButton = !email || email === '' || invalidInput;
 
     return (
       <IntroContainer>
-        <Header uppercase>Set Email</Header>
-        <Label>Please enter the email you want to link to your address</Label>
+        <Header uppercase>{t.title}</Header>
+        <Label>{t.instructions}</Label>
         <Input type="text" data-digix="SetEmail-Textbox" onChange={this.handleInput} />
         {this.renderHint()}
         <CallToAction>
@@ -91,6 +87,7 @@ class EmailOverlay extends React.Component {
             email={email}
             onEmailUpdate={this.onEmailUpdate}
             onEmailUpdateError={this.onEmailUpdateError}
+            translations={t}
           />
         </CallToAction>
       </IntroContainer>
@@ -98,12 +95,13 @@ class EmailOverlay extends React.Component {
   }
 }
 
-const { func, string } = PropTypes;
+const { func, object, string } = PropTypes;
 
 EmailOverlay.propTypes = {
   currentEmail: string,
   showHideAlert: func.isRequired,
   showRightPanel: func.isRequired,
+  translations: object.isRequired,
 };
 
 EmailOverlay.defaultProps = {

--- a/src/components/common/blocks/overlay/profile-email/update-email.js
+++ b/src/components/common/blocks/overlay/profile-email/update-email.js
@@ -6,7 +6,7 @@ import { withChangeEmail } from '@digix/gov-ui/api/graphql-queries/users';
 
 class UpdateEmailButton extends React.Component {
   render() {
-    const { changeEmail, disable, email } = this.props;
+    const { changeEmail, disable, email, translations } = this.props;
     const disableButton = disable || !email;
 
     return (
@@ -18,18 +18,19 @@ class UpdateEmailButton extends React.Component {
         data-digix="EmailOverlay-SetEmail"
         onClick={() => changeEmail(email)}
       >
-        Change Email
+        {translations.submit}
       </Button>
     );
   }
 }
 
-const { bool, func, string } = PropTypes;
+const { bool, func, object, string } = PropTypes;
 
 UpdateEmailButton.propTypes = {
   changeEmail: func,
   disable: bool.isRequired,
   email: string,
+  translations: object.isRequired,
 };
 
 UpdateEmailButton.defaultProps = {

--- a/src/components/common/blocks/overlay/profile-username/index.js
+++ b/src/components/common/blocks/overlay/profile-username/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -7,13 +8,13 @@ import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import {
   CallToAction,
+  NotificationMessage,
   UsernameInput,
 } from '@digix/gov-ui/components/common/blocks/overlay/profile-username/style';
 import {
   IntroContainer,
   OverlayHeader as Header,
   Notifications,
-  Message,
   Label,
   Hint,
 } from '@digix/gov-ui/components/common/common-styles';
@@ -29,10 +30,7 @@ class UsernameOverlay extends React.Component {
     };
 
     this.USERNAME_REGEX = /^(?!user)[a-z0-9_]{2,20}$/;
-    this.ERROR_MESSAGES = {
-      invalid: `Username must be between 2-20 characters, can only be composed of alphanumeric and underscore characters, and must not begin with the word "user".`,
-      connectionError: `Unable to update username. Please try again.`,
-    };
+    this.ERROR_MESSAGES = { ...props.translations.Errors };
   }
 
   onUsernameUpdate = response => {
@@ -44,7 +42,7 @@ class UsernameOverlay extends React.Component {
 
     this.props.showRightPanel({ show: false });
     this.props.showHideAlert({
-      message: 'Username updated',
+      message: this.props.translations.txnSuccess,
     });
   };
 
@@ -81,13 +79,15 @@ class UsernameOverlay extends React.Component {
   };
 
   renderIntro() {
+    const t = this.props.translations;
+
     return (
       <IntroContainer>
-        <Header uppercase>Assign Username</Header>
+        <Header uppercase>{t.title}</Header>
         <Notifications info>
-          <Message>
-            You can only assign a username to yourself <span>ONCE</span>.
-          </Message>
+          <NotificationMessage>
+            <ReactMarkdown source={t.warning} />
+          </NotificationMessage>
         </Notifications>
         <Button
           secondary
@@ -96,29 +96,31 @@ class UsernameOverlay extends React.Component {
           data-digix="UsernameOverlay-Proceed"
           onClick={() => this.showForm()}
         >
-          Proceed
+          {t.proceed}
         </Button>
       </IntroContainer>
     );
   }
 
   renderForm() {
+    const t = this.props.translations;
     const { username, error } = this.state;
     const invalidInput = !!error && error !== this.ERROR_MESSAGES.connectionError;
     const disableButton = !username || username === '' || invalidInput;
 
     return (
       <IntroContainer>
-        <Header uppercase>Assign Username</Header>
-        <Label>Please enter your desired user name</Label>
+        <Header uppercase>{t.title}</Header>
+        <Label>{t.instructions}</Label>
         <UsernameInput type="text" data-digix="SetUsername-TexBox" onChange={this.handleInput} />
         {this.renderHint()}
         <CallToAction>
           <UpdateUsernameButton
             disable={disableButton}
-            username={username}
             onUsernameUpdate={this.onUsernameUpdate}
             onUsernameUpdateError={this.onUsernameUpdateError}
+            translations={t}
+            username={username}
           />
         </CallToAction>
       </IntroContainer>
@@ -135,10 +137,11 @@ class UsernameOverlay extends React.Component {
   }
 }
 
-const { func } = PropTypes;
+const { func, object } = PropTypes;
 UsernameOverlay.propTypes = {
   showHideAlert: func.isRequired,
   showRightPanel: func.isRequired,
+  translations: object.isRequired,
 };
 
 const mapStateToProps = () => ({});

--- a/src/components/common/blocks/overlay/profile-username/style.js
+++ b/src/components/common/blocks/overlay/profile-username/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Input } from '@digix/gov-ui/components/common/elements/index';
+import { Message } from '@digix/gov-ui/components/common/common-styles';
 
 export const CallToAction = styled.div`
   margin-top: 2rem;
@@ -7,4 +8,10 @@ export const CallToAction = styled.div`
 
 export const UsernameInput = styled(Input)`
   text-transform: lowercase;
+`;
+
+export const NotificationMessage = styled(Message)`
+  p {
+    margin-bottom: 0;
+  }
 `;

--- a/src/components/common/blocks/overlay/profile-username/update-username.js
+++ b/src/components/common/blocks/overlay/profile-username/update-username.js
@@ -6,7 +6,7 @@ import { withChangeUsername } from '@digix/gov-ui/api/graphql-queries/users';
 
 class UpdateUsernameButton extends React.Component {
   render() {
-    const { changeUsername, disable, username } = this.props;
+    const { changeUsername, disable, translations, username } = this.props;
     const disableButton = disable || !username;
 
     return (
@@ -18,17 +18,18 @@ class UpdateUsernameButton extends React.Component {
         data-digix="UsernameOverlay-SetUsername"
         onClick={() => changeUsername(username)}
       >
-        Assign Username
+        {translations.submit}
       </Button>
     );
   }
 }
 
-const { bool, func, string } = PropTypes;
+const { bool, func, object, string } = PropTypes;
 
 UpdateUsernameButton.propTypes = {
   changeUsername: func,
   disable: bool.isRequired,
+  translations: object.isRequired,
   username: string,
 };
 

--- a/src/components/common/blocks/user-address-stats/index.js
+++ b/src/components/common/blocks/user-address-stats/index.js
@@ -52,7 +52,7 @@ class UserAddressStats extends React.Component {
           </Data>
         </Item>
         <Item>
-          <Label>{dashboard.UserStats.repuationPoints}</Label>
+          <Label>{dashboard.UserStats.reputationPoints}</Label>
           <Data data-digix="Dashboard-Stats-ReputationPoints">{reputationPoint || 0}</Data>
         </Item>
         <Item>

--- a/src/pages/user/profile/index.js
+++ b/src/pages/user/profile/index.js
@@ -11,14 +11,15 @@ import { Heading, ProfileWrapper } from '@digix/gov-ui/pages/user/profile/style'
 class Profile extends React.Component {
   render() {
     const { history, Translations } = this.props;
+    const t = Translations.data.profile;
 
     return (
       <ProfileWrapper>
-        <Heading>Profile</Heading>
-        <ProfileUserInfo translations={Translations} />
+        <Heading>{t.title}</Heading>
+        <ProfileUserInfo translations={t.ProfileInfo} />
         <UserAddressStats translations={Translations} />
-        <ProfileActivitySummary translations={Translations} />
-        <ModeratorRequirements translations={Translations} history={history} />
+        <ProfileActivitySummary translations={t.Kyc} tSetEmail={t.ProfileInfo.SetEmail} />
+        <ModeratorRequirements history={history} translations={t.ModeratorRequirements} />
       </ProfileWrapper>
     );
   }

--- a/src/pages/user/profile/sections/activity-summary.js
+++ b/src/pages/user/profile/sections/activity-summary.js
@@ -57,9 +57,11 @@ class ProfileActivitySummary extends React.Component {
   }
 
   showSetEmailOverlay() {
+    const { tSetEmail } = this.props;
     const { email } = this.props.userData;
+
     this.props.showRightPanel({
-      component: <EmailOverlay currentEmail={email} />,
+      component: <EmailOverlay currentEmail={email} translations={tSetEmail} />,
       show: true,
     });
   }
@@ -158,12 +160,13 @@ class ProfileActivitySummary extends React.Component {
   }
 }
 
-const { func, shape, string } = PropTypes;
+const { func, shape, string, object } = PropTypes;
 
 ProfileActivitySummary.propTypes = {
   refetchUser: func.isRequired,
   showRightPanel: func.isRequired,
   subscribeToKyc: func.isRequired,
+  tSetEmail: object.isRequired,
   userData: shape({
     displayName: string,
     email: string,

--- a/src/pages/user/profile/sections/moderator-requirements.js
+++ b/src/pages/user/profile/sections/moderator-requirements.js
@@ -52,6 +52,7 @@ class ModeratorRequirements extends React.Component {
   }
 
   render() {
+    const t = this.props.translations;
     const { isModerator } = this.props.AddressDetails;
     const { reputation, stake } = this.getModeratorRequirements();
 
@@ -64,18 +65,18 @@ class ModeratorRequirements extends React.Component {
 
     return (
       <Moderation data-digix="Profile-ModerationRequirements">
-        <Label>TO GAIN MODERATOR STATUS, YOU WILL NEED ANOTHER</Label>
+        <Label uppercase>{t.hint}</Label>
         <Criteria>
           <ModeratorReqs>
             <Data data-digix="Profile-ModerationRequirements-Reputation">{reputation}</Data>
-            <ReqLabel>Reputation Points</ReqLabel>
+            <ReqLabel>{t.reputationPoints}</ReqLabel>
           </ModeratorReqs>
           <Plus>
             <Icon kind="plus" />
           </Plus>
           <ModeratorReqs>
             <Data data-digix="Profile-ModerationRequirements-Stake">{stake}</Data>
-            <ReqLabel>Stake</ReqLabel>
+            <ReqLabel>{t.stake}</ReqLabel>
           </ModeratorReqs>
         </Criteria>
         <Actions>
@@ -85,7 +86,7 @@ class ModeratorRequirements extends React.Component {
             data-digix="Profile-LockMoreDgd-Cta"
             onClick={() => this.showLockDgdOverlay()}
           >
-            Lock More DGD
+            {t.lockDgd}
           </Button>
         </Actions>
       </Moderation>
@@ -102,6 +103,7 @@ ModeratorRequirements.propTypes = {
   getDaoConfig: func.isRequired,
   showHideLockDgdOverlay: func.isRequired,
   subscribeToAddress: func.isRequired,
+  translations: object.isRequired,
 };
 
 ModeratorRequirements.defaultProps = {

--- a/src/pages/user/profile/sections/user-info.js
+++ b/src/pages/user/profile/sections/user-info.js
@@ -23,30 +23,38 @@ class ProfileUserInfo extends React.Component {
   }
 
   showSetUsernameOverlay() {
+    const translations = this.props.translations.SetUsername;
+
     this.props.showRightPanel({
-      component: <UsernameOverlay />,
+      component: <UsernameOverlay translations={translations} />,
       show: true,
     });
   }
 
   showSetEmailOverlay() {
     const { email } = this.props.userData;
+    const translations = this.props.translations.SetEmail;
+
     this.props.showRightPanel({
-      component: <EmailOverlay currentEmail={email} />,
+      component: <EmailOverlay currentEmail={email} translations={translations} />,
       show: true,
     });
   }
 
   render() {
     const { displayName, email, username } = this.props.userData;
-    const { AddressDetails } = this.props;
+    const { AddressDetails, translations } = this.props;
     const { address } = AddressDetails;
     const status = getUserStatus(AddressDetails);
+
+    const tLabels = translations.Labels;
+    const tSetUsername = translations.SetUsername;
+    const tSetEmail = translations.SetEmail;
 
     return (
       <UserInfo>
         <UserItem>
-          <UserLabel>User:</UserLabel>
+          <UserLabel>{tLabels.username}</UserLabel>
           <UserData data-digix="Profile-UserName">{displayName}</UserData>
           {!username && (
             <SetUserInfoBtn
@@ -55,16 +63,16 @@ class ProfileUserInfo extends React.Component {
               onClick={() => this.showSetUsernameOverlay()}
             >
               <Icon kind="plus" />
-              Set Username
+              {tSetUsername.overlayButton}
             </SetUserInfoBtn>
           )}
         </UserItem>
         <UserItem>
-          <UserLabel>Status:</UserLabel>
+          <UserLabel>{tLabels.status}</UserLabel>
           <UserData data-digix="Profile-Status">{status}</UserData>
         </UserItem>
         <UserItem>
-          <UserLabel>Email:</UserLabel>
+          <UserLabel>{tLabels.email}</UserLabel>
           {email && <UserData data-digix="Profile-Email">{email}</UserData>}
           <SetUserInfoBtn
             xsmall
@@ -72,11 +80,11 @@ class ProfileUserInfo extends React.Component {
             onClick={() => this.showSetEmailOverlay()}
           >
             <Icon kind="plus" />
-            Set Email
+            {tSetEmail.overlayButton}
           </SetUserInfoBtn>
         </UserItem>
         <UserItem>
-          <UserLabel>Address:</UserLabel>
+          <UserLabel>{tLabels.address}</UserLabel>
           <UserData data-digix="Profile-Address">{address}</UserData>
         </UserItem>
       </UserInfo>
@@ -90,6 +98,7 @@ ProfileUserInfo.propTypes = {
   AddressDetails: object.isRequired,
   refetchUser: func.isRequired,
   showRightPanel: func.isRequired,
+  translations: object.isRequired,
   userData: shape({
     displayName: string,
     email: string,

--- a/src/pages/user/profile/style.js
+++ b/src/pages/user/profile/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { H1, Card, CardItem } from '@digix/gov-ui/components/common/common-styles';
 import { media } from '@digix/gov-ui/components/common/breakpoints';
@@ -76,6 +76,12 @@ export const Item = styled.div`
 export const Label = styled.div`
   text-align: left;
   font-family: 'Futura PT Heavy', sans-serif;
+
+  ${props =>
+    props.uppercase &&
+    css`
+      text-transform: uppercase;
+    `};
 
   ${media.mobile`
     text-align: center;


### PR DESCRIPTION
Ref: [DGDG-482](https://tracker.digixdev.com/issue/DGDG-482)

As titled. This adds translated text for all functions in the Profile page, except for KYC.

### Test Plan

Verify, visually, that the text is still the same throughout the page and the formatting/UI doesn't break. Go through the following regression tests:
- Visual inspection on the whole Profile page, except KYC
- Set Username
- Set Email
- Redeem Badge (if not yet moderator)
- Lock More DGD (if not yet moderator)

Test for errors and incorrect input as well.