### PR TITLE
Add text formatting to forms

### DIFF
--- a/src/components/common/elements/accordion/accordion-selection.js
+++ b/src/components/common/elements/accordion/accordion-selection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Markdown from 'react-markdown';
 import PropTypes from 'prop-types';
 import Icons from '@digix/gov-ui/components/common/elements/icons/Icons';
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
@@ -53,7 +54,11 @@ export default class AccordionSelection extends React.Component {
             </ChevronContainer>
           </Funding>
         </Header>
-        {isOpen && <Content>{children}</Content>}
+        {isOpen && (
+          <Content>
+            <Markdown source={children} escapeHtml={false} />
+          </Content>
+        )}
       </AccordionItem>
     );
   }

--- a/src/pages/proposals/comment/comment.js
+++ b/src/pages/proposals/comment/comment.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Markdown from 'react-markdown';
 import { connect } from 'react-redux';
 
 import CommentAuthor from '@digix/gov-ui/pages/proposals/comment/author';
@@ -185,7 +186,9 @@ class Comment extends React.Component {
           translations={translations}
         />
         <CommentPost isHidden={isHidden} deleted={isDeleted}>
-          <Content>{commentMessage}</Content>
+          <Content>
+            <Markdown source={commentMessage} escapeHtml={false} />
+          </Content>
           {showActionBar && (
             <ActionBar>
               {this.renderActionBar()}

--- a/src/pages/proposals/comment/editor.js
+++ b/src/pages/proposals/comment/editor.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import ReactQuill from 'react-quill';
 import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
 import { connect } from 'react-redux';
 
 import {
@@ -9,21 +11,32 @@ import {
   CommentEditorContainer,
   CommentTextArea,
   EditorContainer,
+  ErrorMessage,
   PostCommentButton,
 } from '@digix/gov-ui/pages/proposals/comment/style';
 import { renderDisplayName } from '@digix/gov-ui/api/graphql-queries/users';
+import { hasInvalidLink } from '@digix/gov-ui/utils/helpers';
 
 class CommentTextEditor extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       content: '',
+      canPost: false,
     };
+
+    this.EMPTY_HTML = /^((<p>)((<br>)*|(\s*)|)*(<\/p>))*$/;
   }
 
-  onChange = e => {
+  onChange = value => {
+    const { canComment } = this.props;
+    const hasContent = !this.EMPTY_HTML.test(value);
+    const invalidLink = hasInvalidLink(value);
+    const canPost = canComment && hasContent && !invalidLink;
+
     this.setState({
-      content: e.target.value,
+      content: value,
+      canPost,
     });
   };
 
@@ -46,17 +59,18 @@ class CommentTextEditor extends React.Component {
   };
 
   render() {
-    const { content } = this.state;
+    const { content, canPost } = this.state;
     const {
       canComment,
       translations: {
         data: {
           project,
-          common: { buttons },
+          common: { buttons, errors },
         },
       },
     } = this.props;
-    const isContentEmpty = content === '';
+
+    const invalidLink = hasInvalidLink(content);
 
     // TODO: Add Translation
     return (
@@ -66,31 +80,44 @@ class CommentTextEditor extends React.Component {
             <span>{project.commentAs}&nbsp;</span>
             {renderDisplayName('CommentEditor-DisplayName')}
           </Author>
-          <CommentEditorContainer>
+          <CommentEditorContainer error={invalidLink}>
             {!canComment && (
-              <BannedCommentEditor>
-                <p>You have been banned by the administrators from commenting.</p>
-                <p>
-                  Please contact Digix if you want to request a restoration of your account rights.
-                </p>
-              </BannedCommentEditor>
+              <div>
+                <BannedCommentEditor>
+                  <p>You have been banned by the administrators from commenting.</p>
+                  <p>
+                    Please contact Digix if you want to request a restoration of your account
+                    rights.
+                  </p>
+                </BannedCommentEditor>
+                <CommentTextArea disabled={!canComment} data-digix="Thread-Field" />
+              </div>
             )}
-            <CommentTextArea
-              disabled={!canComment}
-              onChange={this.onChange}
-              placeholder={project.commentPlaceHolder}
-              value={content}
-              data-digix="Thread-Field"
-            />
+            {canComment && (
+              <ReactQuill
+                disabled={!canComment}
+                onChange={this.onChange}
+                placeholder={project.commentPlaceHolder}
+                value={content}
+                data-digix="Thread-Field"
+              />
+            )}
+            {invalidLink && (
+              <ErrorMessage>
+                <Markdown source={errors.invalidLink} escapeHtml={false} />
+              </ErrorMessage>
+            )}
           </CommentEditorContainer>
-          <PostCommentButton
-            primary
-            disabled={isContentEmpty || !canComment}
-            onClick={() => this.createComment()}
-            data-digix="Thread-Button"
-          >
-            {buttons.postComment}
-          </PostCommentButton>
+          {canComment && (
+            <PostCommentButton
+              primary
+              disabled={!canPost}
+              onClick={() => this.createComment()}
+              data-digix="Thread-Button"
+            >
+              {buttons.postComment}
+            </PostCommentButton>
+          )}
         </CommentEditor>
       </EditorContainer>
     );

--- a/src/pages/proposals/comment/style.js
+++ b/src/pages/proposals/comment/style.js
@@ -34,7 +34,26 @@ export const EditorContainer = styled.div`
 `;
 
 export const CommentEditorContainer = styled.div`
+  margin-top: 0.5em;
   position: relative;
+
+  & .ql-toolbar.ql-snow {
+    border-top-left-radius: ${props => props.theme.borderRadius};
+    border-top-right-radius: ${props => props.theme.borderRadius};
+  }
+
+  & .ql-container.ql-snow {
+    border-bottom-left-radius: ${props => props.theme.borderRadius};
+    border-bottom-right-radius: ${props => props.theme.borderRadius};
+  }
+
+  ${props =>
+    props.error &&
+    css`
+      & .ql-snow {
+        border: 1px solid ${props.theme.alertMessage.error.default.toString()};
+      }
+    `};
 `;
 
 export const CommentEditor = styled.div``;
@@ -97,7 +116,7 @@ export const CommentPost = styled.div`
   border-radius: ${props => props.theme.borderRadius};
   box-shadow: ${props => props.theme.boxShadow};
   color: ${props => props.theme.textDefault.default.toString()};
-  padding: 2rem 3rem 2rem 3rem;
+  padding: 2rem 3rem 1rem 3rem;
   margin-top: ${props => (props.deleted ? 2 : 0)}rem;
 
   ${props =>
@@ -121,6 +140,7 @@ export const ActionBar = styled.div`
   display: flex;
   justify-content: flex-start;
   border-top: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  padding-bottom: 1rem;
   margin-top: 2rem;
   margin-left: -1rem;
   margin-bottom: -1rem;
@@ -155,4 +175,9 @@ export const ActionCommentButton = styled(Button)`
 export const CommentReplyPost = styled.div`
   margin-left: 5rem;
   margin-top: 1rem;
+`;
+
+export const ErrorMessage = styled.span`
+  color: ${props => props.theme.alertMessage.error.default.toString()};
+  font-size: 1.4rem;
 `;

--- a/src/pages/proposals/confirm/milestones.js
+++ b/src/pages/proposals/confirm/milestones.js
@@ -1,9 +1,15 @@
 import React from 'react';
+import Markdown from 'react-markdown';
 import PropTypes from 'prop-types';
 
-import { HorizontalBar } from '../../../components/common/elements/index';
-
-import { Section, Title, Content, Heading, DataContent } from './style';
+import { HorizontalBar } from '@digix/gov-ui/components/common/elements';
+import {
+  Content,
+  DataContent,
+  Heading,
+  Section,
+  Title,
+} from '@digix/gov-ui/pages/proposals/confirm/style';
 
 export default class Milestones extends React.Component {
   render() {
@@ -28,7 +34,9 @@ export default class Milestones extends React.Component {
                 <Heading>
                   {project.milestone} {i + 1}: {signTransaction.common.details}
                 </Heading>
-                <DataContent>{ms.description}</DataContent>
+                <DataContent>
+                  <Markdown source={ms.description} escapeHtml={false} />
+                </DataContent>
               </div>
             ))}
         </Content>

--- a/src/pages/proposals/details.js
+++ b/src/pages/proposals/details.js
@@ -81,12 +81,14 @@ export default class ProjectDetails extends React.Component {
     const { selectedImage } = this.state;
 
     const hasImages = project.images && project.images.length > 0;
+    const description = project.description || project.noShortDescription;
+
     return (
       <DetailsContainer>
         <Content>
           <SubTitle>{trans.shortDescription}</SubTitle>
           <div data-digix="Details-Short-Desc">
-            {project.description ? project.description : project.noShortDescription}
+            <ReactMarkdown source={description} escapeHtml={false} />
           </div>
           <HR />
         </Content>

--- a/src/pages/proposals/forms/details.js
+++ b/src/pages/proposals/forms/details.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactQuill from 'react-quill';
 import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
 
 import 'react-quill/dist/quill.snow.css';
 import '@digix/gov-ui/pages/proposals/forms/quill.css';
@@ -20,7 +21,9 @@ class Details extends React.Component {
       onChange,
       translations: { project, common },
     } = this.props;
-    const { invalidDetails } = this.props.errors;
+
+    const { invalidDetails, invalidLink } = this.props.errors;
+    const hasDetailsError = invalidDetails || invalidLink;
 
     return (
       <Fieldset>
@@ -29,7 +32,7 @@ class Details extends React.Component {
             {project.projectInformation}
             <span>&nbsp;*</span>
           </Label>
-          <EditorContainer error={invalidDetails}>
+          <EditorContainer error={hasDetailsError}>
             <ReactQuill
               id="details"
               value={form.details || ''}
@@ -37,6 +40,11 @@ class Details extends React.Component {
             />
           </EditorContainer>
           {invalidDetails && <ErrorMessage>{common.errors.fieldIsRequired}</ErrorMessage>}
+          {invalidLink && (
+            <ErrorMessage>
+              <Markdown source={common.errors.invalidLink} escapeHtml={false} />
+            </ErrorMessage>
+          )}
         </FormItem>
       </Fieldset>
     );

--- a/src/pages/proposals/forms/index.js
+++ b/src/pages/proposals/forms/index.js
@@ -10,7 +10,7 @@ import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualiza
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { dijix } from '@digix/gov-ui/utils/dijix';
-import { encodeHash, injectTranslation } from '@digix/gov-ui/utils/helpers';
+import { encodeHash, hasInvalidLink, injectTranslation } from '@digix/gov-ui/utils/helpers';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { getDaoConfig } from '@digix/gov-ui/reducers/info-server/actions';
@@ -66,7 +66,7 @@ class ProposalForms extends React.Component {
     this.FORM_STEPS = [Overview, Details, Multimedia, Milestones];
     this.MAX_FORM_STEP_INDEX = this.FORM_STEPS.length - 1;
     this.NON_EMPTY_STRING = /^(?!\s*$).+/;
-    this.EMPTY_DETAILS = /^((<p>)((<br>)*|(\s*)|)*(<\/p>))*$/;
+    this.EMPTY_HTML = /^((<p>)((<br>)*|(\s*)|)*(<\/p>))*$/;
   }
 
   // will only trigger for Edit Project
@@ -141,7 +141,7 @@ class ProposalForms extends React.Component {
     );
   };
 
-  onFormInput = (e, details) => {
+  onFormInput = (e, details, validateFormItems, fieldChanged, index) => {
     const { form } = this.state;
     let key = e;
     let value = details;
@@ -153,7 +153,7 @@ class ProposalForms extends React.Component {
 
     form[key] = value;
     this.setState({ form: { ...form } }, () => {
-      this.validateForm(key, value);
+      this.validateForm(key, value, validateFormItems, fieldChanged, index);
     });
   };
 
@@ -166,25 +166,26 @@ class ProposalForms extends React.Component {
     this.props.showHideAlert({ message });
   };
 
+  hasErrors = formErrors => Object.values(formErrors).filter(e => !!e).length > 0;
+
   validateOverviewForm(field, value, validateOnChangeForm) {
     const { description, title } = this.state.form;
     let { formErrors } = this.state;
 
     const hasDescription = description && this.NON_EMPTY_STRING.test(description);
     const hasTitle = title && this.NON_EMPTY_STRING.test(title);
-    const validForm = hasDescription && hasTitle;
 
     // do not pass formErrors if validation is due to switching forms
     // if validation is due to user input, only update formErrors for the current input
-    const isValueEmpty = !value || !this.NON_EMPTY_STRING.test(value);
     if (validateOnChangeForm) {
       formErrors = {};
     } else if (field && field === 'description') {
-      formErrors.invalidDescription = isValueEmpty;
+      formErrors.invalidDescription = !hasDescription;
+      formErrors.invalidLink = value && hasInvalidLink(value);
     } else if (field && field === 'title') {
-      formErrors.invalidTitle = isValueEmpty;
+      formErrors.invalidTitle = !hasTitle;
     }
-
+    const validForm = hasDescription && hasTitle && !this.hasErrors(formErrors);
     this.setState({
       formErrors,
       validForm,
@@ -194,21 +195,23 @@ class ProposalForms extends React.Component {
   validateProjectDetailForm(validateOnChangeForm) {
     let { formErrors } = this.state;
     const { details } = this.state.form;
-    const validForm = details && details !== '' && !this.EMPTY_DETAILS.test(details);
+    const hasDetails = details && details !== '' && !this.EMPTY_HTML.test(details);
 
     if (validateOnChangeForm) {
       formErrors = {};
     } else {
-      formErrors.invalidDetails = !validForm;
+      formErrors.invalidDetails = !hasDetails;
+      formErrors.invalidLink = details && hasInvalidLink(details);
     }
 
+    const validForm = hasDetails && !this.hasErrors(formErrors);
     this.setState({
       formErrors,
       validForm,
     });
   }
 
-  validateMilestoneForm(field) {
+  validateMilestoneForm(field, validateForItems, fieldChanged, milestoneIndex) {
     const { form, formErrors } = this.state;
     const { finalReward } = form;
     let { milestones } = form;
@@ -225,17 +228,35 @@ class ProposalForms extends React.Component {
     const hasReward = finalReward && Number(finalReward) > 0;
     const hasMilestones = milestones.length > 0;
     const hasMissingFunds = milestones.filter(m => !m.fund || m.fund === '').length > 0;
-    const milestonesWithMissingDescriptions = milestones.filter(
-      m => !m.description || m.description === '' || !this.NON_EMPTY_STRING.test(m.description)
+    const milestonesWithInvalidDescriptions = milestones.filter(
+      ({ description }) =>
+        !description ||
+        description === '' ||
+        this.EMPTY_HTML.test(description) ||
+        hasInvalidLink(description)
     );
-    const hasMissingDescription = milestonesWithMissingDescriptions.length > 0;
+    const hasInvalidDescription = milestonesWithInvalidDescriptions.length > 0;
 
-    if (field) {
+    formErrors.milestones = {};
+    if (field === 'finalReward') {
       formErrors.invalidReward = !hasReward;
     }
 
+    if (validateForItems && milestones[milestoneIndex]) {
+      const { fund, description } = milestones[milestoneIndex];
+      const invalidFunds = !fund || fund === '';
+      const invalidDescription =
+        !description || description === '' || this.EMPTY_HTML.test(description);
+
+      formErrors.milestones[milestoneIndex] = {
+        invalidFunds: fieldChanged === 'fund' && invalidFunds,
+        invalidDescription: fieldChanged === 'description' && invalidDescription,
+        invalidLink: fieldChanged === 'description' && hasInvalidLink(description),
+      };
+    }
+
     const validForm =
-      hasReward && hasMilestones && !hasMissingFunds && !hasMissingDescription && !exceedsLimit;
+      hasReward && hasMilestones && !hasMissingFunds && !hasInvalidDescription && !exceedsLimit;
 
     this.setState({
       exceedsLimit,
@@ -257,22 +278,22 @@ class ProposalForms extends React.Component {
     return Number(milestones.reduce(milestoneFunds, 0)) + Number(finalReward);
   }
 
-  validateForm(field, value, validateOnChangeForm) {
+  validateForm(field, value, validateFormItems, fieldChanged, index) {
     const { currentStep } = this.state;
 
     switch (currentStep) {
       case 0:
-        this.validateOverviewForm(field, value, validateOnChangeForm);
+        this.validateOverviewForm(field, value, validateFormItems);
         break;
       case 1:
-        this.validateProjectDetailForm(validateOnChangeForm);
+        this.validateProjectDetailForm(validateFormItems);
         break;
       case 2:
         // no validations need for file upload
         this.setState({ validForm: true });
         break;
       case 3:
-        this.validateMilestoneForm(!!field);
+        this.validateMilestoneForm(field, validateFormItems, fieldChanged, index);
         break;
       default:
         this.setState({ validForm: false });

--- a/src/pages/proposals/forms/style.js
+++ b/src/pages/proposals/forms/style.js
@@ -209,6 +209,16 @@ export const EditorContainer = styled.div`
     height: 20rem;
   }
 
+  & .ql-toolbar.ql-snow {
+    border-top-left-radius: ${props => props.theme.borderRadius};
+    border-top-right-radius: ${props => props.theme.borderRadius};
+  }
+
+  & .ql-container.ql-snow {
+    border-bottom-left-radius: ${props => props.theme.borderRadius};
+    border-bottom-right-radius: ${props => props.theme.borderRadius};
+  }
+
   ${props =>
     props.error &&
     css`

--- a/src/pages/user/profile/buttons/redeem-badge.js
+++ b/src/pages/user/profile/buttons/redeem-badge.js
@@ -182,7 +182,7 @@ RedeemBadgeButton.propTypes = {
   history: object.isRequired,
   getAddressDetails: func.isRequired,
   showRightPanel: func.isRequired,
-  translations: func.isRequired,
+  translations: object.isRequired,
   txnTranslations: object.isRequired,
 };
 

--- a/src/translations/chinese/common.json
+++ b/src/translations/chinese/common.json
@@ -4,7 +4,8 @@
     "main": "表决"
   },
   "errors": {
-    "fieldIsRequired": "必填项."
+    "fieldIsRequired": "必填项.",
+    "invalidLink": "Invalid link. Hyperlinks may only begin with **http://** or **https://** or **mailto:**"
   },
   "projectStatus": {
     "all": "全部",

--- a/src/translations/english/common.json
+++ b/src/translations/english/common.json
@@ -4,7 +4,8 @@
     "main": "Main Phase"
   },
   "errors": {
-    "fieldIsRequired": "This field is required."
+    "fieldIsRequired": "This field is required.",
+    "invalidLink": "Invalid link. Hyperlinks may only begin with **http://** or **https://** or **mailto:**"
   },
   "projectStatus": {
     "all": "All",

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -139,3 +139,28 @@ export const injectTranslation = (translation, toInject, setDataDigix, dataDigix
 };
 
 export const getHash = toHash => util.sha256(toHash.toString()).toString('hex');
+
+export const hasInvalidLink = text => {
+  const EMPTY_HTML = /^((<p>)((<br>)*|(\s*)|)*(<\/p>))*$/;
+  if (!text || text === '' || EMPTY_HTML.test(text)) {
+    return false;
+  }
+
+  const links = text.split('a href="');
+  if (links.length < 2) {
+    return false;
+  }
+
+  for (let i = 1; i < links.length; i += 1) {
+    const link = links[i];
+    const isHttp = link.startsWith('http://');
+    const isHttps = link.startsWith('https://');
+    const isEmail = link.startsWith('mailto:');
+
+    if (!isHttp && !isHttps && !isEmail) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
Ref: [DGDG-514](https://tracker.digixdev.com/oauth?state=%2Fissue%2FDGDG-514)

The user should be able to format their input for the following:
- Project details (already existing)
- Milestone description
- Comments

Validation has been added for individual milestones in the project form. This diff also runs validations for suspicious hyperlinks.

### Test Plan
- Run the translations script `npm run ui:generate-translations`.
- Verify the above to be true.
- The formatted values should persist in the project form even if you navigate through different steps.
- The formatted values should be displayed correctly when viewing the preview (during create/edit project) and the project view page.
- An error will occur if the user inputs a link that does not start in `http://`, `https://`, or `mailto:`.

Do regression testing for banning users (user will not be able to comment and the UI for this should not be broken) and for forum admin actions.