### PR TITLE
Add optional data-digix attribute to injected translations

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -99,13 +99,27 @@ export const getUnmetProposalRequirements = (apolloClient, DaoDetails) => {
   });
 };
 
-export const injectTranslation = (translation, toInject) => {
+export const injectTranslation = (translation, toInject, setDataDigix, dataDigixPrefix) => {
+  if (!translation || !toInject) {
+    return null;
+  }
+
   const keys = Object.keys(toInject);
   let injectedTranslation = translation;
 
-  keys.forEach(key => {
-    injectedTranslation = injectedTranslation.replace(`{{${key}}}`, toInject[key]);
-  });
+  if (setDataDigix) {
+    const prefix = dataDigixPrefix || 'Digix';
+    keys.forEach(key => {
+      injectedTranslation = injectedTranslation.replace(
+        `{{${key}}}`,
+        `<span data-digix="${prefix}-${key}">${toInject[key]}</span>`
+      );
+    });
+  } else {
+    keys.forEach(key => {
+      injectedTranslation = injectedTranslation.replace(`{{${key}}}`, toInject[key]);
+    });
+  }
 
   return injectedTranslation;
 };


### PR DESCRIPTION
Ref: [DGDG-482](https://tracker.digixdev.com/issue/DGDG-482)

### Dev Notes
This adds the `setDataDigix` flag, which adds `{dataDigixPrefix}-{key}` as the `data-digix` attribute for injected values. The default prefix is `Digix`.

If `setDataDigix` is not `true`, then it will just return a string with the injected values.

### Sample usage:

```js
render() {
  const translation = "The sky is {{color}}."
  const t = injectTranslation(translation, { color: 'blue' }, true, 'SamplePrefix');

  // <div>The sky is <span data-digix="SamplePrefix-color">blue</span></div>
  return <div dangerouslySetInnerHTML={t} />;
}
```