### PR TITLE
Update default gas price to 10

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,7 +25,7 @@ export const ETHERSCAN_URL =
   (process.env.ENVIRONMENT === 'kovan' && 'https://kovan.etherscan.io/tx/') ||
   'https://kovan.etherscan.io/tx/';
 
-export const DEFAULT_GAS_PRICE = 30 * 1e9;
+export const DEFAULT_GAS_PRICE = 10 * 1e9;
 export const ONE_BILLION = 1000000000;
 
 export const CONVERSIONS = {


### PR DESCRIPTION
Ref: [DGDG-512](https://tracker.digixdev.com/issue/DGDG-512)

### Test Plan
- Do any transaction (e.g. Lock DGD) and check the **Advanced** tab.
- The default gas price should be set to `10`.