### PR TITLE
 Use GraphQL query to get reputation and quarter points for comments

### DIFF
--- a/src/api/comments.js
+++ b/src/api/comments.js
@@ -73,7 +73,7 @@ export const CommentsApi = {
   }),
 
   generateNewComment: (node, currentUser, parentId) => {
-    const { address, displayName } = currentUser;
+    const { address, displayName, quarterPoint, reputationPoint } = currentUser;
 
     return {
       node: {
@@ -87,6 +87,8 @@ export const CommentsApi = {
         user: {
           address,
           displayName,
+          quarterPoint,
+          reputationPoint,
           __typename: 'User',
         },
         replies: {

--- a/src/api/graphql-queries/comments.js
+++ b/src/api/graphql-queries/comments.js
@@ -13,6 +13,8 @@ const fragments = {
       user {
         address
         displayName
+        reputationPoint
+        quarterPoint
       }
     }
   `,

--- a/src/api/graphql-queries/users.js
+++ b/src/api/graphql-queries/users.js
@@ -34,6 +34,8 @@ export const fetchUserQuery = gql`
       createdAt
       isForumAdmin
       isKycOfficer
+      reputationPoint
+      quarterPoint
       kyc {
         id
         status

--- a/src/pages/proposals/comment/author.js
+++ b/src/pages/proposals/comment/author.js
@@ -8,31 +8,27 @@ export default class CommentAuthor extends React.Component {
     const {
       hide,
       user,
-      userPoints,
       translations: {
         data: {
           dashboard: { UserStats },
         },
       },
     } = this.props;
+
     if (hide) {
       return null;
     }
-
-    const points = userPoints[user.address];
-    const reputationPoints = points ? points.reputation : 0;
-    const quarterPoints = points ? points.quarterPoints : 0;
 
     return (
       <UserInfo>
         <span data-digix="CommentAuthor-DisplayName">{user.displayName}</span>
         <span>&bull;</span>
         <span data-digix="CommentAuthor-Reputation">
-          {UserStats.reputationPoints}: {reputationPoints}
+          {UserStats.reputationPoints}: {user.reputationPoint}
         </span>
         <span>&bull;</span>
         <span data-digix="CommentAuthor-QuarterPoints">
-          {UserStats.quarterPoints}: {quarterPoints}
+          {UserStats.quarterPoints}: {user.quarterPoint}
         </span>
       </UserInfo>
     );
@@ -44,7 +40,6 @@ const { bool, object } = PropTypes;
 CommentAuthor.propTypes = {
   hide: bool,
   user: object.isRequired,
-  userPoints: object.isRequired,
   translations: object.isRequired,
 };
 

--- a/src/pages/proposals/comment/comment.js
+++ b/src/pages/proposals/comment/comment.js
@@ -185,7 +185,7 @@ class Comment extends React.Component {
   }
 
   render() {
-    const { currentUser, userPoints, translations } = this.props;
+    const { currentUser, translations } = this.props;
     const { comment } = this.state;
     const { body, isBanned, user } = comment;
     const isForumAdmin = currentUser != null ? currentUser : false;
@@ -198,12 +198,7 @@ class Comment extends React.Component {
 
     return (
       <CommentListItem>
-        <CommentAuthor
-          hide={isDeleted}
-          user={user}
-          userPoints={userPoints}
-          translations={translations}
-        />
+        <CommentAuthor hide={isDeleted} user={user} translations={translations} />
         <CommentPost isHidden={isHidden} deleted={isDeleted}>
           <Content>
             <Markdown source={commentMessage} escapeHtml={false} />
@@ -230,7 +225,6 @@ Comment.propTypes = {
   hideEditor: func.isRequired,
   setError: func.isRequired,
   toggleEditor: func.isRequired,
-  userPoints: object.isRequired,
   translations: object.isRequired,
 };
 

--- a/src/pages/proposals/comment/reply.js
+++ b/src/pages/proposals/comment/reply.js
@@ -95,7 +95,7 @@ class CommentReply extends React.Component {
   };
 
   render() {
-    const { currentUser, renderThreadReplies, setError, userPoints } = this.props;
+    const { currentUser, renderThreadReplies, setError } = this.props;
     const { comment, showEditor, translations } = this.state;
 
     if (!comment) {
@@ -115,7 +115,6 @@ class CommentReply extends React.Component {
               setError={setError}
               hideEditor={this.hideEditor}
               toggleEditor={this.toggleEditor}
-              userPoints={userPoints}
               translations={translations}
             />
             {showEditor && (
@@ -159,7 +158,6 @@ CommentReply.propTypes = {
   renderThreadReplies: func.isRequired,
   setCommentingPrivileges: func.isRequired,
   setError: func.isRequired,
-  userPoints: object.isRequired,
 };
 
 CommentReply.defaultProps = {

--- a/src/pages/proposals/comment/thread.js
+++ b/src/pages/proposals/comment/thread.js
@@ -96,7 +96,7 @@ class ParentThread extends React.Component {
   };
 
   renderThreadReplies = replyList => {
-    const { currentUser, setCommentingPrivileges, setError, userPoints } = this.props;
+    const { currentUser, setCommentingPrivileges, setError } = this.props;
     const replies = replyList.edges;
 
     const replyElements = replies.map(reply => {
@@ -111,7 +111,6 @@ class ParentThread extends React.Component {
           setCommentingPrivileges={setCommentingPrivileges}
           setError={setError}
           renderThreadReplies={this.renderThreadReplies}
-          userPoints={userPoints}
         />
       );
     });
@@ -137,7 +136,7 @@ class ParentThread extends React.Component {
   };
 
   render() {
-    const { currentUser, setError, userPoints } = this.props;
+    const { currentUser, setError } = this.props;
     const { thread, showEditor } = this.state;
     if (!thread) {
       return null;
@@ -151,7 +150,6 @@ class ParentThread extends React.Component {
           hideEditor={this.hideEditor}
           setError={setError}
           toggleEditor={this.toggleEditor}
-          userPoints={userPoints}
         />
         {showEditor && <CommentTextEditor addComment={this.addReply} callback={this.hideEditor} />}
         {this.renderThreadReplies(thread.replies)}
@@ -170,7 +168,6 @@ ParentThread.propTypes = {
   setCommentingPrivileges: func.isRequired,
   setError: func.isRequired,
   thread: object.isRequired,
-  userPoints: object.isRequired,
 };
 
 ParentThread.defaultProps = {


### PR DESCRIPTION
The reputation and quarter points for comments are not showing up in the proposal page for users who do not have a wallet loaded. Since the `dao-server` is now fetching the points for us, we can just use the graphQL query to fetch that data instead of manually doing so through the `info-server`.

### Test Plan
- Comment on a proposal.
- The reputation and quarter points for the user should show up for logged-in and guest users.