### PR TITLE
Track project views

### DIFF
--- a/src/analytics/dashboard.js
+++ b/src/analytics/dashboard.js
@@ -1,0 +1,23 @@
+import ReactGA from 'react-ga';
+
+const CATEGORY = 'DashboardEvent';
+
+const ACTIONS = {
+  viewProject: 'View Project',
+};
+
+const LABELS = {
+  userType: 'User Type',
+};
+
+const LogDashboard = {
+  viewProject: userType => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.viewProject,
+      label: `${LABELS.userType}: ${userType}`,
+    });
+  },
+};
+
+export default LogDashboard;

--- a/src/components/proposal-card/index.js
+++ b/src/components/proposal-card/index.js
@@ -23,6 +23,7 @@ export default class ProposalCard extends React.Component {
           <Proposal
             displayName={displayName}
             details={proposal}
+            history={history}
             title={proposal.title}
             userDetails={userDetails}
             liked={liked}

--- a/src/components/proposal-card/milestones.js
+++ b/src/components/proposal-card/milestones.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
+import LogDashboard from '@digix/gov-ui/analytics/dashboard';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
-
 import { Details, Info, Label, Data } from '@digix/gov-ui/components/proposal-card/style';
+import { getUserStatus } from '@digix/gov-ui/utils/helpers';
+import { UserStatus } from '@digix/gov-ui/constants';
 
 const determineDeadline = proposal => {
   let deadline = Date.now();
@@ -40,9 +43,12 @@ const determineDeadline = proposal => {
   return deadline;
 };
 
-export default class ProposalCardMilestone extends React.Component {
+class ProposalCardMilestone extends React.Component {
   redirectToProposalPage = () => {
-    const { details, history } = this.props;
+    const { AddressDetails, details, history } = this.props;
+
+    const userType = getUserStatus(AddressDetails.data, UserStatus);
+    LogDashboard.viewProject(userType);
     history.push(`/proposals/${details.proposalId}`);
   };
 
@@ -79,8 +85,25 @@ export default class ProposalCardMilestone extends React.Component {
   }
 }
 
+const { object } = PropTypes;
 ProposalCardMilestone.propTypes = {
-  details: PropTypes.object.isRequired,
-  history: PropTypes.object.isRequired,
-  translations: PropTypes.object.isRequired,
+  AddressDetails: object,
+  details: object.isRequired,
+  history: object.isRequired,
+  translations: object.isRequired,
 };
+
+ProposalCardMilestone.defaultProps = {
+  AddressDetails: {
+    data: undefined,
+  },
+};
+
+const mapStateToProps = state => ({
+  AddressDetails: state.infoServer.AddressDetails,
+});
+
+export default connect(
+  mapStateToProps,
+  {}
+)(ProposalCardMilestone);

--- a/src/components/proposal-card/style.js
+++ b/src/components/proposal-card/style.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import { Link } from 'react-router-dom';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { H2 } from '@digix/gov-ui/components/common/common-styles';
 import { media } from '@digix/gov-ui/components/common/breakpoints';
@@ -174,25 +173,27 @@ export const AuthorName = styled.a`
   font-weight: 600;
 `;
 
-export const ViewLink = styled(Link)`
+export const ViewLink = styled.button`
+  background: none;
+  border: none;
   color: ${props => props.theme.link.secondary.base.toString()};
-  font-family: 'Futura PT Book', sans-serif;
+  cursor: pointer;
   display: none;
+  font-family: 'Futura PT Book', sans-serif;
   text-decoration: underline;
   text-transform: uppercase;
+
   &:hover {
     text-decoration: none;
   }
-  &:link,
-  &:visited {
-    text-decoration: underline;
-  }
+
   ${props =>
     props.disabled &&
     css`
       color: ${props.theme.link.disabled.light.toString()};
       pointer-events: none;
     `}
+
   ${media.tablet`
     display: inline-block;
   `};

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -58,7 +58,7 @@ export const formatPercentage = num => {
 
 export const getUserStatus = (addressDetails, translation) => {
   if (!addressDetails) {
-    return null;
+    return UserStatus.guest;
   }
 
   if (addressDetails.isModerator) {


### PR DESCRIPTION
Ref: [DGDG-526](https://tracker.digixdev.com/issue/DGDG-526)

This tracks the clicks for the view/participate button for the Proposal cards on the Dashboard.

### Test Plan
- In the development environment, set `debug` to `true` in `DEFAULT_OPTIONS` of `analytics/index`.
- Click on the view/participate button and verify that the event is being tracked by checking the network logs or the console logs. This should work regardless if the user loaded a wallet or not.
- In the staging/production environment, go through the Load Wallet funnel and check that the events are logged into the `View Project` goal on the Google Analytics website.