### PR TITLE
[Fix] - Gas Limit Claiming Moderator Approval

### DIFF
--- a/src/pages/proposals/proposal-buttons/claim-approval.js
+++ b/src/pages/proposals/proposal-buttons/claim-approval.js
@@ -91,7 +91,7 @@ class ClaimApprovalButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: 8000000,
       ui,
     };
 


### PR DESCRIPTION
Set default gas limit to 8000000 for claiming moderator approval