### PR TITLE
[FIX] Remove console warnings for default gas limits

### DIFF
--- a/src/components/common/blocks/overlay/vote/commit.js
+++ b/src/components/common/blocks/overlay/vote/commit.js
@@ -268,7 +268,7 @@ const { array, func, object, string, bool } = PropTypes;
 CommitVote.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   history: object.isRequired,
   proposalId: string.isRequired,
   proposal: object.isRequired,
@@ -283,6 +283,7 @@ CommitVote.propTypes = {
 };
 
 CommitVote.defaultProps = {
+  gasLimitConfig: undefined,
   revoting: false,
 };
 

--- a/src/components/common/blocks/overlay/vote/reveal.js
+++ b/src/components/common/blocks/overlay/vote/reveal.js
@@ -216,7 +216,7 @@ const { array, func, object } = PropTypes;
 RevealVote.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   history: object.isRequired,
   proposal: object.isRequired,
   sendTransactionToDaoServer: func.isRequired,
@@ -226,6 +226,10 @@ RevealVote.propTypes = {
   web3Redux: object.isRequired,
   translations: object.isRequired,
   txnTranslations: object.isRequired,
+};
+
+RevealVote.defaultProps = {
+  gasLimitConfig: undefined,
 };
 
 const mapStateToProps = state => ({

--- a/src/pages/proposals/forms/documents.js
+++ b/src/pages/proposals/forms/documents.js
@@ -430,12 +430,16 @@ Documents.propTypes = {
   web3Redux: object.isRequired,
   history: object.isRequired,
   ChallengeProof: object.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
   match: object.isRequired,
   addresses: array.isRequired,
+};
+
+Documents.defaultProps = {
+  gasLimitConfig: undefined,
 };
 
 const mapStateToProps = state => ({

--- a/src/pages/proposals/proposal-buttons/abort.js
+++ b/src/pages/proposals/proposal-buttons/abort.js
@@ -134,7 +134,7 @@ AbortProjectButton.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   checkProposalRequirements: func.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -145,6 +145,7 @@ AbortProjectButton.propTypes = {
 };
 
 AbortProjectButton.defaultProps = {
+  gasLimitConfig: undefined,
   isProposer: false,
   finalVersionIpfsDoc: EMPTY_HASH_LONG,
 };

--- a/src/pages/proposals/proposal-buttons/claim-approval.js
+++ b/src/pages/proposals/proposal-buttons/claim-approval.js
@@ -226,7 +226,7 @@ ClaimApprovalButton.propTypes = {
   proposalId: string.isRequired,
   daoConfig: object.isRequired,
   daoDetails: object.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   pendingTransactions: object,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
@@ -248,6 +248,7 @@ ClaimApprovalButton.propTypes = {
 
 ClaimApprovalButton.defaultProps = {
   draftVoting: undefined,
+  gasLimitConfig: undefined,
   votingStage: undefined,
   pendingTransactions: undefined,
   transactions: undefined,

--- a/src/pages/proposals/proposal-buttons/claim-funding.js
+++ b/src/pages/proposals/proposal-buttons/claim-funding.js
@@ -141,7 +141,7 @@ ClaimFundingButton.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   checkProposalRequirements: func.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -152,6 +152,7 @@ ClaimFundingButton.propTypes = {
 };
 
 ClaimFundingButton.defaultProps = {
+  gasLimitConfig: undefined,
   isProposer: false,
 };
 

--- a/src/pages/proposals/proposal-buttons/claim-results.js
+++ b/src/pages/proposals/proposal-buttons/claim-results.js
@@ -253,7 +253,7 @@ ClaimResultsButton.propTypes = {
   checkProposalRequirements: func.isRequired,
   daoConfig: object.isRequired,
   daoDetails: object.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   pendingTransactions: object,
   showHideAlert: func.isRequired,
   getDaoConfig: func.isRequired,
@@ -269,6 +269,7 @@ ClaimResultsButton.propTypes = {
 };
 
 ClaimResultsButton.defaultProps = {
+  gasLimitConfig: undefined,
   isProposer: false,
   pendingTransactions: undefined,
   transactions: undefined,

--- a/src/pages/proposals/proposal-buttons/endorse.js
+++ b/src/pages/proposals/proposal-buttons/endorse.js
@@ -117,7 +117,7 @@ EndorseProjectButton.propTypes = {
   isModerator: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -128,8 +128,9 @@ EndorseProjectButton.propTypes = {
 };
 
 EndorseProjectButton.defaultProps = {
-  isModerator: false,
   endorser: EMPTY_HASH,
+  gasLimitConfig: undefined,
+  isModerator: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/pages/proposals/proposal-buttons/finalize.js
+++ b/src/pages/proposals/proposal-buttons/finalize.js
@@ -161,7 +161,7 @@ FinalizeProjectButton.propTypes = {
   stage: string.isRequired,
   endorser: string,
   proposalId: string.isRequired,
-  finalVersionIpfsDoc: string.isRequired,
+  finalVersionIpfsDoc: string,
   isProposer: bool,
   web3Redux: object.isRequired,
   daoConfig: object.isRequired,
@@ -170,7 +170,7 @@ FinalizeProjectButton.propTypes = {
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   getDaoConfig: func.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   showTxSigningModal: func.isRequired,
   addresses: array.isRequired,
   history: object.isRequired,
@@ -180,8 +180,10 @@ FinalizeProjectButton.propTypes = {
 };
 
 FinalizeProjectButton.defaultProps = {
-  isProposer: false,
   endorser: EMPTY_HASH,
+  finalVersionIpfsDoc: '',
+  gasLimitConfig: undefined,
+  isProposer: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/pages/proposals/proposal-buttons/milestone-completed.js
+++ b/src/pages/proposals/proposal-buttons/milestone-completed.js
@@ -139,7 +139,7 @@ CompleteMilestoneButton.propTypes = {
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
   checkProposalRequirements: func.isRequired,
-  gasLimitConfig: object.isRequired,
+  gasLimitConfig: object,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,
   showTxSigningModal: func.isRequired,
@@ -150,6 +150,7 @@ CompleteMilestoneButton.propTypes = {
 };
 
 CompleteMilestoneButton.defaultProps = {
+  gasLimitConfig: undefined,
   isProposer: false,
 };
 


### PR DESCRIPTION
Ref: [DGDG-478](https://tracker.digixdev.com/issue/DGDG-478)

The warnings appear when the user views project pages without loading a wallet. This diff should remove the warnings.

### Test Plan
- View a project as a guest user. There should be no console warnings.
- The gas limits should still be there when you load a wallet and do a transaction.