### PR TITLE
[Fix] - Vote/Reveal button on Special Proposals

### DIFF
--- a/src/pages/proposals/proposal-buttons/reveal-button.js
+++ b/src/pages/proposals/proposal-buttons/reveal-button.js
@@ -49,7 +49,7 @@ class RevealVoteButton extends React.PureComponent {
     if (
       !isParticipant ||
       (!proposal.draftVoting && !isSpecial) ||
-      (!isActive || isSpecial) ||
+      (!isActive && isSpecial) ||
       (proposal.votingStage !== VotingStages.commit && !isSpecial) ||
       hasRevealed ||
       !hasVoted

--- a/src/pages/proposals/proposal-buttons/vote-commit.js
+++ b/src/pages/proposals/proposal-buttons/vote-commit.js
@@ -47,7 +47,6 @@ class CommitVoteButton extends React.PureComponent {
     const votingRound = vote ? vote.votingRound[currentVotingRound || 0] : undefined;
     const hasVoted = votingRound ? votingRound.commit : false;
 
-    console.log({ isActive });
     if (
       !isParticipant ||
       (!proposal.draftVoting && !isSpecial) ||


### PR DESCRIPTION
This fixes an issue where Vote/Reveal Button shows for non-authenticated users.

Test Plan
 - Create a special proposal `truffle exec scripts/digixdao-interactions/create-special-proposal.js`
 - View Special Proposal details
 - Verify that Vote and/or Reveal button is not visible
 - Load a participant/Moderator wallet and verify that Vote and/or Reveal (visible only when user has voted) is visible