### PR TITLE
Track events for commit/reveal voting

### DIFF
--- a/src/analytics/commitVote.js
+++ b/src/analytics/commitVote.js
@@ -1,0 +1,74 @@
+import ReactGA from 'react-ga';
+import Analytics from '@digix/gov-ui/analytics';
+
+const CATEGORY = 'CommitVote';
+const TXN_LABEL = 'CommitVoteTxn';
+
+const ACTIONS = {
+  initiate: 'Initiate',
+  changeVote: 'Change Vote',
+  proceedToChangeVote: 'Proceed to Change Vote',
+  selectVote: 'Select Vote Option',
+  downloadJson: 'Download Json',
+  submit: 'Submit',
+};
+
+const LABELS = {
+  yes: 'Yes',
+  no: 'No',
+  proposal: 'Proposal ID',
+  userType: 'User Type:',
+};
+
+const LogCommitVote = {
+  initiate: type => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.initiate,
+      label: `${LABELS.userType}: ${type}`,
+    });
+  },
+
+  changeVote: type => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.changeVote,
+      label: `${LABELS.userType}: ${type}`,
+    });
+  },
+
+  proceedToChangeVote: () => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.proceedToChangeVote,
+    });
+  },
+
+  selectVote: vote => {
+    const label = vote ? LABELS.yes : LABELS.no;
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.selectVote,
+      label,
+    });
+  },
+
+  downloadJson: () => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.downloadJson,
+    });
+  },
+
+  submit: proposalId => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.submit,
+      label: `${LABELS.proposal}: ${proposalId}`,
+    });
+  },
+
+  txn: Analytics.LogTxn(CATEGORY, TXN_LABEL),
+};
+
+export default LogCommitVote;

--- a/src/analytics/revealVote.js
+++ b/src/analytics/revealVote.js
@@ -1,0 +1,45 @@
+import ReactGA from 'react-ga';
+import Analytics from '@digix/gov-ui/analytics';
+
+const CATEGORY = 'RevealVote';
+const TXN_LABEL = 'RevealVoteTxn';
+
+const ACTIONS = {
+  initiate: 'Initiate',
+  uploadJson: 'Upload Json',
+  submit: 'Submit',
+};
+
+const LABELS = {
+  proposal: 'Proposal ID',
+  userType: 'User Type:',
+};
+
+const LogRevealVote = {
+  initiate: type => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.initiate,
+      label: `${LABELS.userType}: ${type}`,
+    });
+  },
+
+  uploadJson: () => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.uploadJson,
+    });
+  },
+
+  submit: proposalId => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.submit,
+      label: `${LABELS.proposal}: ${proposalId}`,
+    });
+  },
+
+  txn: Analytics.LogTxn(CATEGORY, TXN_LABEL),
+};
+
+export default LogRevealVote;

--- a/src/components/common/blocks/overlay/vote/commit.js
+++ b/src/components/common/blocks/overlay/vote/commit.js
@@ -6,7 +6,6 @@ import secureRandom from 'secure-random';
 import moment from 'moment';
 
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
-
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
 import {
   IntroContainer,
@@ -22,13 +21,12 @@ import {
   DownloadJson,
 } from '@digix/gov-ui/components/common/blocks/overlay/vote/style';
 
-import { buffer2Hex } from '@digix/gov-ui/utils/helpers';
-
 import Dao from '@digix/dao-contracts/build/contracts/DaoVoting.json';
 import getContract from '@digix/gov-ui/utils/contracts';
+import LogCommitVote from '@digix/gov-ui/analytics/commitVote';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-
+import { buffer2Hex } from '@digix/gov-ui/utils/helpers';
 import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
@@ -37,7 +35,7 @@ import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/act
 
 const network = SpectrumConfig.defaultNetworks[0];
 
-class CommitVote extends React.Component {
+class CommitVoteOverlay extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -90,6 +88,7 @@ class CommitVote extends React.Component {
 
   setVote = vote => {
     const random = secureRandom(32, { type: 'Uint8Array' });
+    LogCommitVote.selectVote(vote);
 
     this.setState({
       hasVoted: true,
@@ -99,10 +98,12 @@ class CommitVote extends React.Component {
   };
 
   handleChangeVote = () => {
+    LogCommitVote.proceedToChangeVote();
     this.setState({ changeVote: true });
   };
 
   handleDownload = () => {
+    LogCommitVote.downloadJson();
     this.setState({ hasDownloaded: true });
   };
 
@@ -116,6 +117,9 @@ class CommitVote extends React.Component {
       proposal: { currentVotingRound = 0, isSpecial },
       translations: { snackbars },
     } = this.props;
+
+    LogCommitVote.submit(proposalId);
+
     const { abi, address } = getContract(Dao, network);
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
     const hash = web3Utils.soliditySha3(
@@ -153,6 +157,7 @@ class CommitVote extends React.Component {
       network,
       web3Params,
       ui,
+      logTxn: LogCommitVote.txn,
       showTxSigningModal: this.props.showTxSigningModal,
       translations: this.props.txnTranslations,
     };
@@ -265,7 +270,7 @@ class CommitVote extends React.Component {
 
 const { array, func, object, string, bool } = PropTypes;
 
-CommitVote.propTypes = {
+CommitVoteOverlay.propTypes = {
   addresses: array.isRequired,
   ChallengeProof: object.isRequired,
   gasLimitConfig: object,
@@ -282,7 +287,7 @@ CommitVote.propTypes = {
   txnTranslations: object.isRequired,
 };
 
-CommitVote.defaultProps = {
+CommitVoteOverlay.defaultProps = {
   gasLimitConfig: undefined,
   revoting: false,
 };
@@ -302,5 +307,5 @@ export default web3Connect(
       showRightPanelAction: showRightPanel,
       showTxSigningModal,
     }
-  )(CommitVote)
+  )(CommitVoteOverlay)
 );

--- a/src/components/common/blocks/overlay/vote/reveal.js
+++ b/src/components/common/blocks/overlay/vote/reveal.js
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
-
-import Button from '@digix/gov-ui/components/common/elements/buttons/index';
 import {
   IntroContainer,
   OverlayHeader as Header,
@@ -13,16 +10,18 @@ import {
   ErrorCaption,
 } from '@digix/gov-ui/components/common/common-styles';
 
+import Button from '@digix/gov-ui/components/common/elements/buttons/index';
 import Dao from '@digix/dao-contracts/build/contracts/DaoVoting.json';
 import getContract from '@digix/gov-ui/utils/contracts';
+import LogRevealVote from '@digix/gov-ui/analytics/revealVote';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-
 import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import { showHideAlert, showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
+import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 
 const network = SpectrumConfig.defaultNetworks[0];
 
@@ -84,6 +83,8 @@ class RevealVote extends React.Component {
       proposal: { currentVotingRound, proposalId, isSpecial },
       translations: { snackbars },
     } = this.props;
+
+    LogRevealVote.submit(proposalId);
     const { abi, address } = getContract(Dao, network);
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
 
@@ -118,6 +119,7 @@ class RevealVote extends React.Component {
       network,
       web3Params,
       ui,
+      logTxn: LogRevealVote.txn,
       showTxSigningModal: this.props.showTxSigningModal,
       translations: this.props.txnTranslations,
     };
@@ -126,6 +128,8 @@ class RevealVote extends React.Component {
   };
 
   handleUpload = e => {
+    LogRevealVote.uploadJson();
+
     let error;
     const {
       translations: {

--- a/src/pages/proposals/proposal-buttons/reveal-button.js
+++ b/src/pages/proposals/proposal-buttons/reveal-button.js
@@ -3,14 +3,17 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/index';
+import LogRevealVote from '@digix/gov-ui/analytics/revealVote';
 import RevealVoteOverlay from '@digix/gov-ui/components/common/blocks/overlay/vote/reveal';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { getUserStatus } from '@digix/gov-ui/utils/helpers';
 import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
-import { VotingStages } from '@digix/gov-ui/constants';
+import { UserStatus, VotingStages } from '@digix/gov-ui/constants';
 
 class RevealVoteButton extends React.PureComponent {
   showOverlay = () => {
     const {
+      AddressDetails,
       history,
       proposalId,
       showRightPanelAction,
@@ -18,6 +21,9 @@ class RevealVoteButton extends React.PureComponent {
       translations,
       txnTranslations,
     } = this.props;
+
+    const userType = getUserStatus(AddressDetails.data, UserStatus);
+    LogRevealVote.initiate(userType);
 
     showRightPanelAction({
       component: (
@@ -75,6 +81,7 @@ class RevealVoteButton extends React.PureComponent {
 const { bool, func, object, string } = PropTypes;
 
 RevealVoteButton.propTypes = {
+  AddressDetails: object.isRequired,
   isParticipant: bool,
   proposal: object.isRequired,
   proposalId: string.isRequired,
@@ -91,7 +98,7 @@ RevealVoteButton.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  addressDetails: state.infoServer.AddressDetails,
+  AddressDetails: state.infoServer.AddressDetails,
 });
 
 export default web3Connect(

--- a/src/pages/proposals/proposal-buttons/vote-commit.js
+++ b/src/pages/proposals/proposal-buttons/vote-commit.js
@@ -4,13 +4,16 @@ import { connect } from 'react-redux';
 
 import Button from '@digix/gov-ui/components/common/elements/buttons/index';
 import CommitVoteOverlay from '@digix/gov-ui/components/common/blocks/overlay/vote/commit';
+import LogCommitVote from '@digix/gov-ui/analytics/commitVote';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { getUserStatus } from '@digix/gov-ui/utils/helpers';
 import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
-import { VotingStages } from '@digix/gov-ui/constants';
+import { UserStatus, VotingStages } from '@digix/gov-ui/constants';
 
 class CommitVoteButton extends React.PureComponent {
   showOverlay = hasVoted => {
     const {
+      AddressDetails,
       history,
       proposalId,
       showRightPanelAction,
@@ -18,6 +21,13 @@ class CommitVoteButton extends React.PureComponent {
       translations,
       txnTranslations,
     } = this.props;
+
+    const userType = getUserStatus(AddressDetails.data, UserStatus);
+    if (hasVoted) {
+      LogCommitVote.changeVote(userType);
+    } else {
+      LogCommitVote.initiate(userType);
+    }
 
     showRightPanelAction({
       component: (
@@ -68,6 +78,7 @@ class CommitVoteButton extends React.PureComponent {
 const { bool, func, object, string } = PropTypes;
 
 CommitVoteButton.propTypes = {
+  AddressDetails: object.isRequired,
   isParticipant: bool,
   proposal: object.isRequired,
   proposalId: string.isRequired,
@@ -83,7 +94,9 @@ CommitVoteButton.defaultProps = {
   votes: undefined,
 };
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+  AddressDetails: state.infoServer.AddressDetails,
+});
 
 export default web3Connect(
   connect(


### PR DESCRIPTION
Ref: [DGDG-526](https://tracker.digixdev.com/issue/DGDG-526)

This tracks the events for participant voting, which includes the commit and reveal scheme.

### Test Plan
- In the development environment, set `debug` to `true` in `DEFAULT_OPTIONS` of `analytics/index`.
- Create a special project.
- Commit/Reveal votes on the project and verify that the events are being tracked by checking the network logs or the console logs. You can see the events [here](https://docs.google.com/spreadsheets/d/1RAknTGo74dogK-MOzOlYwoXiFJOqoGX6ynIL4KP82Ec/edit#gid=1676405102&range=120:120)
- In the staging/production environment, go through the Load Wallet funnel and check that the events are logged into the `Participant Voting` goal on the Google Analytics website.