### PR TITLE
Update missing translations for loading wallets

### DIFF
--- a/src/translations/chinese/loadWallet.json
+++ b/src/translations/chinese/loadWallet.json
@@ -27,6 +27,9 @@
       "name": "名称",
       "addressNickname": "昵称",
       "error": "名字是必填项目",
+      "ConnectionError": {
+        "noMetamask": "无法连接到MetaMask钱包.确保您已登入MetaMask钱包."
+      },
       "proofOfControl": {
         "description": "等待 Metamask 签名中",
         "instructions": "请确认您 MetaMask的签名. 点击“取消”来取消签名."
@@ -41,7 +44,8 @@
         "instructions": "选择硬件钱包衍生路径",
         "default": "Ledger (默认)",
         "account": "账户",
-        "custom": "Ledger Live/更改硬件钱包路径"
+        "custom": "Ledger Live/更改硬件钱包路径",
+        "loading": "获取地址中..."
       },
       "selectAddress": {
         "instructions": "选择要激活的地址",
@@ -64,7 +68,8 @@
         "instructions": "选择硬件钱包衍生路径",
         "default": "Trezor (默认)",
         "account": "账户",
-        "custom": "更改硬件钱包路径"
+        "custom": "更改硬件钱包路径",
+        "loading": "获取地址中..."
       },
       "selectAddress": {
         "instructions": "选择要激活的地址",
@@ -87,7 +92,9 @@
     "error": "密码输入错误",
     "proofOfControl": {
       "description": "这个签名用来证明您拥有此以太坊地址. 签名代表您同意您对 DigixDAO上的此地址有使用权."
-    }
+    },
+    "importInstructions": "点此加载文件.",
+    "importError": "不支持此Keystore类型."
   },
   "connectedWallet": {
     "title": "连接钱包",
@@ -110,29 +117,6 @@
         "requiredName": "请提供姓名",
         "invalidNames": "您必须为钱包地址提供一个姓名.",
         "invalidPassword": "密码与用户名不符."
-      }
-    },
-    "Json": {
-      "importInstructions": "点此加载文件.",
-      "importError": "不支持此Keystore类型."
-    },
-    "Metamask": {
-      "ConnectionError": {
-        "noMetamask": "无法连接到MetaMask钱包.确保您已登入MetaMask钱包."
-      }
-    },
-    "Ledger": {
-      "chooseAddress": {
-        "selectPath": {
-          "loading": "获取地址中..."
-        }
-      }
-    },
-    "Trezor": {
-      "chooseAddress": {
-        "selectPath": {
-          "loading": "获取地址中..."
-        }
       }
     }
   }

--- a/src/translations/english/loadWallet.json
+++ b/src/translations/english/loadWallet.json
@@ -27,6 +27,9 @@
       "name": "Name",
       "addressNickname": "Address Nickname",
       "error": "You must provide a name.",
+      "ConnectionError": {
+        "noMetamask": "Cannot connect to MetaMask wallet. Make sure to login to your MetaMask wallet."
+      },
       "proofOfControl": {
         "description": "Waiting for Metamask Sign Confirmation",
         "instructions": "Please confirm your signature in MetaMask. If you wish to cancel, click the 'Cancel' button in MetaMask."
@@ -41,7 +44,8 @@
         "instructions": "Select HD Derivation Path",
         "default": "Ledger (Default)",
         "account": "Account",
-        "custom": "Ledger Live/Custom Wallet HD path"
+        "custom": "Ledger Live/Custom Wallet HD path",
+        "loading": "Getting address info..."
       },
       "selectAddress": {
         "instructions": "Select addresses to enable",
@@ -64,7 +68,8 @@
         "instructions": "Select HD Derivation Path",
         "default": "Trezor (Default)",
         "account": "Account",
-        "custom": "Custom Wallet HD path"
+        "custom": "Custom Wallet HD path",
+        "loading": "Getting address info..."
       },
       "selectAddress": {
         "instructions": "Select addresses to enable",
@@ -87,7 +92,9 @@
     "error": "Key derivation failed - possibly wrong passphrase",
     "proofOfControl": {
       "description": "This signing is to prove to our server that you are in control of the Ethereum account that was loaded. By signing this message, you are proving that you control the selected account for use on DigixDAO."
-    }
+    },
+    "importInstructions": "Click or drag and drop here to load your file.",
+    "importError": "Keystore type not supported."
   },
   "connectedWallet": {
     "title": "Connected Wallet",
@@ -110,29 +117,6 @@
         "requiredName": "You must provide a name.",
         "invalidNames": "You must provide a name for all addresses.",
         "invalidPassword": "Passwords do not match."
-      }
-    },
-    "Json": {
-      "importInstructions": "Click or drag and drop here to load your file.",
-      "importError": "Keystore type not supported."
-    },
-    "Metamask": {
-      "ConnectionError": {
-        "noMetamask": "Cannot connect to MetaMask wallet. Make sure to login to your MetaMask wallet."
-      }
-    },
-    "Ledger": {
-      "chooseAddress": {
-        "selectPath": {
-          "loading": "Getting address info..."
-        }
-      }
-    },
-    "Trezor": {
-      "chooseAddress": {
-        "selectPath": {
-          "loading": "Getting address info..."
-        }
       }
     }
   }


### PR DESCRIPTION
### Code Review Notes

Depends on PR [#28](https://github.com/DigixGlobal/governance-ui/pull/28) in the `governance-ui` repo.

### Test Plan
- Run the translations script. `npm run ui:generate-translations`
- Some texts have been added Chinese translations when you load different wallet types.