### PR TITLE
Track events for loading a wallet and signing the proof of control

### DIFF
--- a/src/analytics/loadWallet.js
+++ b/src/analytics/loadWallet.js
@@ -1,0 +1,75 @@
+import ReactGA from 'react-ga';
+import Analytics from '@digix/gov-ui/analytics';
+
+const CATEGORY = 'LoadWallet';
+const TXN_LABEL = 'LoadWalletTxn';
+const SIGN_MSG_TXN = 'SignProofofControlTxn';
+
+const ACTIONS = {
+  initiate: 'Initiate',
+  proceedToSelection: 'Proceed to Wallet Select',
+  selectWalletType: 'Select Wallet Type',
+  load: 'Load Wallet Successfully',
+  loadError: 'Load Wallet Error',
+  cancelLoading: 'Cancel Loading of Wallet',
+  signMessage: 'Sign Proof of Control',
+  cancelSigning: 'Cancel Signing Proof of Control',
+};
+
+const LABELS = {
+  walletType: 'Wallet Type',
+};
+
+export const LogLoadWallet = {
+  initiate: () => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.initiate,
+    });
+  },
+
+  proceedToSelection: () => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.proceedToSelection,
+    });
+  },
+
+  selectWalletType: type => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.selectWalletType,
+      label: `${LABELS.walletType}: ${type}`,
+    });
+  },
+
+  load: type => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.load,
+      label: `${LABELS.walletType}: ${type}`,
+    });
+  },
+
+  loadError: error => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.loadError,
+      value: error,
+    });
+  },
+
+  cancel: type => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.cancelLoading,
+      label: `${LABELS.walletType}: ${type}`,
+    });
+  },
+
+  txn: Analytics.LogTxn(CATEGORY, TXN_LABEL),
+};
+
+export const LogSignMessage = {
+  txn: Analytics.LogTxn(CATEGORY, SIGN_MSG_TXN),
+};

--- a/src/components/common/blocks/address-watcher/index.js
+++ b/src/components/common/blocks/address-watcher/index.js
@@ -24,6 +24,7 @@ import {
 import { fetchAddressQuery } from '@digix/gov-ui/api/graphql-queries/address';
 import { fetchDisplayName, fetchUserQuery } from '@digix/gov-ui/api/graphql-queries/users';
 import { getChallengeVanilla, proveChallenge } from '@digix/gov-ui/reducers/dao-server/actions';
+import { LogSignMessage } from '@digix/gov-ui/analytics/loadWallet';
 import { withApollo } from 'react-apollo';
 
 class AddressWatcher extends React.PureComponent {
@@ -83,7 +84,12 @@ class AddressWatcher extends React.PureComponent {
       const signMessage = new Promise(resolve =>
         resolve(
           this.props.showMsgSigningModal({
-            txData: { message, caption, translations },
+            txData: {
+              message,
+              caption,
+              translations,
+              logSignMessage: LogSignMessage,
+            },
             network,
           })
         )

--- a/src/components/common/blocks/navbar/wallet.js
+++ b/src/components/common/blocks/navbar/wallet.js
@@ -19,6 +19,7 @@ import {
 } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 import ErrorMessageOverlay from '@digix/gov-ui/components/common/blocks/overlay/error-message';
+import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class WalletButton extends React.Component {
   state = {
@@ -26,6 +27,7 @@ class WalletButton extends React.Component {
   };
 
   onWalletClick = () => {
+    LogLoadWallet.initiate();
     this.props.showHideWalletOverlay(true);
   };
 

--- a/src/components/common/blocks/wallet/intro.js
+++ b/src/components/common/blocks/wallet/intro.js
@@ -11,11 +11,13 @@ import {
 } from '@digix/gov-ui/components/common/common-styles';
 import { ActionContainer } from '@digix/gov-ui/components/common/blocks/wallet/style.js';
 import { WalletStages } from '@digix/gov-ui/constants';
+import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class Intro extends React.Component {
   handleButtonClick = () => {
     const { onChangeStage } = this.props;
     if (onChangeStage) {
+      LogLoadWallet.proceedToSelection();
       onChangeStage(WalletStages.LoadingWallet);
     }
   };

--- a/src/components/common/blocks/wallet/json/index.js
+++ b/src/components/common/blocks/wallet/json/index.js
@@ -7,6 +7,7 @@ import ImportKeystoreModal from 'spectrum-lightsuite/src/libs/material-ui/compon
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/';
 import Icon from '@digix/gov-ui/components/common/elements/icons';
+import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class V3Keystore extends React.Component {
   render() {
@@ -33,6 +34,7 @@ class V3Keystore extends React.Component {
           updateDefaultAddress
           translations={this.props.translations}
           commonTranslations={this.props.commonTranslations}
+          logLoadWallet={LogLoadWallet}
           trigger={
             <Button kind="round" secondary large showIcon fluid>
               <Icon kind="json" />

--- a/src/components/common/blocks/wallet/ledger/index.js
+++ b/src/components/common/blocks/wallet/ledger/index.js
@@ -8,6 +8,7 @@ import KeystoreCreationForm from 'spectrum-lightsuite/src/libs/material-ui/compo
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/';
 import Icon from '@digix/gov-ui/components/common/elements/icons';
+import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class Ledger extends React.Component {
   render() {
@@ -38,6 +39,7 @@ class Ledger extends React.Component {
           allowedKeystoreTypes={['ledger']}
           translations={this.props.translations}
           commonTranslations={this.props.commonTranslations}
+          logLoadWallet={LogLoadWallet}
           trigger={
             <Button kind="round" secondary large showIcon fluid>
               <Icon kind="ledger" />

--- a/src/components/common/blocks/wallet/metamask/index.js
+++ b/src/components/common/blocks/wallet/metamask/index.js
@@ -8,6 +8,7 @@ import KeystoreCreationForm from 'spectrum-lightsuite/src/libs/material-ui/compo
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/';
 import Icon from '@digix/gov-ui/components/common/elements/icons';
+import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class Metamask extends React.Component {
   render() {
@@ -38,6 +39,7 @@ class Metamask extends React.Component {
           allowedKeystoreTypes={['metamask']}
           translations={this.props.translations}
           commonTranslations={this.props.commonTranslations}
+          logLoadWallet={LogLoadWallet}
           trigger={
             <Button kind="round" secondary fluid large showIcon>
               <Icon kind="metamask" />

--- a/src/components/common/blocks/wallet/trezor/index.js
+++ b/src/components/common/blocks/wallet/trezor/index.js
@@ -8,6 +8,7 @@ import KeystoreCreationForm from 'spectrum-lightsuite/src/libs/material-ui/compo
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/';
 import Icon from '@digix/gov-ui/components/common/elements/icons';
+import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class Trezor extends React.Component {
   render() {
@@ -38,6 +39,7 @@ class Trezor extends React.Component {
           allowedKeystoreTypes={['trezor']}
           translations={this.props.translations}
           commonTranslations={this.props.commonTranslations}
+          logLoadWallet={LogLoadWallet}
           trigger={
             <Button kind="round" secondary fluid showIcon large>
               <Icon kind="trezor" />


### PR DESCRIPTION
Ref: [DGDG-526](https://tracker.digixdev.com/issue/DGDG-526)

This tracks the events for loading a wallet and signing the proof of control modal.

### Code Review Notes

Dependent on PR [#33](https://github.com/DigixGlobal/governance-ui/pull/33) in `governance-ui`.

### Test Plan
- In the development environment, set `debug` to `true` in `DEFAULT_OPTIONS` of `analytics/index`.
- Load different types of wallets and verify that the events are being tracked by checking the network logs or the console logs.
- In the staging/production environment, go through the Load Wallet funnel and check that the events are logged into the `Load Wallet Funnel` goal on the Google Analytics website.