### PR TITLE
Show Continue Participation modal

### DIFF
--- a/src/components/common/blocks/address-watcher/index.js
+++ b/src/components/common/blocks/address-watcher/index.js
@@ -29,6 +29,7 @@ class AddressWatcher extends React.PureComponent {
   state = {
     verifyingUser: false,
   };
+
   componentDidMount = () => {
     const { defaultAddress } = this.props;
     if (defaultAddress && defaultAddress.address) {
@@ -50,7 +51,13 @@ class AddressWatcher extends React.PureComponent {
       getAddressDetailsVanilla(address)
         .then(({ json: { result } }) => result)
         .then(details => {
-          if (!details.isParticipant && !details.isKycOfficer && !details.isForumAdmin) {
+          const hasDgdLocked = Number(details.lockedDgd) > 0;
+          if (
+            !details.isParticipant &&
+            !details.isKycOfficer &&
+            !details.isForumAdmin &&
+            !hasDgdLocked
+          ) {
             this.props.setUserAddress(address);
             this.setState({ verifyingUser: false });
 

--- a/src/components/common/blocks/overlay/unlock-dgd/index.js
+++ b/src/components/common/blocks/overlay/unlock-dgd/index.js
@@ -112,6 +112,10 @@ class UnlockDgdOverlay extends React.Component {
         txHash,
       });
 
+      if (this.props.onSuccess) {
+        this.props.onSuccess();
+      }
+
       this.props.showRightPanel({ show: false });
     };
 
@@ -225,6 +229,7 @@ UnlockDgdOverlay.propTypes = {
   DaoConfig: object.isRequired,
   getDaoConfig: func.isRequired,
   maxAmount: number.isRequired,
+  onSuccess: func,
   showRightPanel: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlert: func.isRequired,
@@ -234,12 +239,15 @@ UnlockDgdOverlay.propTypes = {
   web3Redux: object.isRequired,
 };
 
-UnlockDgdOverlay.defaultProps = {};
+UnlockDgdOverlay.defaultProps = {
+  onSuccess: undefined,
+};
 
 const mapStateToProps = state => ({
   addresses: getAddresses(state),
   ChallengeProof: state.daoServer.ChallengeProof.data,
   DaoConfig: state.infoServer.DaoConfig.data,
+  txnTranslations: state.daoServer.Translations.data.signTransaction,
 });
 
 export default web3Connect(

--- a/src/constants.js
+++ b/src/constants.js
@@ -114,3 +114,8 @@ export const KycErrors = {
     details: null,
   },
 };
+
+export const CONFIRM_PARTICIPATION_CACHE = {
+  key: 'DAO_PARTICIPATION',
+  value: 't7L6CuJ1pDqY0Cu5',
+};

--- a/src/pages/continue-participation.js
+++ b/src/pages/continue-participation.js
@@ -1,52 +1,225 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
+import DaoStakeLocking from '@digix/dao-contracts/build/contracts/DaoStakeLocking.json';
+import getContract from '@digix/gov-ui/utils/contracts';
+import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
+import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
+import UnlockDgdOverlay from '@digix/gov-ui/components/common/blocks/overlay/unlock-dgd/index';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { Content, Title, Intro } from '@digix/gov-ui/pages/style';
+import {
+  CONFIRM_PARTICIPATION_CACHE,
+  DEFAULT_GAS,
+  DEFAULT_GAS_PRICE,
+} from '@digix/gov-ui/constants';
+import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
+import { getAddresses } from 'spectrum-lightsuite/src/selectors';
+import { getHash } from '@digix/gov-ui/utils/helpers';
+import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
+import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
+import {
+  showHideAlert,
+  showHideLockDgdOverlay,
+  showRightPanel,
+} from '@digix/gov-ui/reducers/gov-ui/actions';
+import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
+import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
+
+registerUIs({ txVisualization: { component: TxVisualization } });
+const network = SpectrumConfig.defaultNetworks[0];
 
 class ConfirmParticipation extends React.Component {
+  setError = error => {
+    this.props.showHideAlert({
+      message: JSON.stringify(error && error.message) || error,
+    });
+  };
+
+  setHash = () => {
+    const { address } = this.props.AddressDetails;
+    const { currentQuarter } = this.props.DaoInfo;
+    const { key, value } = CONFIRM_PARTICIPATION_CACHE;
+
+    const hash = getHash(`${value}_${currentQuarter}_${address}`);
+    localStorage.setItem(key, hash);
+  };
+
+  continueParticipation = () => {
+    this.props.closeModal();
+
+    const t = this.props.tSnackbar;
+    const { addresses, ChallengeProof, web3Redux } = this.props;
+    const { abi, address } = getContract(DaoStakeLocking, network);
+
+    const sourceAddress = addresses.find(({ isDefault }) => isDefault);
+    const contract = web3Redux
+      .web3(network)
+      .eth.contract(abi)
+      .at(address);
+
+    const ui = {
+      caption: t.title,
+      header: t.txUiHeader,
+      type: 'txVisualization',
+    };
+
+    const web3Params = {
+      gasPrice: DEFAULT_GAS_PRICE,
+      gas: DEFAULT_GAS,
+      ui,
+    };
+
+    const onTransactionAttempt = txHash => {
+      if (ChallengeProof) {
+        this.props.sendTransactionToDaoServer({
+          txHash,
+          title: t.title,
+          token: ChallengeProof['access-token'],
+          client: ChallengeProof.client,
+          uid: ChallengeProof.uid,
+        });
+      }
+    };
+
+    const onTransactionSuccess = txHash => {
+      this.props.showHideAlert({
+        message: t.message,
+        txHash,
+      });
+
+      this.setHash();
+      this.props.showRightPanel({ show: false });
+    };
+
+    const payload = {
+      address: sourceAddress,
+      contract,
+      func: contract.confirmContinuedParticipation,
+      network,
+      onFailure: this.setError,
+      onFinally: txHash => onTransactionAttempt(txHash),
+      onSuccess: txHash => onTransactionSuccess(txHash),
+      params: undefined,
+      showTxSigningModal: this.props.showTxSigningModal,
+      translations: this.props.txnTranslations,
+      ui,
+      web3Params,
+    };
+
+    return executeContractFunction(payload);
+  };
+
+  showLockDgdOverlay() {
+    this.props.closeModal();
+    this.props.showHideLockDgdOverlay(true, this.setHash, 'Continue Participation Modal');
+  }
+
+  showUnlockDgdOverlay() {
+    const { lockedDgd } = this.props.AddressDetails;
+    const { tUnlock } = this.props;
+
+    this.props.closeModal();
+    this.props.showRightPanel({
+      component: (
+        <UnlockDgdOverlay
+          maxAmount={Number(lockedDgd)}
+          onSuccess={this.setHash}
+          translations={tUnlock}
+        />
+      ),
+      show: true,
+    });
+  }
+
   render() {
+    const t = this.props.translations;
+    const tOptions = this.props.translations.options;
+
     return (
       <Content>
-        <Title>Confirming Participation For New Quarter</Title>
-        <Intro>
-          In order to continue participating in the new quarter, we need you to sign a transaction
-          confirming the amount of stake you have on the platform. There are 3 options of
-          transaction you can make:
-        </Intro>
+        <Title>{t.title}</Title>
+        <Intro>{t.instructions}</Intro>
 
         <Button
           fluid
           large
           reverse
           data-digix="Confirm-Participation-Lock-More-Dgd"
-          onClick={this.handleTosClose}
           style={{ marginLeft: '0' }}
+          onClick={() => this.showLockDgdOverlay()}
         >
-          I want to lock more DGD
+          {tOptions.lockDgd}
         </Button>
         <Button
           fluid
           large
           reverse
           data-digix="Confirm-Participation-Continue-Lock-Up"
-          onClick={this.handleTosClose}
           style={{ marginLeft: '0' }}
+          onClick={() => this.continueParticipation()}
         >
-          I want to continue with my current lock-up of DGD
+          {tOptions.continueCurrentLockup}
         </Button>
         <Button
           fluid
           large
           reverse
           data-digix="Confirm-Participation-Unlock-Dgd"
-          onClick={this.handleTosClose}
           style={{ marginLeft: '0' }}
+          onClick={() => this.showUnlockDgdOverlay()}
         >
-          I want to unlock some DGD
+          {tOptions.unlockDgd}
         </Button>
       </Content>
     );
   }
 }
 
-export default ConfirmParticipation;
+const { array, func, object } = PropTypes;
+
+ConfirmParticipation.propTypes = {
+  addresses: array.isRequired,
+  AddressDetails: object.isRequired,
+  ChallengeProof: object.isRequired,
+  closeModal: func.isRequired,
+  DaoInfo: object.isRequired,
+  sendTransactionToDaoServer: func.isRequired,
+  showHideAlert: func.isRequired,
+  showHideLockDgdOverlay: func.isRequired,
+  showRightPanel: func.isRequired,
+  showTxSigningModal: func.isRequired,
+  translations: object.isRequired,
+  tSnackbar: object.isRequired,
+  txnTranslations: object.isRequired,
+  tUnlock: object.isRequired,
+  web3Redux: object.isRequired,
+};
+
+const mapStateToProps = state => ({
+  addresses: getAddresses(state),
+  AddressDetails: state.infoServer.AddressDetails.data,
+  ChallengeProof: state.daoServer.ChallengeProof.data,
+  DaoInfo: state.infoServer.DaoDetails.data,
+  translations: state.daoServer.Translations.data.confirmParticipation,
+  tSnackbar: state.daoServer.Translations.data.snackbar.snackbars.continueParticipation,
+  tUnlock: state.daoServer.Translations.data.wallet.LockedDgd.UnlockDgd,
+  txnTranslations: state.daoServer.Translations.data.signTransaction,
+});
+
+export default withFetchAddress(
+  web3Connect(
+    connect(
+      mapStateToProps,
+      {
+        showHideAlert,
+        showHideLockDgdOverlay,
+        showRightPanel,
+        sendTransactionToDaoServer,
+        showTxSigningModal,
+      }
+    )(ConfirmParticipation)
+  )
+);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,17 +2,20 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Modal from 'react-responsive-modal';
-import util from 'ethereumjs-util';
 
 import CountdownPage from '@digix/gov-ui/components/common/blocks/loader/countdown';
 import ProposalCard from '@digix/gov-ui/components/proposal-card';
 import Timeline from '@digix/gov-ui/components/common/blocks/timeline';
 import UserAddressStats from '@digix/gov-ui/components/common/blocks/user-address-stats/index';
 import ProposalFilter from '@digix/gov-ui/components/common/blocks/filter/index';
+import { CONFIRM_PARTICIPATION_CACHE } from '@digix/gov-ui/constants';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
+import { getHash } from '@digix/gov-ui/utils/helpers';
+import { getDefaultAddress } from 'spectrum-lightsuite/src/selectors';
 
 import {
   getAddressDetails,
+  getDaoConfig,
   getDaoDetails,
   getProposals,
 } from '@digix/gov-ui/reducers/info-server/actions';
@@ -52,7 +55,7 @@ class LandingPage extends React.PureComponent {
     } = this.props;
 
     const storedHash = localStorage.getItem('GOVERNANCE_UI');
-    const hash = this.hashTos();
+    const hash = getHash(ToS);
     if (storedHash && storedHash === hash) {
       this.setState({ showTos: false });
     }
@@ -74,6 +77,13 @@ class LandingPage extends React.PureComponent {
   };
 
   componentDidMount = () => {
+    const { getAddressDetailsAction } = this.props;
+    const { address } = this.props.defaultAddress;
+
+    Promise.all([getAddressDetailsAction(address), this.props.getDaoConfig]).then(() => {
+      this.showContinueParticipationModal();
+    });
+
     if (window.Cookiebot) {
       try {
         window.Cookiebot.show();
@@ -129,11 +139,6 @@ class LandingPage extends React.PureComponent {
     });
   };
 
-  hashTos = () => {
-    const hash = util.sha256(ToS.toString()).toString('hex');
-    return hash;
-  };
-
   fixScrollbar = ShowWallet => {
     if (ShowWallet && ShowWallet.show) {
       document.body.classList.add('modal-is-open');
@@ -144,7 +149,7 @@ class LandingPage extends React.PureComponent {
 
   handleTosClose = () => {
     this.setState({ showTos: false }, () => {
-      localStorage.setItem('GOVERNANCE_UI', this.hashTos());
+      localStorage.setItem('GOVERNANCE_UI', getHash(ToS));
     });
   };
 
@@ -161,6 +166,41 @@ class LandingPage extends React.PureComponent {
       this.setState({ disableButton: false });
     }
   };
+
+  showContinueParticipationModal() {
+    const { ChallengeProof } = this.props;
+    const { CONFIG_MINIMUM_LOCKED_DGD } = this.props.DaoConfig;
+    const { currentQuarter, isGlobalRewardsSet } = this.props.DaoDetails.data;
+    const AddressDetails = this.props.AddressDetails.data;
+    const lastParticipatedQuarter = AddressDetails && AddressDetails.lastParticipatedQuarter;
+
+    const hasLoadedWallet = ChallengeProof.data;
+    const isPastParticipant =
+      lastParticipatedQuarter > 0 && lastParticipatedQuarter < currentQuarter;
+
+    const lockedDgd = Number(AddressDetails && AddressDetails.lockedDgd);
+    const minimumDgd = Number(CONFIG_MINIMUM_LOCKED_DGD);
+    const hasEnoughDgd = lockedDgd >= minimumDgd;
+
+    const { key, value } = CONFIRM_PARTICIPATION_CACHE;
+    const storedHash = localStorage.getItem(key);
+
+    // always include the currentQuarter so that we have unique hashes per quarter
+    const expectedHash = getHash(`${value}_${currentQuarter}_${AddressDetails.address}`);
+    const alreadyParticipating = storedHash && storedHash === expectedHash;
+
+    const showModal =
+      hasLoadedWallet &&
+      isGlobalRewardsSet &&
+      isPastParticipant &&
+      hasEnoughDgd &&
+      !alreadyParticipating;
+
+    if (showModal) {
+      localStorage.removeItem(key, expectedHash);
+      this.setState({ showParticipateModal: true });
+    }
+  }
 
   renderLandingPage() {
     const { order, showTos, disableButton, showParticipateModal } = this.state;
@@ -261,8 +301,8 @@ class LandingPage extends React.PureComponent {
             </Button>
           </Content>
         </Modal>
-        <Modal open={showParticipateModal} onClose={this.handleModalClose}>
-          <ConfirmParticipation />
+        <Modal open={showParticipateModal} onClose={() => true} showCloseIcon={false}>
+          <ConfirmParticipation closeModal={this.handleModalClose} />
         </Modal>
       </Fragment>
     );
@@ -281,7 +321,9 @@ class LandingPage extends React.PureComponent {
 const { bool, object, func, string } = PropTypes;
 
 LandingPage.propTypes = {
+  DaoConfig: object.isRequired,
   DaoDetails: object.isRequired,
+  defaultAddress: object,
   AddressDetails: object.isRequired,
   Proposals: object.isRequired,
   ChallengeProof: object,
@@ -291,6 +333,7 @@ LandingPage.propTypes = {
   ShowWallet: object,
   history: object.isRequired,
   getAddressDetailsAction: func.isRequired,
+  getDaoConfig: func.isRequired,
   getDaoDetailsAction: func.isRequired,
   getProposalsAction: func.isRequired,
   getProposalLikesByUserAction: func.isRequired,
@@ -303,18 +346,24 @@ LandingPage.propTypes = {
 
 LandingPage.defaultProps = {
   ChallengeProof: undefined,
+  defaultAddress: {
+    address: undefined,
+  },
   UserLikedProposals: undefined,
   ProposalLikes: undefined,
   ShowWallet: undefined,
   Language: 'en',
 };
 
-export default connect(
-  ({
-    infoServer: { DaoDetails, Proposals, AddressDetails },
+const mapStateToProps = state => {
+  const {
+    infoServer: { DaoDetails, Proposals, AddressDetails, DaoConfig },
     daoServer: { ChallengeProof, UserLikedProposals, ProposalLikes, Translations },
     govUI: { HasCountdown, ShowWallet, Language },
-  }) => ({
+  } = state;
+
+  return {
+    DaoConfig: DaoConfig.data,
     DaoDetails,
     Proposals,
     AddressDetails,
@@ -325,9 +374,15 @@ export default connect(
     HasCountdown,
     ShowWallet,
     Language,
-  }),
+    defaultAddress: getDefaultAddress(state),
+  };
+};
+
+export default connect(
+  mapStateToProps,
   {
     getAddressDetailsAction: getAddressDetails,
+    getDaoConfig,
     getDaoDetailsAction: getDaoDetails,
     getProposalsAction: getProposals,
     getProposalLikesByUserAction: getProposalLikesByUser,

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -40,18 +40,11 @@ class VotingStake extends React.Component {
   }
 
   showUnlockDgdOverlay() {
-    const { txnTranslations } = this.props;
     const { lockedDgd } = this.props.AddressDetails;
     const tUnlock = this.props.translations.UnlockDgd;
 
     this.props.showRightPanel({
-      component: (
-        <UnlockDgdOverlay
-          maxAmount={Number(lockedDgd)}
-          translations={tUnlock}
-          txnTranslations={txnTranslations}
-        />
-      ),
+      component: <UnlockDgdOverlay maxAmount={Number(lockedDgd)} translations={tUnlock} />,
       show: true,
     });
   }
@@ -114,7 +107,6 @@ VotingStake.propTypes = {
   showRightPanel: func.isRequired,
   subscribeToAddress: func.isRequired,
   translations: object.isRequired,
-  txnTranslations: object.isRequired,
 };
 
 VotingStake.defaultProps = {

--- a/src/translations/chinese/confirmParticipation.json
+++ b/src/translations/chinese/confirmParticipation.json
@@ -1,0 +1,9 @@
+{
+  "title": "Confirming Participation For New Quarter",
+  "instructions": "In order to continue participating in the new quarter, we need you to sign a transaction confirming the amount of stake you have on the platform. There are 3 options of transactions you can make:",
+  "options": {
+    "lockDgd": "I want to lock more DGD",
+    "continueCurrentLockup": "I want to continue with my current lock-up of DGD",
+    "unlockDgd": "I want to unlock some DGD"
+  }
+}

--- a/src/translations/chinese/snackbar.json
+++ b/src/translations/chinese/snackbar.json
@@ -70,6 +70,11 @@
       "title": "Add Updates",
       "txUiHeader": "Project",
       "message": "Your Add Updates Transaction is pending confirmation. See More"
+    },
+    "continueParticipation": {
+      "title": "Continue Participation",
+      "txUiHeader": "User",
+      "message": "Your continuation of participation with current lock-up is pending confirmation. See More"
     }
   }
 }

--- a/src/translations/english/confirmParticipation.json
+++ b/src/translations/english/confirmParticipation.json
@@ -1,0 +1,9 @@
+{
+  "title": "Confirming Participation For New Quarter",
+  "instructions": "In order to continue participating in the new quarter, we need you to sign a transaction confirming the amount of stake you have on the platform. There are 3 options of transactions you can make:",
+  "options": {
+    "lockDgd": "I want to lock more DGD",
+    "continueCurrentLockup": "I want to continue with my current lock-up of DGD",
+    "unlockDgd": "I want to unlock some DGD"
+  }
+}

--- a/src/translations/english/snackbar.json
+++ b/src/translations/english/snackbar.json
@@ -70,6 +70,11 @@
       "title": "Add Updates",
       "txUiHeader": "Project",
       "message": "Your Add Updates Transaction is pending confirmation. See More"
+    },
+    "continueParticipation": {
+      "title": "Continue Participation",
+      "txUiHeader": "User",
+      "message": "Your continuation of participation with current lock-up is pending confirmation. See More"
     }
   }
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Markdown from 'react-markdown';
 import multihash from '@digix/multi-hash';
+import util from 'ethereumjs-util';
 
 import { fetchUserQuery } from '@digix/gov-ui/api/graphql-queries/users';
 import { KycStatus, UserStatus } from '@digix/gov-ui/constants';
@@ -136,3 +137,5 @@ export const injectTranslation = (translation, toInject, setDataDigix, dataDigix
 
   return <Markdown source={injected} escapeHtml={false} />;
 };
+
+export const getHash = toHash => util.sha256(toHash.toString()).toString('hex');


### PR DESCRIPTION
Ref: [DGDG-249](https://tracker.digixdev.com/issue/DGDG-249)

### Dev Notes

This modal is shown when the following conditions have been met:
- User has loaded their wallet
- User was a past participant with enough DGDs locked in to continue participating in the new quarter
- Current quarter's rewards have been set (`DaoInfo.isGlobalRewardsSet`)
- User has not taken action from the modal before

We check if the user has taken action on the modal by caching the following key in localStorage: `[CONFIRM_PARTICIPATION_CACHE.value]_[currentQuarter]_[address]`. Including the `currentQuarter` will make sure the key is unique for each quarter (ensuring that the modal will always pop-up in the locking phase), while the `address` differentiates the users in case different wallets are used in the same browser.

### Test Plan
- Ensure that the account you're using satisfies the conditions above.
- Teleport to the next quarter then load your wallet.
- The modal should pop-up and ask you if you want to lock DGD, continue with your current stake, or unlock DGD. All three options should function as intended.
- If the user has completed one of the options successfully, they should not see the modal anymore. Switching tabs or reloading your wallet will not make the modal appear.
- The user should not be able to exit the modal without choosing one of the three options.
- Moving to the next quarter (teleporting to the next locking phase) will invalidate the cache and make the modal pop-up for all users again.