### PR TITLE
Use default gas limits from txConfig

### DIFF
--- a/src/components/common/blocks/address-watcher/index.js
+++ b/src/components/common/blocks/address-watcher/index.js
@@ -9,6 +9,7 @@ import { showMsgSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { setDaoAuthorization, setInfoAuthorization } from '@digix/gov-ui/api/graphql';
 import {
   getAddressDetailsVanilla,
+  getTxConfig,
   setAddressDetails,
 } from '@digix/gov-ui/reducers/info-server/actions';
 
@@ -114,6 +115,7 @@ class AddressWatcher extends React.PureComponent {
                 this.props.setAuthentationStatus(true),
                 this.props.setAddressDetails(details),
                 this.props.showHideWalletOverlay(false),
+                this.props.getTxConfig(),
                 this.props.client.query({ query: fetchAddressQuery, fetchPolicy: 'network-only' }),
                 this.props.client.query({ query: fetchDisplayName, fetchPolicy: 'network-only' }),
                 this.props.client.query({ query: fetchUserQuery, fetchPolicy: 'network-only' }),
@@ -142,6 +144,7 @@ AddressWatcher.propTypes = {
   setAuthentationStatus: func.isRequired,
   setAddressDetails: func.isRequired,
   getTokenUsdValue: func.isRequired,
+  getTxConfig: func.isRequired,
   showHideAlert: func.isRequired,
   showHideWalletOverlay: func.isRequired,
   showMsgSigningModal: func.isRequired,
@@ -173,6 +176,7 @@ export default withApollo(
     {
       setAddressDetails,
       getTokenUsdValue,
+      getTxConfig,
       showHideAlert,
       showHideWalletOverlay,
       setAuthentationStatus,

--- a/src/components/common/blocks/lock-dgd/index.js
+++ b/src/components/common/blocks/lock-dgd/index.js
@@ -25,7 +25,7 @@ import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/ac
 import TextField from '@digix/gov-ui/components/common/elements/textfield';
 import Button from '@digix/gov-ui/components/common/elements/buttons';
 import getContract, { getDGDBalanceContract } from '@digix/gov-ui/utils/contracts';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
 import LogLockDgd from '@digix/gov-ui/analytics/lockDgd';
 
@@ -188,6 +188,7 @@ class LockDgd extends React.Component {
     LogLockDgd.submit(addedDgd);
 
     const {
+      gasLimitConfig,
       web3Redux,
       sendTransactionToDaoServer: sendTransactionToDaoServerAction,
       challengeProof,
@@ -200,7 +201,10 @@ class LockDgd extends React.Component {
       .eth.contract(abi)
       .at(address);
 
-    const web3Params = { gasPrice: DEFAULT_GAS_PRICE, gas: DEFAULT_GAS };
+    const web3Params = {
+      gasPrice: DEFAULT_GAS_PRICE,
+      gas: gasLimitConfig.LOCK_DGD || gasLimitConfig.DEFAULT,
+    };
 
     const ui = {
       dgd,
@@ -351,12 +355,14 @@ LockDgd.propTypes = {
   addresses: array,
   showHideAlert: func.isRequired,
   translations: object,
+  gasLimitConfig: object,
 };
 
 LockDgd.defaultProps = {
   defaultAddress: undefined,
   addresses: undefined,
   addressMaxAllowance: undefined,
+  gasLimitConfig: undefined,
   translations: {
     lockDgd: {},
     wallet: {},
@@ -372,6 +378,7 @@ const mapStateToProps = state => ({
   lockDgdOverlay: state.govUI.lockDgdOverlay,
   addressMaxAllowance: state.govUI.addressMaxAllowance,
   translations: state.daoServer.Translations.data,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/components/common/blocks/overlay/approve-badge-redemption/index.js
+++ b/src/components/common/blocks/overlay/approve-badge-redemption/index.js
@@ -12,7 +12,7 @@ import { toBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
 import DaoStakeLocking from '@digix/dao-contracts/build/contracts/DaoStakeLocking.json';
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/index'; // '../../elements/buttons';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
@@ -58,7 +58,7 @@ class BadgeRedemptionApproval extends React.Component {
   };
 
   handleSubmit = () => {
-    const { web3Redux, addresses } = this.props;
+    const { addresses, gasLimitConfig, web3Redux } = this.props;
     const { address: daoStakeLockingAddress } = getContract(DaoStakeLocking, network);
     const { abi, address } = getDGDBadgeBalanceContract(network);
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
@@ -76,7 +76,7 @@ class BadgeRedemptionApproval extends React.Component {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -125,6 +125,7 @@ const { array, func, object } = PropTypes;
 BadgeRedemptionApproval.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   history: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlertAction: func.isRequired,
@@ -136,8 +137,9 @@ BadgeRedemptionApproval.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
   translations: state.daoServer.Translations.data.approveInteraction,
   txnTranslations: state.daoServer.Translations.data.signTransaction,
 });

--- a/src/components/common/blocks/overlay/approve-draft/index.js
+++ b/src/components/common/blocks/overlay/approve-draft/index.js
@@ -17,7 +17,7 @@ import getContract from '@digix/gov-ui/utils/contracts';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -83,6 +83,7 @@ class ApproveProposalOverlay extends React.Component {
 
   handleSubmit = () => {
     const {
+      gasLimitConfig,
       web3Redux,
       addresses,
       proposalId,
@@ -104,7 +105,7 @@ class ApproveProposalOverlay extends React.Component {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.MODERATOR_VOTE || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -173,6 +174,7 @@ const { array, func, object, string } = PropTypes;
 ApproveProposalOverlay.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   history: object.isRequired,
   proposalId: string.isRequired,
   sendTransactionToDaoServer: func.isRequired,
@@ -185,8 +187,9 @@ ApproveProposalOverlay.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/components/common/blocks/overlay/change-funding/index.js
+++ b/src/components/common/blocks/overlay/change-funding/index.js
@@ -24,7 +24,7 @@ import getContract from '@digix/gov-ui/utils/contracts';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -179,6 +179,7 @@ class ChangeFundingOverlay extends React.Component {
 
   handleSubmit = () => {
     const {
+      gasLimitConfig,
       web3Redux,
       addresses,
       proposalDetails,
@@ -202,7 +203,7 @@ class ChangeFundingOverlay extends React.Component {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.CHANGE_FUNDINGS || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -312,6 +313,7 @@ ChangeFundingOverlay.propTypes = {
   addresses: array.isRequired,
   daoConfig: object.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   proposalDetails: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlertAction: func.isRequired,
@@ -324,9 +326,10 @@ ChangeFundingOverlay.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  addresses: getAddresses(state),
   ChallengeProof: state.daoServer.ChallengeProof,
   daoConfig: state.infoServer.DaoConfig,
-  addresses: getAddresses(state),
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
   txnTranslations: state.daoServer.Translations.data.signTransaction,
 });
 

--- a/src/components/common/blocks/overlay/unlock-dgd/index.js
+++ b/src/components/common/blocks/overlay/unlock-dgd/index.js
@@ -8,7 +8,7 @@ import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { getDaoConfig } from '@digix/gov-ui/reducers/info-server/actions';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
@@ -73,7 +73,7 @@ class UnlockDgdOverlay extends React.Component {
 
   unlockDgd = unlockAmount => {
     const t = this.props.translations;
-    const { addresses, ChallengeProof, web3Redux } = this.props;
+    const { addresses, ChallengeProof, gasLimitConfig, web3Redux } = this.props;
     const { abi, address } = getContract(DaoStakeLocking, network);
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
@@ -90,7 +90,7 @@ class UnlockDgdOverlay extends React.Component {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.UNLOCK_DGD || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -227,6 +227,7 @@ UnlockDgdOverlay.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
   DaoConfig: object.isRequired,
+  gasLimitConfig: object.isRequired,
   getDaoConfig: func.isRequired,
   maxAmount: number.isRequired,
   onSuccess: func,
@@ -247,6 +248,7 @@ const mapStateToProps = state => ({
   addresses: getAddresses(state),
   ChallengeProof: state.daoServer.ChallengeProof.data,
   DaoConfig: state.infoServer.DaoConfig.data,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
   txnTranslations: state.daoServer.Translations.data.signTransaction,
 });
 

--- a/src/components/common/blocks/overlay/vote/commit.js
+++ b/src/components/common/blocks/overlay/vote/commit.js
@@ -29,7 +29,7 @@ import getContract from '@digix/gov-ui/utils/contracts';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -109,6 +109,7 @@ class CommitVote extends React.Component {
   handleSubmit = () => {
     const { voteObject } = this.state;
     const {
+      gasLimitConfig,
       web3Redux,
       addresses,
       proposalId,
@@ -134,9 +135,10 @@ class CommitVote extends React.Component {
       type: 'txVisualization',
     };
 
+    const gasLimit = isSpecial ? gasLimitConfig.COMMIT_VOTE_SPECIAL : gasLimitConfig.COMMIT_VOTE;
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimit || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -266,6 +268,7 @@ const { array, func, object, string, bool } = PropTypes;
 CommitVote.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   history: object.isRequired,
   proposalId: string.isRequired,
   proposal: object.isRequired,
@@ -284,8 +287,9 @@ CommitVote.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/components/common/blocks/overlay/vote/reveal.js
+++ b/src/components/common/blocks/overlay/vote/reveal.js
@@ -18,7 +18,7 @@ import getContract from '@digix/gov-ui/utils/contracts';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -78,6 +78,7 @@ class RevealVote extends React.Component {
   handleSubmit = () => {
     const { voteObject } = this.state;
     const {
+      gasLimitConfig,
       web3Redux,
       addresses,
       proposal: { currentVotingRound, proposalId, isSpecial },
@@ -97,9 +98,10 @@ class RevealVote extends React.Component {
       type: 'txVisualization',
     };
 
+    const gasLimit = isSpecial ? gasLimitConfig.REVEAL_VOTE_SPECIAL : gasLimitConfig.REVEAL_VOTE;
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimit || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -214,6 +216,7 @@ const { array, func, object } = PropTypes;
 RevealVote.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   history: object.isRequired,
   proposal: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
@@ -226,8 +229,9 @@ RevealVote.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/components/common/blocks/wallet/connected-wallet/index.js
+++ b/src/components/common/blocks/wallet/connected-wallet/index.js
@@ -10,7 +10,7 @@ import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import DaoStakeLocking from '@digix/dao-contracts/build/contracts/DaoStakeLocking.json';
 
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 
 import {
   showHideLockDgdOverlay,
@@ -20,7 +20,7 @@ import {
   showHideWalletOverlay,
 } from '@digix/gov-ui/reducers/gov-ui/actions';
 
-import { getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import { getDaoDetails, getTxConfig } from '@digix/gov-ui/reducers/info-server/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
@@ -58,7 +58,9 @@ class ConnectedWallet extends React.Component {
 
   componentDidMount() {
     const { defaultAddress, AddressDetails } = this.props;
+    this.props.getTxConfig();
     this._isMounted = true;
+
     if (defaultAddress.address && AddressDetails.data) {
       const address = AddressDetails.data;
       const hasParticipated = address.isParticipant || address.lastParticipatedQuarter > 0;
@@ -131,7 +133,7 @@ class ConnectedWallet extends React.Component {
   };
 
   handleApprove = () => {
-    const { web3Redux, challengeProof, addresses } = this.props;
+    const { web3Redux, challengeProof, addresses, gasLimitConfig } = this.props;
 
     const { abi, address } = getDGDBalanceContract(network);
     const contract = web3Redux
@@ -144,9 +146,10 @@ class ConnectedWallet extends React.Component {
       header: 'DGD Approval',
       type: 'txVisualization',
     };
+
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -342,12 +345,15 @@ ConnectedWallet.propTypes = {
   translations: object.isRequired,
   approvalTranslations: object.isRequired,
   txnTranslations: object.isRequired,
+  gasLimitConfig: object,
+  getTxConfig: func.isRequired,
 };
 
 ConnectedWallet.defaultProps = {
   AddressDetails: undefined,
   addressMaxAllowance: undefined,
   tokenUsdValues: undefined,
+  gasLimitConfig: undefined,
   DaoDetails: {
     data: {
       isGlobalRewardsSet: false,
@@ -371,6 +377,7 @@ const mapStateToProps = state => ({
   translations: state.daoServer.Translations.data.loadWallet.connectedWallet,
   approvalTranslations: state.daoServer.Translations.data.approveInteraction,
   txnTranslations: state.daoServer.Translations.data.signTransaction,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default connect(
@@ -381,6 +388,7 @@ export default connect(
     showHideLockDgdOverlayAction: showHideLockDgdOverlay,
     canLockDgd,
     getDaoDetails,
+    getTxConfig,
     fetchMaxAllowance,
     showTxSigningModal,
     sendTransactionToDaoServer,

--- a/src/pages/continue-participation.js
+++ b/src/pages/continue-participation.js
@@ -10,11 +10,7 @@ import UnlockDgdOverlay from '@digix/gov-ui/components/common/blocks/overlay/unl
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { Content, Title, Intro } from '@digix/gov-ui/pages/style';
-import {
-  CONFIRM_PARTICIPATION_CACHE,
-  DEFAULT_GAS,
-  DEFAULT_GAS_PRICE,
-} from '@digix/gov-ui/constants';
+import { CONFIRM_PARTICIPATION_CACHE, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { getHash } from '@digix/gov-ui/utils/helpers';
@@ -51,7 +47,7 @@ class ConfirmParticipation extends React.Component {
     this.props.closeModal();
 
     const t = this.props.tSnackbar;
-    const { addresses, ChallengeProof, web3Redux } = this.props;
+    const { addresses, ChallengeProof, gasLimitConfig, web3Redux } = this.props;
     const { abi, address } = getContract(DaoStakeLocking, network);
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
@@ -68,7 +64,7 @@ class ConfirmParticipation extends React.Component {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.CONFIRM_CONTINUE_PARTICIPATION || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -186,6 +182,7 @@ ConfirmParticipation.propTypes = {
   ChallengeProof: object.isRequired,
   closeModal: func.isRequired,
   DaoInfo: object.isRequired,
+  gasLimitConfig: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlert: func.isRequired,
   showHideLockDgdOverlay: func.isRequired,
@@ -203,6 +200,7 @@ const mapStateToProps = state => ({
   AddressDetails: state.infoServer.AddressDetails.data,
   ChallengeProof: state.daoServer.ChallengeProof.data,
   DaoInfo: state.infoServer.DaoDetails.data,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
   translations: state.daoServer.Translations.data.confirmParticipation,
   tSnackbar: state.daoServer.Translations.data.snackbar.snackbars.continueParticipation,
   tUnlock: state.daoServer.Translations.data.wallet.LockedDgd.UnlockDgd,

--- a/src/pages/proposals/forms/documents.js
+++ b/src/pages/proposals/forms/documents.js
@@ -48,7 +48,7 @@ import {
   ModalCta,
 } from '@digix/gov-ui/pages/proposals/forms/style';
 
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 
 registerUIs({ txVisualization: { component: TxVisualization } });
 
@@ -188,6 +188,7 @@ class Documents extends React.Component {
       web3Redux,
       ChallengeProof,
       addresses,
+      gasLimitConfig,
       translations: {
         snackbar: { snackbars },
       },
@@ -209,9 +210,10 @@ class Documents extends React.Component {
           header: snackbars.addDocs.txUiHeader,
           type: 'txVisualization',
         };
+
         const web3Params = {
           gasPrice: DEFAULT_GAS_PRICE,
-          gas: DEFAULT_GAS,
+          gas: gasLimitConfig.ADD_PROPOSAL_DOC || gasLimitConfig.DEFAULT,
           ui,
         };
 
@@ -428,6 +430,7 @@ Documents.propTypes = {
   web3Redux: object.isRequired,
   history: object.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -436,9 +439,10 @@ Documents.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  translations: state.daoServer.Translations.data,
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
+  translations: state.daoServer.Translations.data,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/forms/index.js
+++ b/src/pages/proposals/forms/index.js
@@ -8,7 +8,7 @@ import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { dijix } from '@digix/gov-ui/utils/dijix';
 import { encodeHash, hasInvalidLink, injectTranslation } from '@digix/gov-ui/utils/helpers';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
@@ -340,6 +340,7 @@ class ProposalForms extends React.Component {
       addresses,
       ChallengeProof,
       contractMethod,
+      gasLimitConfig,
       successMessage,
       transactionTitle,
       web3Redux,
@@ -383,9 +384,14 @@ class ProposalForms extends React.Component {
       value = toBigNumber(preProposalCollateral * 1e18);
     }
 
+    const gasLimit =
+      contractMethod !== 'modifyProposal'
+        ? gasLimitConfig.EDIT_PROPOSAL
+        : gasLimitConfig.CREATE_PROPOSAL;
+
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimit || gasLimitConfig.DEFAULT,
       value,
       ui,
     };
@@ -609,6 +615,7 @@ ProposalForms.propTypes = {
   DaoConfig: object.isRequired,
   dataDigixPrefix: string.isRequired,
   getDaoConfig: func.isRequired,
+  gasLimitConfig: object.isRequired,
   history: object.isRequired,
   ProposalDetails: object,
   sendTransactionToDaoServer: func.isRequired,
@@ -630,6 +637,7 @@ const mapStateToProps = state => ({
   addresses: getAddresses(state),
   ChallengeProof: state.daoServer.ChallengeProof,
   DaoConfig: state.infoServer.DaoConfig,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/abort.js
+++ b/src/pages/proposals/proposal-buttons/abort.js
@@ -12,12 +12,7 @@ import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import getContract from '@digix/gov-ui/utils/contracts';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import {
-  ProposalStages,
-  DEFAULT_GAS,
-  DEFAULT_GAS_PRICE,
-  EMPTY_HASH_LONG,
-} from '@digix/gov-ui/constants';
+import { ProposalStages, DEFAULT_GAS_PRICE, EMPTY_HASH_LONG } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -34,7 +29,14 @@ class AbortProjectButton extends React.PureComponent {
     });
 
   handleSubmit = () => {
-    const { web3Redux, ChallengeProof, addresses, proposalId, translations } = this.props;
+    const {
+      addresses,
+      ChallengeProof,
+      gasLimitConfig,
+      proposalId,
+      translations,
+      web3Redux,
+    } = this.props;
 
     const { abi, address } = getContract(Dao, network);
     const contract = web3Redux
@@ -49,7 +51,7 @@ class AbortProjectButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.ABORT_PROPOSAL || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -132,6 +134,7 @@ AbortProjectButton.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   checkProposalRequirements: func.isRequired,
+  gasLimitConfig: object.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -147,8 +150,9 @@ AbortProjectButton.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/claim-approval.js
+++ b/src/pages/proposals/proposal-buttons/claim-approval.js
@@ -10,12 +10,7 @@ import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { injectTranslation } from '@digix/gov-ui/utils/helpers';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import {
-  DEFAULT_GAS,
-  DEFAULT_GAS_PRICE,
-  VotingStages,
-  MAX_PEOPLE_PER_CLAIM,
-} from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE, VotingStages, MAX_PEOPLE_PER_CLAIM } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import MultiStepClaim from '@digix/gov-ui/components/common/blocks/overlay/claim-approval';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
@@ -71,6 +66,7 @@ class ClaimApprovalButton extends React.PureComponent {
 
   handleSubmit = useMaxClaim => () => {
     const {
+      gasLimitConfig,
       web3Redux,
       ChallengeProof,
       addresses,
@@ -89,14 +85,14 @@ class ClaimApprovalButton extends React.PureComponent {
       header: snackbars.claimApproval.txUiHeader,
       type: 'txVisualization',
     };
+
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: 8000000,
+      gas: gasLimitConfig.CLAIM_DRAFT_VOTING || gasLimitConfig.DEFAULT,
       ui,
     };
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
-
     const onTransactionAttempt = txHash => {
       if (ChallengeProof.data) {
         this.props.sendTransactionToDaoServer({
@@ -230,6 +226,7 @@ ClaimApprovalButton.propTypes = {
   proposalId: string.isRequired,
   daoConfig: object.isRequired,
   daoDetails: object.isRequired,
+  gasLimitConfig: object.isRequired,
   pendingTransactions: object,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
@@ -261,6 +258,7 @@ const mapStateToProps = state => ({
   addresses: getAddresses(state),
   daoConfig: state.infoServer.DaoConfig,
   daoDetails: state.infoServer.DaoDetails,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/claim-funding.js
+++ b/src/pages/proposals/proposal-buttons/claim-funding.js
@@ -16,12 +16,7 @@ import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualiza
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import Button from '@digix/gov-ui/components/common/elements/buttons/index';
-import {
-  DEFAULT_GAS,
-  DEFAULT_GAS_PRICE,
-  ProposalErrors,
-  ProposalStages,
-} from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE, ProposalErrors, ProposalStages } from '@digix/gov-ui/constants';
 
 registerUIs({ txVisualization: { component: TxVisualization } });
 
@@ -35,6 +30,7 @@ class ClaimFundingButton extends React.PureComponent {
 
   handleSubmit = () => {
     const {
+      gasLimitConfig,
       web3Redux,
       ChallengeProof,
       addresses,
@@ -56,7 +52,7 @@ class ClaimFundingButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.CLAIM_FUNDING || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -145,6 +141,7 @@ ClaimFundingButton.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   checkProposalRequirements: func.isRequired,
+  gasLimitConfig: object.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -159,8 +156,9 @@ ClaimFundingButton.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/claim-results.js
+++ b/src/pages/proposals/proposal-buttons/claim-results.js
@@ -16,7 +16,7 @@ import { withSearchTransactions } from '@digix/gov-ui/api/graphql-queries/transa
 
 import getContract from '@digix/gov-ui/utils/contracts';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE, MAX_PEOPLE_PER_CLAIM } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE, MAX_PEOPLE_PER_CLAIM } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import MultiStepClaim from '@digix/gov-ui/components/common/blocks/overlay/claim-approval';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
@@ -76,11 +76,12 @@ class ClaimResultsButton extends React.PureComponent {
 
   handleSubmit = useMaxClaim => () => {
     const {
+      gasLimitConfig,
       web3Redux,
       ChallengeProof,
       addresses,
       proposal,
-      proposal: { currentVotingRound = 0, proposalId },
+      proposal: { currentVotingRound = 0, isSpecial, proposalId },
       translations: { snackbars },
     } = this.props;
 
@@ -97,9 +98,11 @@ class ClaimResultsButton extends React.PureComponent {
       header: snackbars.claimResult.TxUiHeader,
       type: 'txVisualization',
     };
+
+    const gasLimit = isSpecial ? gasLimitConfig.CLAIM_SPECIAL_VOTING : gasLimitConfig.CLAIM_VOTING;
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimit || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -250,6 +253,7 @@ ClaimResultsButton.propTypes = {
   checkProposalRequirements: func.isRequired,
   daoConfig: object.isRequired,
   daoDetails: object.isRequired,
+  gasLimitConfig: object.isRequired,
   pendingTransactions: object,
   showHideAlert: func.isRequired,
   getDaoConfig: func.isRequired,
@@ -275,6 +279,7 @@ const mapStateToProps = state => ({
   addresses: getAddresses(state),
   daoConfig: state.infoServer.DaoConfig,
   daoDetails: state.infoServer.DaoDetails,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/endorse.js
+++ b/src/pages/proposals/proposal-buttons/endorse.js
@@ -12,12 +12,7 @@ import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import getContract from '@digix/gov-ui/utils/contracts';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import {
-  ProposalStages,
-  DEFAULT_GAS,
-  DEFAULT_GAS_PRICE,
-  EMPTY_HASH,
-} from '@digix/gov-ui/constants';
+import { ProposalStages, DEFAULT_GAS_PRICE, EMPTY_HASH } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -35,6 +30,7 @@ class EndorseProjectButton extends React.PureComponent {
 
   handleSubmit = () => {
     const {
+      gasLimitConfig,
       web3Redux,
       ChallengeProof,
       addresses,
@@ -55,7 +51,7 @@ class EndorseProjectButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.ENDORSE_PROPOSAL || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -121,6 +117,7 @@ EndorseProjectButton.propTypes = {
   isModerator: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  gasLimitConfig: object.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -136,8 +133,9 @@ EndorseProjectButton.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/finalize.js
+++ b/src/pages/proposals/proposal-buttons/finalize.js
@@ -12,12 +12,7 @@ import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import getContract from '@digix/gov-ui/utils/contracts';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import {
-  ProposalStages,
-  DEFAULT_GAS,
-  DEFAULT_GAS_PRICE,
-  EMPTY_HASH,
-} from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE, EMPTY_HASH, ProposalStages } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -49,7 +44,14 @@ class FinalizeProjectButton extends React.PureComponent {
     });
 
   handleSubmit = () => {
-    const { web3Redux, challengeProof, addresses, proposalId, translations } = this.props;
+    const {
+      addresses,
+      challengeProof,
+      gasLimitConfig,
+      proposalId,
+      translations,
+      web3Redux,
+    } = this.props;
 
     const { abi, address } = getContract(Dao, network);
     const contract = web3Redux
@@ -64,7 +66,7 @@ class FinalizeProjectButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.FINALIZE_PROPOSAL || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -168,6 +170,7 @@ FinalizeProjectButton.propTypes = {
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   getDaoConfig: func.isRequired,
+  gasLimitConfig: object.isRequired,
   showTxSigningModal: func.isRequired,
   addresses: array.isRequired,
   history: object.isRequired,
@@ -182,9 +185,10 @@ FinalizeProjectButton.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  challengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  challengeProof: state.daoServer.ChallengeProof,
   daoConfig: state.infoServer.DaoConfig,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/milestone-completed.js
+++ b/src/pages/proposals/proposal-buttons/milestone-completed.js
@@ -12,7 +12,7 @@ import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 import getContract from '@digix/gov-ui/utils/contracts';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE, ProposalStages } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE, ProposalStages } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -28,6 +28,7 @@ class CompleteMilestoneButton extends React.PureComponent {
 
   handleSubmit = () => {
     const {
+      gasLimitConfig,
       web3Redux,
       ChallengeProof,
       addresses,
@@ -49,7 +50,7 @@ class CompleteMilestoneButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.FINISH_MILESTONE || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -138,6 +139,7 @@ CompleteMilestoneButton.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   checkProposalRequirements: func.isRequired,
+  gasLimitConfig: object.isRequired,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -152,8 +154,9 @@ CompleteMilestoneButton.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  ChallengeProof: state.daoServer.ChallengeProof,
   addresses: getAddresses(state),
+  ChallengeProof: state.daoServer.ChallengeProof,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
   txnTranslations: state.daoServer.Translations.data.signTransaction,
 });
 

--- a/src/pages/user/profile/buttons/redeem-badge.js
+++ b/src/pages/user/profile/buttons/redeem-badge.js
@@ -17,7 +17,7 @@ import getContract, { getDGDBadgeBalanceContract } from '@digix/gov-ui/utils/con
 import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
 
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
@@ -82,7 +82,7 @@ class RedeemBadgeButton extends React.PureComponent {
 
   handleSubmit = () => {
     const t = this.props.translations;
-    const { web3Redux, challengeProof, addresses } = this.props;
+    const { web3Redux, challengeProof, addresses, gasLimitConfig } = this.props;
 
     const { abi, address } = getContract(DaoStakeLocking, network);
     const contract = web3Redux
@@ -97,7 +97,7 @@ class RedeemBadgeButton extends React.PureComponent {
     };
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -179,6 +179,7 @@ RedeemBadgeButton.propTypes = {
   addresses: array.isRequired,
   daoInfo: object.isRequired,
   addressDetails: object.isRequired,
+  gasLimitConfig: object.isRequired,
   history: object.isRequired,
   getAddressDetails: func.isRequired,
   showRightPanel: func.isRequired,
@@ -191,6 +192,7 @@ const mapStateToProps = state => ({
   addressDetails: state.infoServer.AddressDetails.data,
   daoInfo: state.infoServer.DaoDetails.data,
   addresses: getAddresses(state),
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
   translations: state.daoServer.Translations.data.profile.ModeratorRequirements,
   txnTranslations: state.daoServer.Translations.data.signTransaction,
 });

--- a/src/pages/user/wallet/sections/participation-reward.js
+++ b/src/pages/user/wallet/sections/participation-reward.js
@@ -9,7 +9,7 @@ import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualiza
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 
 import { Button } from '@digix/gov-ui/components/common/elements/index';
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
+import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { getAddressDetails, getDaoDetails } from '@digix/gov-ui/reducers/info-server/actions';
@@ -51,7 +51,7 @@ class ParticipationReward extends React.Component {
 
   claimReward = () => {
     const tClaim = this.props.translations.ClaimReward;
-    const { addresses, ChallengeProof, web3Redux } = this.props;
+    const { addresses, ChallengeProof, gasLimitConfig, web3Redux } = this.props;
     const { abi, address } = getContract(DaoRewardsManager, network);
 
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
@@ -68,7 +68,7 @@ class ParticipationReward extends React.Component {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: DEFAULT_GAS,
+      gas: gasLimitConfig.CLAIM_REWARDS || gasLimitConfig.DEFAULT,
       ui,
     };
 
@@ -152,6 +152,7 @@ ParticipationReward.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
   DaoDetails: object.isRequired,
+  gasLimitConfig: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showHideAlert: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -166,6 +167,7 @@ const mapStateToProps = state => ({
   CanLockDgd: state.govUI.CanLockDgd,
   ChallengeProof: state.daoServer.ChallengeProof,
   DaoDetails: state.infoServer.DaoDetails,
+  gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
 const ParticipationRewardComponent = web3Connect(

--- a/src/reducers/info-server/actions.js
+++ b/src/reducers/info-server/actions.js
@@ -8,6 +8,7 @@ export const actions = {
   GET_PROPOSALS_COUNT: `${REDUX_PREFIX}GET_PROPOSALS_COUNT`,
   GET_PROPOSAL_DETAILS: `${REDUX_PREFIX}GET_PROPOSAL_DETAILS`,
   GET_BLOCK_CONFIG: `${REDUX_PREFIX}GET_BLOCK_CONFIG`,
+  GET_TX_CONFIG: `${REDUX_PREFIX}GET_TX_CONFIG`,
 };
 
 function doFetch(url) {
@@ -80,4 +81,8 @@ export function getProposalDetails(proposalId) {
 
 export function getBlockConfig() {
   return fetchData(`${INFO_SERVER}/config`, actions.GET_BLOCK_CONFIG);
+}
+
+export function getTxConfig() {
+  return fetchData(`${INFO_SERVER}/txConfigs`, actions.GET_TX_CONFIG);
 }

--- a/src/reducers/info-server/index.js
+++ b/src/reducers/info-server/index.js
@@ -42,6 +42,12 @@ const defaultState = {
     error: null,
     fetching: null,
   },
+  TxConfig: {
+    history: [],
+    data: {},
+    error: null,
+    fetching: null,
+  },
 };
 
 export default function(state = defaultState, action) {
@@ -163,7 +169,24 @@ export default function(state = defaultState, action) {
           ...action.payload,
         },
       };
-
+    case actions.GET_TX_CONFIG:
+      return {
+        ...state,
+        TxConfig: {
+          ...state.TxConfig,
+          ...action.payload,
+          history: !action.payload.data
+            ? state.TxConfig.history
+            : [
+                {
+                  ...action.payload.data,
+                  updated: action.payload.updated,
+                },
+              ]
+                .concat(state.TxConfig.history)
+                .slice(0, 100),
+        },
+      };
     default:
       return state;
   }

--- a/src/translations/english/project.json
+++ b/src/translations/english/project.json
@@ -94,7 +94,7 @@
     "reviewVoteResults": "Review Vote {{votingRound}} Results",
     "reviewVote": "Review Vote",
     "proposalVote": "Project Vote",
-    "timeLeftToCommit": "Time Left to End of Comit"
+    "timeLeftToCommit": "Time Left to End of Commit"
   },
   "alerts": {
     "failedModeratorVoting": "Your project fails the voting, either by voting results or its already past the deadline for claiming voting results. Please click the button below to claim your failed project and get back your collateral.",


### PR DESCRIPTION
Ref: [DGDG-478](https://tracker.digixdev.com/issue/DGDG-478)

### Dependencies

This is dependent on PR [#28](https://github.com/DigixGlobal/info-server/pull/28) from `info-server`.

### Dev Notes

The gas limits will come from the `/txConfigs` endpoint in `info-server`. If there isn't a specific limit set for the transaction, we'll use the `DEFAULT` value instead.

The transactions that use the default gas limit are:
- Approve Interaction
- Approve Badge Redemption
- Badge Redemption

### Test Plan
- For each transaction type, check that the value for `gas` in the `Details` tab. The value should be the same as the corresponding value in the `/txConfigs` endpoint.