### PR TITLE
Make sure to always get the updated user stats

### DIFF
--- a/src/api/graphql-queries/address.js
+++ b/src/api/graphql-queries/address.js
@@ -37,7 +37,7 @@ export const addressSubscription = gql`
 `;
 
 export const withFetchAddress = Component => props => (
-  <Query query={fetchAddressQuery}>
+  <Query query={fetchAddressQuery} fetchPolicy="network-only">
     {({ loading, error, data, subscribeToMore }) => {
       if (loading || error) {
         return null;


### PR DESCRIPTION
The user's quarter points are not updated automatically when the value changes in the `info-server`. This diff makes sure we are relying on the updated data and not the GraphQL cache.

### Test Plan
- Create a special proposal and commit/reveal your vote. This should increase your quarter points.
- Check your quarter points in the dashboard or profile page. The value should be updated and correspond to the value in the `info-server` (see `https://localhost:3001/address/:address`).