### PR TITLE
Pass message signer translations to governance-ui

### DIFF
--- a/src/components/common/blocks/address-watcher/index.js
+++ b/src/components/common/blocks/address-watcher/index.js
@@ -68,12 +68,14 @@ class AddressWatcher extends React.PureComponent {
     return getChallengeVanilla(address).then(({ json: { result } }) => {
       const message = result.challenge;
       const network = this.props.defaultNetworks[0];
-      const caption =
-        'This signing is to prove to our server that you are in control of the Ethereum account that was loaded. By signing this message, you are proving that you control the selected account for use on DigixDAO.';
+
+      const translations = this.props.translations.loadWallet;
+      const caption = translations.Json.proofOfControl.description;
+
       const signMessage = new Promise(resolve =>
         resolve(
           this.props.showMsgSigningModal({
-            txData: { message, caption },
+            txData: { message, caption, translations },
             network,
           })
         )
@@ -138,10 +140,14 @@ AddressWatcher.propTypes = {
   showMsgSigningModal: func.isRequired,
   proveChallenge: func.isRequired,
   setUserAddress: func.isRequired,
+  translations: object,
 };
 
 AddressWatcher.defaultProps = {
-  defaultAddress: undefined,
+  defaultAddress: {
+    address: undefined,
+  },
+  translations: undefined,
 };
 
 const mapStateToProps = state => ({
@@ -151,6 +157,7 @@ const mapStateToProps = state => ({
   challenge: state.daoServer.Challenge,
   challengeProof: state.daoServer.ChallengeProof,
   signChallenge: state.govUI.SignChallenge,
+  translations: state.daoServer.Translations.data,
 });
 
 export default withApollo(

--- a/src/translations/loadWallet.json
+++ b/src/translations/loadWallet.json
@@ -52,7 +52,8 @@
       },
       "proofOfControl": {
         "description": "Ready to Sign Message",
-        "firmware": "Firmware {{version}} - replay protection enabled!"
+        "firmware": "Firmware {{version}} - replay protection enabled!",
+        "firmwareDisabled": "Firmware {{version}} - replay protection disabled!"
       }
     }
   },
@@ -86,7 +87,9 @@
     "signInstructions": "Enter your password to sign message",
     "error": "Key derivation failed - possibly wrong passphrase",
     "proofOfControl": {
-      "description": "This signing is to prove to our server that you are in control of the Ethereum account that was loaded. By signing this message, you are proving that you control the selected account for use on DigixDAO."
+      "description": "This signing is to prove to our server that you are in control of the Ethereum account that was loaded. By signing this message, you are proving that you control the selected account for use on DigixDAO.",
+      "signing": "Signing message...",
+      "sign": "Sign Message"
     }
   },
   "connectedWallet": {

--- a/src/translations/missing.json
+++ b/src/translations/missing.json
@@ -100,8 +100,8 @@
   },
   "spinner": {
     "pleaseWait": "Please wait.",
-    "hold": "Hold tight while your project is being uploaded to IPFS.",
-
+    "hold": "Hold tight while your project is being uploaded to IPFS."
+  },
   "approveInteraction": {
     "transaction": {
       "title": "Approve Interaction",
@@ -140,7 +140,11 @@
     },
     "Json": {
       "importInstructions": "Click or drag and drop here to load your file.",
-      "importError": "Keystore type not supported."
+      "importError": "Keystore type not supported.",
+      "proofOfControl": {
+        "signing": "Signing message...",
+        "sign": "Sign Message"
+      }
     },
     "Metamask": {
       "ConnectionError": {
@@ -150,7 +154,10 @@
     "Ledger": {
       "chooseAddress": {
         "selectPath": {
-          "loading": "Getting address info..."
+          "loading": "Getting address info...",
+          "proofOfControl": {
+            "firmwareDisabled": "Firmware {{version}} - replay protection disabled!"
+          }
         }
       }
     },
@@ -160,6 +167,11 @@
           "loading": "Getting address info..."
         }
       }
+    }
+  },
+  "signTransaction": {
+    "Ledger": {
+      "firmwareDisabled": "Firmware {{version}} - replay protection disabled!"
     }
   }
 }

--- a/src/translations/signTransaction.json
+++ b/src/translations/signTransaction.json
@@ -16,7 +16,8 @@
   },
   "Ledger": {
     "ready": "Ready to Sign Transaction",
-    "firmware": "Firmware {{version}} - replay protection enabled!"
+    "firmware": "Firmware {{version}} - replay protection enabled!",
+    "firmwareDisabled": "Firmware {{version}} - replay protection disabled!"
   },
   "Trezor": {
     "ready": "Ready to Sign Transaction",


### PR DESCRIPTION
Ref: [DGDG-482](https://tracker.digixdev.com/issue/DGDG-482)

`governance-ui` has the modals for signing the proof of control, so we need to pass the translations there as a prop. This also adds missing translations for signing.