### PR TITLE
Translate modals for loading different wallet types

### DIFF
--- a/src/components/common/blocks/wallet/json/index.js
+++ b/src/components/common/blocks/wallet/json/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import DefaultAddressSelector from 'spectrum-lightsuite/src/libs/material-ui/components/common/default_address_selector';
 import ImportKeystoreModal from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/import_keystore_modal';
 
@@ -29,6 +31,8 @@ class V3Keystore extends React.Component {
           skipConfirmation
           onSuccess={() => this.props.onSuccess()}
           updateDefaultAddress
+          translations={this.props.translations}
+          commonTranslations={this.props.commonTranslations}
           trigger={
             <Button kind="round" secondary large showIcon fluid>
               <Icon kind="json" />
@@ -41,14 +45,22 @@ class V3Keystore extends React.Component {
   }
 }
 
-const { func } = PropTypes;
+const { func, object } = PropTypes;
 
 V3Keystore.propTypes = {
+  commonTranslations: object.isRequired,
   createKeystore: func,
   onSuccess: func.isRequired,
+  translations: object.isRequired,
 };
 
 V3Keystore.defaultProps = {
   createKeystore: undefined,
 };
-export default V3Keystore;
+
+const mapStateToProps = state => ({
+  translations: state.daoServer.Translations.data.loadWallet.Json,
+  commonTranslations: state.daoServer.Translations.data.loadWallet.common,
+});
+
+export default connect(mapStateToProps)(V3Keystore);

--- a/src/components/common/blocks/wallet/ledger/index.js
+++ b/src/components/common/blocks/wallet/ledger/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import DefaultAddressSelector from 'spectrum-lightsuite/src/libs/material-ui/components/common/default_address_selector';
 import KeystoreModal from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/keystore_modal';
 import KeystoreCreationForm from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/keystore_creation_form';
@@ -34,6 +36,8 @@ class Ledger extends React.Component {
           header="Load Ledger Wallet"
           hideSelector
           allowedKeystoreTypes={['ledger']}
+          translations={this.props.translations}
+          commonTranslations={this.props.commonTranslations}
           trigger={
             <Button kind="round" secondary large showIcon fluid>
               <Icon kind="ledger" />
@@ -46,14 +50,22 @@ class Ledger extends React.Component {
   }
 }
 
-const { func } = PropTypes;
+const { func, object } = PropTypes;
 
 Ledger.propTypes = {
+  commonTranslations: object.isRequired,
   createKeystore: func,
   onSuccess: func.isRequired,
+  translations: object.isRequired,
 };
 
 Ledger.defaultProps = {
   createKeystore: undefined,
 };
-export default Ledger;
+
+const mapStateToProps = state => ({
+  translations: state.daoServer.Translations.data.loadWallet.Ledger,
+  commonTranslations: state.daoServer.Translations.data.loadWallet.common,
+});
+
+export default connect(mapStateToProps)(Ledger);

--- a/src/components/common/blocks/wallet/metamask/index.js
+++ b/src/components/common/blocks/wallet/metamask/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import DefaultAddressSelector from 'spectrum-lightsuite/src/libs/material-ui/components/common/default_address_selector';
 import KeystoreModal from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/keystore_modal';
 import KeystoreCreationForm from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/keystore_creation_form';
@@ -34,6 +36,8 @@ class Metamask extends React.Component {
           header="Load MetaMask Wallet"
           hideSelector
           allowedKeystoreTypes={['metamask']}
+          translations={this.props.translations}
+          commonTranslations={this.props.commonTranslations}
           trigger={
             <Button kind="round" secondary fluid large showIcon>
               <Icon kind="metamask" />
@@ -46,14 +50,22 @@ class Metamask extends React.Component {
   }
 }
 
-const { func } = PropTypes;
+const { func, object } = PropTypes;
 
 Metamask.propTypes = {
+  commonTranslations: object.isRequired,
   createKeystore: func,
   onSuccess: func.isRequired,
+  translations: object.isRequired,
 };
 
 Metamask.defaultProps = {
   createKeystore: undefined,
 };
-export default Metamask;
+
+const mapStateToProps = state => ({
+  translations: state.daoServer.Translations.data.loadWallet.Metamask,
+  commonTranslations: state.daoServer.Translations.data.loadWallet.common,
+});
+
+export default connect(mapStateToProps)(Metamask);

--- a/src/components/common/blocks/wallet/trezor/index.js
+++ b/src/components/common/blocks/wallet/trezor/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import DefaultAddressSelector from 'spectrum-lightsuite/src/libs/material-ui/components/common/default_address_selector';
 import KeystoreModal from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/keystore_modal';
 import KeystoreCreationForm from 'spectrum-lightsuite/src/libs/material-ui/components/keystores/keystore_creation_form';
@@ -34,6 +36,8 @@ class Trezor extends React.Component {
           header="Load Trezor Wallet"
           hideSelector
           allowedKeystoreTypes={['trezor']}
+          translations={this.props.translations}
+          commonTranslations={this.props.commonTranslations}
           trigger={
             <Button kind="round" secondary fluid showIcon large>
               <Icon kind="trezor" />
@@ -46,14 +50,22 @@ class Trezor extends React.Component {
   }
 }
 
-const { func } = PropTypes;
+const { func, object } = PropTypes;
 
 Trezor.propTypes = {
+  commonTranslations: object.isRequired,
   createKeystore: func,
   onSuccess: func.isRequired,
+  translations: object.isRequired,
 };
 
 Trezor.defaultProps = {
   createKeystore: undefined,
 };
-export default Trezor;
+
+const mapStateToProps = state => ({
+  translations: state.daoServer.Translations.data.loadWallet.Trezor,
+  commonTranslations: state.daoServer.Translations.data.loadWallet.common,
+});
+
+export default connect(mapStateToProps)(Trezor);

--- a/src/translations/missing.json
+++ b/src/translations/missing.json
@@ -128,5 +128,38 @@
       "title": "DGD Approval",
       "message": "Your DGD Approval Transaction is pending confirmation. See More"
     }
+  },
+  "loadWallet": {
+    "common": {
+      "createErrors": {
+        "requiredwalletType": "Please select a wallet type.",
+        "requiredName": "You must provide a name.",
+        "invalidNames": "You must provide a name for all addresses.",
+        "invalidPassword": "Passwords do not match."
+      }
+    },
+    "Json": {
+      "importInstructions": "Click or drag and drop here to load your file.",
+      "importError": "Keystore type not supported."
+    },
+    "Metamask": {
+      "ConnectionError": {
+        "noMetamask": "Cannot connect to MetaMask wallet. Make sure to login to your MetaMask wallet."
+      }
+    },
+    "Ledger": {
+      "chooseAddress": {
+        "selectPath": {
+          "loading": "Getting address info..."
+        }
+      }
+    },
+    "Trezor": {
+      "chooseAddress": {
+        "selectPath": {
+          "loading": "Getting address info..."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Ref: [DGDG-482](https://tracker.digixdev.com/issue/DGDG-482)

This passes the translations to the `governance-ui` repo so it can show translated text for the modals when loading a wallet.