### PR TITLE
Fix broken KYC overlay

### DIFF
--- a/src/pages/user/profile/sections/activity-summary.js
+++ b/src/pages/user/profile/sections/activity-summary.js
@@ -31,10 +31,9 @@ class ProfileActivitySummary extends React.Component {
   }
 
   getKycStatus() {
-    // TODO: translate for other languages
     const { kyc } = this.props.userData;
     if (kyc && kyc.status) {
-      return kyc.status.charAt(0) + kyc.status.slice(1).toLowerCase();
+      return kyc.status;
     }
 
     return this.DEFAULT_KYC_STATUS;
@@ -67,7 +66,7 @@ class ProfileActivitySummary extends React.Component {
     const { refetchUser, translations } = this.props;
 
     this.props.showRightPanel({
-      component: <KycOverlay refetchUser={refetchUser} translations={translations} />,
+      component: <KycOverlay refetchUser={refetchUser} translations={translations.kyc} />,
       large: true,
       show: true,
     });


### PR DESCRIPTION
The overlay broke because of a change in the translations path being passed to the component. This diff fixes that, and also removes the formatting for the KYC status being displayed (which should already be handled by the translations).