### PR TITLE
[FEATURE] - Lazy loading of KYC Data

### DIFF
--- a/src/api/graphql-queries/kyc-officer.js
+++ b/src/api/graphql-queries/kyc-officer.js
@@ -1,8 +1,18 @@
 import gql from 'graphql-tag';
 
 export const searchKycQuery = gql`
-  query searchKycs($page: PositiveInteger, $pageSize: PositiveInteger, $status: KycStatusEnum) {
-    searchKycs(page: $page, pageSize: $pageSize, status: $status) {
+  query searchKycs(
+    $page: PositiveInteger
+    $pageSize: PositiveInteger
+    $status: KycStatusEnum
+    $sort: SearchKycFieldEnum
+    $sortBy: SortByEnum
+  ) {
+    searchKycs(page: $page, pageSize: $pageSize, status: $status, sort: $sort, sortBy: $sortBy) {
+      hasNextPage
+      hasPreviousPage
+      totalCount
+      totalPage
       edges {
         node {
           id

--- a/src/components/common/blocks/digix-table/index.js
+++ b/src/components/common/blocks/digix-table/index.js
@@ -2,17 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ReactTable from 'react-table';
+import Paging from './paging';
+
 import './react-table.css';
 
 export default class DigixTable extends React.Component {
   render() {
-    return <ReactTable {...this.props} />;
+    const { showPagination } = this.props;
+    return (
+      <ReactTable
+        {...this.props}
+        showPagination={showPagination}
+        PaginationComponent={showPagination ? Paging : undefined}
+        loadingText="Loading..."
+      />
+    );
   }
 }
 
-const { array, object, oneOfType } = PropTypes;
+const { array, object, bool, oneOfType } = PropTypes;
 
 DigixTable.propTypes = {
   data: oneOfType([array, object]).isRequired,
   columns: oneOfType([array, object]).isRequired,
+  showPagination: bool,
+};
+
+DigixTable.defaultProps = {
+  showPagination: true,
 };

--- a/src/components/common/blocks/digix-table/paging.js
+++ b/src/components/common/blocks/digix-table/paging.js
@@ -1,0 +1,140 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import { Input, Select, Icon } from '@digix/gov-ui/components/common/elements/index';
+
+import { Container, Next, Previous, Text } from './style';
+
+const rows = [
+  {
+    value: 10,
+    text: '10 rows per page',
+  },
+  {
+    value: 20,
+    text: '20 rows per page',
+  },
+  {
+    value: 50,
+    text: '50 rows per page',
+  },
+  {
+    value: 75,
+    text: '75 rows per page',
+  },
+  {
+    value: 100,
+    text: '100 rows per page',
+  },
+];
+
+class Paging extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      rowsPerPage: this.props.defaultPageSize,
+      selectedPage: 1,
+      useSelectedPage: false,
+    };
+  }
+
+  componentDidMount() {
+    document.addEventListener('keypress', this.handleKeyDown);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keypress', this.handleKeyDown);
+  }
+
+  onRowsChange = e => {
+    const { fetchData, handleLoading, currentPage } = this.props;
+    const { value } = e.target;
+    handleLoading(false, fetchData, Number(currentPage), Number(value));
+  };
+  onPageChange = e => {
+    const { value } = e.target;
+
+    this.setState({
+      selectedPage: value,
+      useSelectedPage: true,
+    });
+  };
+
+  handleKeyDown = e => {
+    if (e.key === 'Enter' || e.which === 13 || e.keyCode === 13) {
+      const { selectedPage, rowsPerPage } = this.state;
+      if (Number(selectedPage) > 0) {
+        const { fetchData, handleLoading } = this.props;
+        handleLoading(false, fetchData, Number(selectedPage), Number(rowsPerPage));
+      }
+    }
+  };
+
+  handleNextPage = () => {
+    const { fetchData, handleLoading, currentPage } = this.props;
+    const { rowsPerPage } = this.state;
+    const value = Number(currentPage) + 1;
+    handleLoading(false, fetchData, Number(value), Number(rowsPerPage));
+  };
+
+  handlePreviousPage = () => {
+    const { fetchData, handleLoading, currentPage } = this.props;
+    const { rowsPerPage } = this.state;
+    const value = Number(currentPage) - 1;
+    handleLoading(false, fetchData, Number(value), Number(rowsPerPage));
+  };
+
+  render() {
+    const { selectedPage, useSelectedPage } = this.state;
+    const { currentPage, pages } = this.props;
+    const { rowsPerPage } = this.state;
+
+    const isFirstPage = currentPage <= 1;
+    const isLastPage = currentPage >= pages;
+
+    return (
+      <Fragment>
+        <Container>
+          <Previous
+            disabled={isFirstPage}
+            onClick={this.handlePreviousPage}
+            data-digix="PREVIOUS-PAGE"
+          >
+            <Icon kind="arrow" />
+          </Previous>
+          <Text>Page </Text>
+          <Input
+            type="number"
+            value={useSelectedPage ? selectedPage : currentPage}
+            data-digix="PAGE-NUMBER"
+            small
+            width="100px"
+            onChange={e => this.onPageChange(e, this.props)}
+          />
+          <Text>of {pages}</Text>
+          <Select
+            id="rowsPerPage"
+            data-digix="ROWS-PER-PAGE"
+            onChange={e => this.onRowsChange(e)}
+            value={rowsPerPage}
+            width="200px"
+            items={rows}
+          />
+          <Next disabled={isLastPage} onClick={this.handleNextPage} data-digix="NEXT-PAGE">
+            <Icon kind="arrow" />
+          </Next>
+        </Container>
+      </Fragment>
+    );
+  }
+}
+
+const { number, func } = PropTypes;
+Paging.propTypes = {
+  pages: number.isRequired,
+  fetchData: func.isRequired,
+  defaultPageSize: number.isRequired,
+  handleLoading: func.isRequired,
+  currentPage: number.isRequired,
+};
+export default Paging;

--- a/src/components/common/blocks/digix-table/style.js
+++ b/src/components/common/blocks/digix-table/style.js
@@ -1,0 +1,55 @@
+import styled, { css } from 'styled-components';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
+
+const ButtonStyles = css`
+  background: ${props => props.theme.background.white.toString()};
+  border: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  border-radius: ${props => props.theme.borderRadius};
+  box-shadow: none;
+  font-size: 1.2rem;
+  margin: 0.5rem;
+  padding: 1rem;
+  top: 1rem;
+
+  div {
+    margin-right: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+
+  &:hover {
+    background: ${props => props.theme.background.white.toString()};
+    border: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  }
+`;
+
+export const Next = styled(Button)`
+  ${ButtonStyles};
+  right: 1rem;
+
+  div {
+    transform: rotate(275deg);
+  }
+`;
+
+export const Previous = styled(Button)`
+  ${ButtonStyles};
+  right: 5.5rem;
+
+  div {
+    transform: rotate(90deg);
+  }
+`;
+
+export const Container = styled.div`
+  display: flex;
+  align-content: center;
+  justify-content: center;
+`;
+
+export const Text = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+`;

--- a/src/components/common/blocks/loader/spinner.js
+++ b/src/components/common/blocks/loader/spinner.js
@@ -15,9 +15,10 @@ class Spinner extends React.Component {
       translations: {
         project: { spinner },
       },
+      height,
     } = this.props;
     return (
-      <Preloaders>
+      <Preloaders height={height}>
         <SpinnerWrapper>
           <Content>
             <Loader />
@@ -31,8 +32,14 @@ class Spinner extends React.Component {
   }
 }
 
+const { object, string } = PropTypes;
 Spinner.propTypes = {
-  translations: PropTypes.object.isRequired,
+  translations: object.isRequired,
+  height: string,
+};
+
+Spinner.defaultProps = {
+  height: undefined,
 };
 
 export default Spinner;

--- a/src/components/common/blocks/loader/style.js
+++ b/src/components/common/blocks/loader/style.js
@@ -7,7 +7,8 @@ export const Preloaders = styled.div`
   justify-content: center;
   align-items: center;
   position: absolute;
-  height: 100vh;
+  height: ${props => props.height || '100vh'};
+
   z-index: 1001;
   background: #fff;
 
@@ -334,5 +335,5 @@ export const Box = styled.div`
     props.col2 &&
     css`
       grid-column: span 2;
-    `};   
+    `};
 `;

--- a/src/pages/kyc/officer/index.js
+++ b/src/pages/kyc/officer/index.js
@@ -17,37 +17,39 @@ import { withFetchUser } from '@digix/gov-ui/api/graphql-queries/users';
 
 import { KycWrapper, Title, CTAContainer, TabButton } from '@digix/gov-ui/pages/kyc/officer/style';
 
-// import '@digix/gov-ui/pages/kyc/officer/modal_styles.css';
+import Spinner from '@digix/gov-ui/components/common/blocks/loader/spinner';
 
 const columns = [
   {
     Header: 'User Id',
-    id: 'id',
-    accessor: d => d.node.userId, // String-based value accessors!
+    id: 'USER_ID',
+    accessor: d => d.node.userId,
+    sortable: false,
+    filterable: false,
   },
   {
     Header: 'Status',
-    id: 'status',
+    id: 'STATUS',
     accessor: d => showStatusIcon(d.node.status),
   },
   {
     Header: 'Name',
-    id: 'Name', // Required because our accessor is not a string
+    id: 'NAME',
     accessor: d => `${d.node.firstName} ${d.node.lastName}`, // Custom value accessors!
   },
   {
-    Header: 'Country of Residence', // Required because our accessor is not a string
-    id: 'residence',
+    Header: 'Country of Residence',
+    id: 'COUNTRY_OF_RESIDENCE',
     accessor: d => d.node.residenceProof.residence.country,
   },
   {
-    Header: 'Nationality', // Required because our accessor is not a string
-    id: 'nationality',
-    accessor: d => d.node.nationality, // Custom value accessors!
+    Header: 'Nationality',
+    id: 'NATIONALITY',
+    accessor: d => d.node.nationality,
   },
   {
     Header: 'Last Updated',
-    id: 'updatedAt',
+    id: 'LAST_UPDATED',
     accessor: d => moment(d.node.updatedAt).format('YYYY-MM-DD h:mm:ss a'),
   },
 ];
@@ -59,6 +61,9 @@ class KycOfficerDashboard extends React.Component {
       selectedIndex: 0,
       filter: 'All',
       reloading: false,
+      page: 1,
+      pageSize: 10,
+      customLoading: false,
     };
   }
 
@@ -84,6 +89,12 @@ class KycOfficerDashboard extends React.Component {
     this.setState({ filter: status, reloading: false });
   };
 
+  handleFetch = (loading, onFetchData, page, pageSize) => {
+    this.setState({ customLoading: loading, page, pageSize }, () =>
+      onFetchData({ page: Number(page), pageSize: Number(pageSize) })
+    );
+  };
+
   renderInfo = () => {
     const { selected } = this.state;
 
@@ -98,7 +109,15 @@ class KycOfficerDashboard extends React.Component {
   };
 
   render() {
-    const { selected, selectedIndex, filter, reloading } = this.state;
+    const {
+      selected,
+      selectedIndex,
+      filter,
+      reloading,
+      page,
+      pageSize,
+      customLoading,
+    } = this.state;
     const { userData, history } = this.props;
     if (!userData || (userData && !userData.isKycOfficer)) history.push('/');
     return (
@@ -146,15 +165,32 @@ class KycOfficerDashboard extends React.Component {
             Rejected KYC Requests
           </TabButton>
         </CTAContainer>
-        {/* <FilterLabel>Showing {filter || 'All'} KYC</FilterLabel> */}
         <Query
           query={searchKycQuery}
           fetchPolicy="network-only"
-          variables={{ status: filter === 'All' ? undefined : filter }}
+          variables={{
+            status: filter === 'All' ? undefined : filter,
+            page,
+            pageSize,
+            sort: 'LAST_UPDATED',
+            sortBy: 'DESC',
+          }}
         >
           {({ data, loading, error, refetch }) => {
             if (loading) {
-              return <div>Loading...</div>;
+              return (
+                <Spinner
+                  translations={{
+                    project: {
+                      spinner: {
+                        pleaseWait: 'Please wait....',
+                        hold: 'Getting KYC data',
+                      },
+                    },
+                  }}
+                  height="100%"
+                />
+              );
             }
 
             if (error) {
@@ -162,11 +198,30 @@ class KycOfficerDashboard extends React.Component {
             }
             if (reloading) refetch();
 
+            const { totalCount, totalPage, edges: rows } = data.searchKycs;
             return (
               <Fragment>
                 <DigixTable
-                  data={data.searchKycs.edges}
+                  data={rows}
                   columns={columns}
+                  loading={loading || customLoading}
+                  manual
+                  totalRows={totalCount}
+                  currentPage={page}
+                  page={page}
+                  defaultPageSize={pageSize}
+                  pages={totalPage}
+                  showPagination
+                  handleLoading={this.handleFetch}
+                  fetchData={refetch}
+                  onSortedChange={newSorted => {
+                    refetch({
+                      page,
+                      pageSize,
+                      sort: newSorted[0].id,
+                      sortBy: newSorted[0].desc ? 'DESC' : 'ASC',
+                    });
+                  }}
                   getTrProps={(state, rowInfo) => {
                     if (rowInfo && rowInfo.row) {
                       return {

--- a/src/pages/kyc/officer/style.js
+++ b/src/pages/kyc/officer/style.js
@@ -47,7 +47,7 @@ export const Value = styled.div`
 `;
 
 export const TabButton = styled(Button)`
-  width: 25%;
+  width: 20%;
   border-radius: 0;
   box-shadow: none;
   border: 1px solid ${props => props.theme.buttonPrimary.border.fade.toString()};


### PR DESCRIPTION
Ref [DGDG-535](https://tracker.digixdev.com/issue/DGDG-535)

This feature replaces the existing sorting and pagination of KYC list which was done by loading KYC in one request and replaced the loading message similar to what is used when creating a project.

Test Plan
 - seed multiple KYC requests
 - change rows per page and/or navigate to different pages by either clicking on the arrows or inputting a page number on the text box

Note:
 - This requires changes from [Dao Server](https://github.com/DigixGlobal/dao-server/pull/60) so either use branch `feature/DGDG-535` or wait until it is merged to `sprint-8b` 