### PR TITLE
correct data-digix naming for locked stake and locked dgd

### DIFF
--- a/src/components/common/blocks/user-address-stats/index.js
+++ b/src/components/common/blocks/user-address-stats/index.js
@@ -58,10 +58,10 @@ class UserAddressStats extends React.Component {
         <Item>
           <Label>{dashboard.UserStats.stake}</Label>
           <Data data-digix="Dashboard-Stats-Stake">
-            <span data-digix="Dashboard-DGD-Stake">{stake}</span>
+            <span data-digix="Dashboard-Locked-Stake">{stake}</span>
             <span className="equiv">
               <span>( </span>
-              <span data-digix="Dashboard-DGD-Stake">{dgd}</span>
+              <span data-digix="Dashboard-Locked-DGD">{dgd}</span>
               <span>&nbsp;{dashboard.UserStats.dgdLocked} )</span>
             </span>
           </Data>


### PR DESCRIPTION
Target: 
- move data-digix locators to right container and rename it to its corresponding target.