### PR TITLE
Make sure View Project button is always enabled for participants

### DIFF
--- a/src/components/proposal-card/milestones.js
+++ b/src/components/proposal-card/milestones.js
@@ -40,24 +40,6 @@ const determineDeadline = proposal => {
   return deadline;
 };
 
-const disableParticipateWhen = (proposal, user) => {
-  switch (proposal.stage.toLowerCase()) {
-    case 'idea':
-      return true;
-    case 'draft':
-      return !user.data.isModerator;
-    case 'proposal':
-      return !user.data.isParticipant;
-    case 'ongoing':
-      return true;
-    case 'review':
-      return !user.data.isParticipant;
-    case 'archived':
-      return true;
-    default:
-      return true;
-  }
-};
 export default class ProposalCardMilestone extends React.Component {
   redirectToProposalPage = () => {
     const { details, history } = this.props;
@@ -68,7 +50,6 @@ export default class ProposalCardMilestone extends React.Component {
     const { details, userDetails, translations } = this.props;
     const { currentMilestone } = details;
     const mileStones = currentMilestone ? Object.keys(currentMilestone) : [];
-    const disabledParticipate = disableParticipateWhen(details, userDetails);
     const {
       data: {
         dashboard: { ProposalCard: cardTranslation },
@@ -87,7 +68,11 @@ export default class ProposalCardMilestone extends React.Component {
           <Data>{determineDeadline(details) || 'N/A'} </Data>
         </Info>
         <Info>
-          <Button primary disabled={disabledParticipate} onClick={this.redirectToProposalPage}>
+          <Button
+            primary
+            disabled={!userDetails.data.address}
+            onClick={this.redirectToProposalPage}
+          >
             {buttons.participate}
           </Button>
         </Info>


### PR DESCRIPTION
Ref: [DGDG-507](https://tracker.digixdev.com/issue/DGDG-507)

The button used to be a `Participate` button that is only enabled if the user is allowed to participate in the project, depending on their role and on which stage the project is. This diff changes that so that it is only disabled if the user is a non-participant.

### Test Plan
- The button should be disabled if you haven't loaded a wallet yet.
- The button will be enabled once you have loaded a wallet.