### PR TITLE
Allow pdf upload for KYC

### DIFF
--- a/src/api/graphql-queries/kyc-officer.js
+++ b/src/api/graphql-queries/kyc-officer.js
@@ -37,6 +37,8 @@ export const searchKycQuery = gql`
             expirationDate
             type
             image {
+              contentType
+              filename
               dataUrl
             }
           }
@@ -53,7 +55,6 @@ export const searchKycQuery = gql`
             image {
               contentType
               filename
-              fileSize
               dataUrl
             }
           }
@@ -62,7 +63,6 @@ export const searchKycQuery = gql`
             image {
               contentType
               filename
-              fileSize
               dataUrl
             }
           }

--- a/src/components/common/blocks/overlay/kyc/form-step.js
+++ b/src/components/common/blocks/overlay/kyc/form-step.js
@@ -1,11 +1,16 @@
 import React from 'react';
+import Modal from 'react-responsive-modal';
 import PropTypes from 'prop-types';
 
-import { Button, Input, Select } from '@digix/gov-ui/components/common/elements/index';
+import PDFViewer from '@digix/gov-ui/components/common/elements/pdf-viewer';
+import { Button, Icon, Input, Select } from '@digix/gov-ui/components/common/elements/index';
 import { Label } from '@digix/gov-ui/components/common/common-styles';
 import {
-  FieldItem,
+  Enlarge,
   ErrorMessage,
+  FieldItem,
+  FilePreview,
+  ModalCta,
 } from '@digix/gov-ui/components/common/blocks/overlay/kyc/style.js';
 
 // NOTE: extend this class and add to KycOverlay.STAGES when adding a new step
@@ -17,6 +22,7 @@ class KycFormStep extends React.Component {
 
     this.state = {
       formValues: {},
+      openFilePreview: false,
     };
 
     this.FIELD_TYPES = {
@@ -25,16 +31,16 @@ class KycFormStep extends React.Component {
       select: 3,
     };
 
+    this.VALID_IMAGE_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png'];
+    this.VALID_FILE_TYPES = this.VALID_IMAGE_FILE_TYPES.concat(['application/pdf']);
+
     this.REGEX = {
       date: /^\d{4}-\d{2}-\d{2}$/,
       nonEmptyString: /^(?!\s*$).+/,
       phoneNumber: /^[+]?[0-9][0-9]+[0-9]+$/,
     };
 
-    this.LABELS = {
-      imageFile: t.Labels.file,
-    };
-
+    this.LABELS = t.Labels;
     this.ERROR_MESSAGES = { ...t.Errors };
 
     // NOTE: replace this with your own validation rules when extending the class
@@ -44,7 +50,7 @@ class KycFormStep extends React.Component {
         // function that checks the validity of the field
         // it returns the object { isValid, errorMessage }
         // where the errorMessage will show up if isValid === false
-        customValidation: this.isImageFileValid,
+        customValidation: this.isFileValid,
 
         // default message to show when input fails to match the pattern
         defaultErrorMessage: this.ERROR_MESSAGES.required,
@@ -70,6 +76,14 @@ class KycFormStep extends React.Component {
   }
 
   getInputElement = fieldName => document.querySelector(`input[name="${fieldName}"]`);
+
+  getAcceptableFileTypes = () => {
+    if (this.state.proofMethod) {
+      return this.VALID_IMAGE_FILE_TYPES;
+    }
+
+    return this.VALID_FILE_TYPES;
+  };
 
   isDateValid = fieldName => {
     const inputElement = this.getInputElement(fieldName);
@@ -118,7 +132,7 @@ class KycFormStep extends React.Component {
     };
   };
 
-  isImageFileValid = fieldName => {
+  isFileValid = fieldName => {
     // if image is captured by webcam, we can assume it's valid
     // since it will have already passed the regex for it
     if (this.state.proofMethod === 'webcam') {
@@ -138,12 +152,13 @@ class KycFormStep extends React.Component {
     }
 
     // check file type
-    const VALID_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png'];
     const file = inputElement.files[0];
-    if (!VALID_FILE_TYPES.includes(file.type)) {
+    if (!this.getAcceptableFileTypes().includes(file.type)) {
+      const { isValid, isImage } = this.ERROR_MESSAGES.file;
+      const typeError = this.state.proofMethod ? isImage : isValid;
       return {
         isValid: false,
-        errorMessage: this.ERROR_MESSAGES.file.isImage,
+        errorMessage: typeError,
       };
     }
 
@@ -212,6 +227,12 @@ class KycFormStep extends React.Component {
     return fieldsWithErrors.length === 0;
   }
 
+  toggleFilePreview() {
+    this.setState({
+      openFilePreview: !this.state.openFilePreview,
+    });
+  }
+
   updateState(fieldName, value) {
     // if input is captured by webcam, it should already be saved in the state
     if (this.state.proofMethod === 'webcam') {
@@ -240,7 +261,7 @@ class KycFormStep extends React.Component {
 
   _renderFileInput = (fieldName, props) => (
     <Button
-      accept="image/*"
+      accept={this.getAcceptableFileTypes().join(',')}
       dataDigix={`KycForm-${fieldName}`}
       fluid
       id={fieldName}
@@ -328,6 +349,60 @@ class KycFormStep extends React.Component {
         {this._renderInputElement(rule.type, fieldName, props)}
         {rule.hasError && <ErrorMessage>{rule.errorMessage}</ErrorMessage>}
       </FieldItem>
+    );
+  };
+
+  renderFilePreview = fieldName => {
+    const fileSrc = this.state.formValues[fieldName];
+    const fileRules = this.VALIDATION_RULES[fieldName];
+    const isFilePreviewPdf = fileSrc.startsWith('data:application/pdf');
+
+    if (!fileSrc) {
+      return null;
+    }
+
+    return (
+      <div>
+        <Enlarge kind="text" onClick={() => this.toggleFilePreview()}>
+          <Icon kind="magnifier" />
+        </Enlarge>
+        {isFilePreviewPdf && <PDFViewer file={fileSrc} showNav={false} />}
+        {!isFilePreviewPdf && (
+          <img src={fileSrc} alt={fileRules.alt} data-digix={fileRules.dataDigix} />
+        )}
+      </div>
+    );
+  };
+
+  renderFilePreviewModal = fieldName => {
+    const fileSrc = this.state.formValues[fieldName];
+    const isFilePreviewPdf = fileSrc.startsWith('data:application/pdf');
+
+    return (
+      <Modal
+        open={!!this.state.openFilePreview}
+        onClose={() => this.toggleFilePreview()}
+        showCloseIcon={false}
+        styles={{
+          modal: {
+            maxWidth: '45%',
+            width: '100%',
+          },
+          overlay: {
+            zIndex: 1100,
+          },
+        }}
+      >
+        <FilePreview>
+          {!isFilePreviewPdf && <img alt="" style={{ width: '100%' }} src={fileSrc} />}
+          {isFilePreviewPdf && <PDFViewer file={fileSrc} />}
+        </FilePreview>
+        <ModalCta>
+          <Button primary invert onClick={() => this.toggleFilePreview()}>
+            Close
+          </Button>
+        </ModalCta>
+      </Modal>
     );
   };
 }

--- a/src/components/common/blocks/overlay/kyc/steps/address.js
+++ b/src/components/common/blocks/overlay/kyc/steps/address.js
@@ -103,19 +103,20 @@ class KycOverlayAddress extends KycFormStep {
       },
 
       residenceProofDataUrl: {
-        customValidation: this.isImageFileValid,
+        customValidation: this.isFileValid,
         defaultErrorMessage: this.ERROR_MESSAGES.required,
         errorMessage: null,
         hasError: stateValues.residenceProofDataUrl ? false : undefined,
-        label: this.LABELS.imageFile,
+        label: this.LABELS.file,
         pattern: this.REGEX.nonEmptyString,
         type: this.FIELD_TYPES.fileInput,
+        alt: 'Residence Proof Preview',
+        dataDigix: 'KycForm-ResidenceProofPreview',
       },
     };
   }
 
   render() {
-    const { residenceProofDataUrl } = this.state.formValues;
     const t = this.translations;
 
     return (
@@ -140,17 +141,10 @@ class KycOverlayAddress extends KycFormStep {
             </FieldGroup>
           </FieldItem>
           <FieldItem>
-            <PreviewImage>
-              {residenceProofDataUrl && (
-                <img
-                  src={residenceProofDataUrl}
-                  alt="Residence Proof Preview"
-                  data-digix="KycForm-ResidenceProofPreview"
-                />
-              )}
-            </PreviewImage>
+            <PreviewImage>{this.renderFilePreview('residenceProofDataUrl')}</PreviewImage>
           </FieldItem>
         </FieldGroup>
+        {this.renderFilePreviewModal('residenceProofDataUrl')}
       </FormSection>
     );
   }

--- a/src/components/common/blocks/overlay/kyc/steps/basic-information.js
+++ b/src/components/common/blocks/overlay/kyc/steps/basic-information.js
@@ -149,13 +149,15 @@ class KycOverlayBasicInformation extends KycFormStep {
       },
 
       identificationProofDataUrl: {
-        customValidation: this.isImageFileValid,
+        customValidation: this.isFileValid,
         defaultErrorMessage: this.ERROR_MESSAGES.required,
         errorMessage: null,
         hasError: stateValues.identificationProofDataUrl ? false : undefined,
-        label: t.identificationProofDataUrl,
+        label: this.LABELS.file,
         pattern: null,
         type: this.FIELD_TYPES.fileInput,
+        alt: 'National I.D. Preview',
+        dataDigix: 'KycForm-NationalIdPreview',
       },
 
       identificationProofExpirationDate: {
@@ -181,7 +183,6 @@ class KycOverlayBasicInformation extends KycFormStep {
   }
 
   render() {
-    const { identificationProofDataUrl } = this.state.formValues;
     const t = this.translations;
 
     return (
@@ -228,17 +229,10 @@ class KycOverlayBasicInformation extends KycFormStep {
             </FieldGroup>
           </FieldItem>
           <FieldItem>
-            <PreviewImage>
-              {identificationProofDataUrl && (
-                <img
-                  src={identificationProofDataUrl}
-                  alt="National I.D. Preview"
-                  data-digix="KycForm-NationalIdPreview"
-                />
-              )}
-            </PreviewImage>
+            <PreviewImage>{this.renderFilePreview('identificationProofDataUrl')}</PreviewImage>
           </FieldItem>
         </FieldGroup>
+        {this.renderFilePreviewModal('identificationProofDataUrl')}
       </FormSection>
     );
   }

--- a/src/components/common/blocks/overlay/kyc/steps/photo-upload.js
+++ b/src/components/common/blocks/overlay/kyc/steps/photo-upload.js
@@ -60,11 +60,11 @@ class KycOverlayPhotoUpload extends KycFormStep {
     const stateValues = this.state.formValues;
     this.VALIDATION_RULES = {
       identificationPoseDataUrl: {
-        customValidation: this.isImageFileValid,
+        customValidation: this.isFileValid,
         defaultErrorMessage: this.ERROR_MESSAGES.required,
         errorMessage: null,
         hasError: stateValues.identificationPoseDataUrl ? false : undefined,
-        label: this.LABELS.imageFile,
+        label: this.LABELS.image,
         pattern: this.REGEX.nonEmptyString,
         type: this.FIELD_TYPES.fileInput,
       },

--- a/src/components/common/blocks/overlay/kyc/style.js
+++ b/src/components/common/blocks/overlay/kyc/style.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { media } from '@digix/gov-ui/components/common/breakpoints';
 import { H3 } from '@digix/gov-ui/components/common/common-styles';
 
@@ -52,6 +53,7 @@ export const FormSection = styled.div`
 `;
 
 export const FieldItem = styled.div`
+  position: relative;
   margin: 0 1rem 2rem 1rem;
   flex: 1;
 
@@ -103,15 +105,17 @@ export const PreviewImage = styled.div`
   background: ${props => props.theme.card.border.lighter.toString()};
   border-radius: ${props => props.theme.borderRadius};
   border: 1px solid ${props => props.theme.card.border.lighter.toString()};
-  height: 250px;
-  max-height: ${MAX_PREVIEW_DIMENSION};
+  height: 100%;
   margin-top: 2.5rem;
+  position: relative;
+  width: 100%;
 
+  canvas,
   img {
-    width: auto;
-    max-width: 100%;
     height: auto;
     max-height: 100%;
+    max-width: 100%;
+    width: auto;
   }
 
   ${media.tablet`
@@ -210,4 +214,56 @@ export const ErrorMessage = styled.span`
   color: ${props => props.theme.alertMessage.error.default.toString()};
   display: inline-block;
   font-size: 1.4rem;
+`;
+
+export const FilePreview = styled.div`
+  background: #fff;
+  border-bottom: 0;
+  flex: 0 1 calc(50% - 0.5rem);
+  margin-right: 0;
+  margin-bottom: 1rem;
+  position: relative;
+  padding: 0;
+
+  canvas,
+  img {
+    width: 100%;
+  }
+
+  ${media.mobile`
+    flex: 0 1 100%;
+  `}
+`;
+
+export const ModalCta = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  button {
+    margin: 0;
+  }
+`;
+
+export const Enlarge = styled(Button)`
+  background: ${props => props.theme.background.white.toString()};
+  border: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  border-radius: ${props => props.theme.borderRadius};
+  box-shadow: none;
+  font-size: 1.2rem;
+  margin: 0.5rem;
+  padding: 1rem;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+
+  div {
+    height: 1.75rem;
+    margin-right: 0;
+    width: 1.75rem;
+  }
+
+  &:hover {
+    background: ${props => props.theme.background.white.toString()};
+    border: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  }
 `;

--- a/src/components/common/elements/pdf-viewer/index.js
+++ b/src/components/common/elements/pdf-viewer/index.js
@@ -57,7 +57,9 @@ export default class PdfViewer extends React.PureComponent {
     const { showNav } = this.props;
 
     const { file } = this.props;
-    if (!file) return null;
+    if (!file || !file.startsWith('data:application/pdf')) {
+      return null;
+    }
 
     return (
       <Fragment>

--- a/src/pages/kyc/officer/style.js
+++ b/src/pages/kyc/officer/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { H1, H3, Card, FieldItem } from '@digix/gov-ui/components/common/common-styles';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 
@@ -44,6 +44,14 @@ export const Caption = styled.div`
 export const Value = styled.div`
   width: 75%;
   padding: 1rem 2rem;
+
+  canvas,
+  img {
+    height: auto;
+    max-height: 100%;
+    max-width: 100%;
+    width: auto;
+  }
 `;
 
 export const TabButton = styled(Button)`
@@ -84,17 +92,37 @@ export const FieldItemKYC = styled(FieldItem)`
   }
 `;
 
-export const FieldImg = styled.img`
-  width: 100%;
-  cursor: pointer;
-`;
-
 export const CloseButton = styled(Button)`
-  position: absolute;
-  background: #fff;
   border: 0;
   top: 10px;
   right: 5px;
   margin: 0;
   padding: 1rem 1.5rem;
+  text-align: center;
+  width: 100%;
+  display: block;
+`;
+
+export const Enlarge = styled(Button)`
+  background: ${props => props.theme.background.white.toString()};
+  border: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  border-radius: ${props => props.theme.borderRadius};
+  box-shadow: none;
+  font-size: 1.2rem;
+  margin: 0.5rem;
+  padding: 1rem;
+  right: 1rem;
+  text-align: right;
+  top: 1rem;
+
+  div {
+    height: 1.75rem;
+    margin-right: 0;
+    width: 1.75rem;
+  }
+
+  &:hover {
+    background: ${props => props.theme.background.white.toString()};
+    border: 1px solid ${props => props.theme.borderColor.lighter.toString()};
+  }
 `;

--- a/src/pages/kyc/officer/user-info.js
+++ b/src/pages/kyc/officer/user-info.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import PDFViewer from '@digix/gov-ui/components/common/elements/pdf-viewer';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import Modal from 'react-responsive-modal';
@@ -12,11 +13,11 @@ import Icon from '@digix/gov-ui/components/common/elements/icons';
 import {
   Container,
   Caption,
-  FieldImg,
   Value,
   ValueWrapper,
   UserTitle,
   CloseButton,
+  Enlarge,
 } from '@digix/gov-ui/pages/kyc/officer/style';
 
 const renderIps = ips => (
@@ -44,9 +45,15 @@ class UserInfo extends React.Component {
     this.setState({ approve: value });
   };
 
+  isFileTypePdf = fieldName => fieldName.image.contentType === 'application/pdf';
+
   render() {
     const { user, header } = this.props;
     const { approve, selectedImage } = this.state;
+
+    const isIdProofPdf = this.isFileTypePdf(user.identificationProof);
+    const isResidenceProofPdf = this.isFileTypePdf(user.residenceProof);
+
     return (
       <Container>
         <UserTitle>{`${header} ${user.firstName} ${user.lastName}`}</UserTitle>
@@ -173,11 +180,10 @@ class UserInfo extends React.Component {
             <ValueWrapper>
               <Caption>Webcam Proof</Caption>
               <Value>
-                <FieldImg
-                  src={user.identificationPose.image.dataUrl}
-                  alt=""
-                  onClick={this.showHideImage(user.identificationPose.image.dataUrl)}
-                />
+                <Enlarge kind="text" onClick={this.showHideImage(user.identificationPose.image)}>
+                  <Icon kind="magnifier" />
+                </Enlarge>
+                <img src={user.identificationPose.image.dataUrl} alt="" />
               </Value>
             </ValueWrapper>
             <ValueWrapper>
@@ -195,12 +201,14 @@ class UserInfo extends React.Component {
         {user.residenceProof && user.residenceProof.residence !== undefined && (
           <ValueWrapper>
             <Caption>Residence Proof</Caption>
-            <Value>
-              <FieldImg
-                src={user.residenceProof.image.dataUrl}
-                alt=""
-                onClick={this.showHideImage(user.residenceProof.image.dataUrl)}
-              />
+            <Value preview>
+              <Enlarge kind="text" onClick={this.showHideImage(user.residenceProof.image)}>
+                <Icon kind="magnifier" />
+              </Enlarge>
+              {isResidenceProofPdf && (
+                <PDFViewer file={user.residenceProof.image.dataUrl} showNav={false} />
+              )}
+              {!isResidenceProofPdf && <img src={user.residenceProof.image.dataUrl} alt="" />}
             </Value>
           </ValueWrapper>
         )}
@@ -223,12 +231,14 @@ class UserInfo extends React.Component {
             </ValueWrapper>
             <ValueWrapper>
               <Caption>ID Proof</Caption>
-              <Value>
-                <FieldImg
-                  src={user.identificationProof.image.dataUrl}
-                  alt=""
-                  onClick={this.showHideImage(user.identificationProof.image.dataUrl)}
-                />
+              <Value preview>
+                <Enlarge kind="text" onClick={this.showHideImage(user.identificationProof.image)}>
+                  <Icon kind="magnifier" />
+                </Enlarge>
+                {isIdProofPdf && (
+                  <PDFViewer file={user.identificationProof.image.dataUrl} showNav={false} />
+                )}
+                {!isIdProofPdf && <img src={user.identificationProof.image.dataUrl} alt="" />}
               </Value>
             </ValueWrapper>
           </Fragment>
@@ -262,11 +272,16 @@ class UserInfo extends React.Component {
             )}
           </Fragment>
         )}
-        <Modal open={selectedImage} showCloseIcon onClose={this.showHideImage()} center>
+        <Modal open={selectedImage} showCloseIcon={false} onClose={this.showHideImage()} center>
           <div>
-            <img alt="" style={{ width: '100%' }} src={selectedImage} />
-            <CloseButton onClick={this.showHideImage()} style={{ boxShadow: 'none' }}>
-              <Icon kind="close" style={{ marginRight: 0 }} />
+            {!!selectedImage && selectedImage.contentType === 'application/pdf' && (
+              <PDFViewer file={selectedImage.dataUrl} />
+            )}
+            {!!selectedImage && selectedImage.contentType !== 'application/pdf' && (
+              <img alt="" style={{ width: '100%' }} src={selectedImage.dataUrl} />
+            )}
+            <CloseButton primary onClick={this.showHideImage()}>
+              Close
             </CloseButton>
           </div>
         </Modal>
@@ -274,8 +289,8 @@ class UserInfo extends React.Component {
     );
   }
 }
-const { object, string, func } = PropTypes;
 
+const { object, string, func } = PropTypes;
 UserInfo.propTypes = {
   user: object.isRequired,
   header: string.isRequired,

--- a/src/translations/chinese/profile.json
+++ b/src/translations/chinese/profile.json
@@ -89,14 +89,16 @@
         },
         "file": {
           "missing": "上传文件",
-          "isImage": "照片格式必须为 JPEG 或 PNG ",
+          "isImage": "Image must be in JPEG or PNG format",
+          "isValid": "照片格式必须为 JPEG 或 PNG 或 PDF",
           "size": "文件必须小于 10 MB."
         },
         "phone": "Invalid phone number",
         "required": "必填项."
       },
       "Labels": {
-        "file": "照片格式必须为 JPEG 或 PNG & 文件必须小于 10 MB."
+        "file": "照片格式必须为 JPEG 或 PNG & 文件必须小于 10 MB.",
+        "image": "照片格式必须为 JPEG 或 PNG 或 PDF & 文件必须小于 10 MB."
       },
       "Fields": {
         "BasicInformation": {

--- a/src/translations/english/profile.json
+++ b/src/translations/english/profile.json
@@ -89,14 +89,16 @@
         },
         "file": {
           "missing": "Please upload a file.",
-          "isImage": "Image must be in JPEG or PNG format",
+          "isImage": "照片格式必须为 JPEG 或 PNG",
+          "isValid": "Image must be in JPEG, PNG, or PDF format",
           "size": "Filesize must be less than 10 MB."
         },
         "phone": "Invalid phone number",
         "required": "This field is required."
       },
       "Labels": {
-        "file": "Image must be in JPEG or PNG format & filesize must be less than 10MB."
+        "file": "File must be in JPEG, PNG, or PDF format & filesize must be less than 10MB.",
+        "image": "File must be in JPEG, PNG format & filesize must be less than 10MB."
       },
       "Fields": {
         "BasicInformation": {


### PR DESCRIPTION
Ref: [DGDG-505](https://tracker.digixdev.com/issue/DGDG-505)

### Code Review Notes

Depends on PR [#62](https://github.com/DigixGlobal/dao-server/pull/62) in `dao-server`

### Test Plan
- Submit a KYC request. You should be able to upload PDF files for the ID and Residence proof, but not for the Webcam/Photo Upload.
- Both images and PDF files should be rendered correctly in the preview. Clicking on the enlarge icon will open the files in a modal where you can navigate through PDF pages.
- Log in as the KYC admin. These files should be rendered correctly, and you should also be able to navigate PDF pages through the modal.