### PR TITLE
[Fix] - Issue with loading KYC data

### DIFF
--- a/src/api/graphql-queries/kyc-officer.js
+++ b/src/api/graphql-queries/kyc-officer.js
@@ -20,52 +20,72 @@ export const searchKycQuery = gql`
           status
           firstName
           lastName
-          gender
-          birthdate
+
           nationality
-          phoneNumber
-          employmentStatus
-          employmentIndustry
-          email
-          updatedAt
-          createdAt
-          incomeRange
-          ipAddresses
-          ethAddress
-          identificationProof {
-            number
-            expirationDate
-            type
-            image {
-              contentType
-              filename
-              dataUrl
-            }
-          }
           residenceProof {
             type
             residence {
-              address
-              addressDetails
-              city
               country
-              postalCode
-              state
-            }
-            image {
-              contentType
-              filename
-              dataUrl
             }
           }
-          identificationPose {
-            verificationCode
-            image {
-              contentType
-              filename
-              dataUrl
-            }
-          }
+        }
+      }
+    }
+  }
+`;
+
+export const getKycDetail = gql`
+  query getKyc($id: String!) {
+    kyc(id: $id) {
+      id
+      userId
+      status
+      firstName
+      lastName
+      gender
+      birthdate
+      nationality
+      phoneNumber
+      employmentStatus
+      employmentIndustry
+      email
+      updatedAt
+      createdAt
+      incomeRange
+      ipAddresses
+      ethAddress
+      identificationProof {
+        number
+        expirationDate
+        type
+        image {
+          dataUrl
+        }
+      }
+      residenceProof {
+        type
+        residence {
+          address
+          addressDetails
+          city
+          country
+          postalCode
+          state
+        }
+        image {
+          contentType
+          filename
+          fileSize
+          dataUrl
+        }
+      }
+      identificationPose {
+        verificationCode
+        image {
+          contentType
+          filename
+          fileSize
+          dataUrl
         }
       }
     }

--- a/src/components/common/blocks/digix-table/paging.js
+++ b/src/components/common/blocks/digix-table/paging.js
@@ -47,9 +47,9 @@ class Paging extends React.PureComponent {
   }
 
   onRowsChange = e => {
-    const { fetchData, handleLoading, currentPage } = this.props;
+    const { fetchData, handleLoading } = this.props;
     const { value } = e.target;
-    handleLoading(false, fetchData, Number(currentPage), Number(value));
+    handleLoading(false, fetchData, 1, Number(value));
   };
   onPageChange = e => {
     const { value } = e.target;

--- a/src/pages/kyc/officer/index.js
+++ b/src/pages/kyc/officer/index.js
@@ -9,7 +9,7 @@ import { Query } from 'react-apollo';
 import DigixTable from '@digix/gov-ui/components/common/blocks/digix-table';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 
-import { searchKycQuery } from '@digix/gov-ui/api/graphql-queries/kyc-officer';
+import { searchKycQuery, getKycDetail } from '@digix/gov-ui/api/graphql-queries/kyc-officer';
 
 import UserInfo from '@digix/gov-ui/pages/kyc/officer/user-info';
 import { showStatusIcon } from '@digix/gov-ui/pages/kyc/officer/constants';
@@ -97,14 +97,46 @@ class KycOfficerDashboard extends React.Component {
 
   renderInfo = () => {
     const { selected } = this.state;
-
     if (!selected) return null;
     return (
-      <UserInfo
-        user={selected.node}
-        header={selected.node.status === 'PENDING' ? 'User Verification - ' : 'User Detail - '}
-        onCompleted={this.onClose}
-      />
+      <Query
+        query={getKycDetail}
+        fetchPolicy="network-only"
+        variables={{
+          id: selected.node.id,
+        }}
+      >
+        {({ data, loading, error }) => {
+          if (loading) {
+            return (
+              <Spinner
+                translations={{
+                  project: {
+                    spinner: {
+                      pleaseWait: 'Please wait....',
+                      hold: 'Getting KYC data',
+                    },
+                  },
+                }}
+                height="400px"
+              />
+            );
+          }
+
+          if (error) {
+            return null;
+          }
+          return (
+            <UserInfo
+              user={data.kyc}
+              header={
+                selected.node.status === 'PENDING' ? 'User Verification - ' : 'User Detail - '
+              }
+              onCompleted={this.onClose}
+            />
+          );
+        }}
+      </Query>
     );
   };
 

--- a/src/pages/kyc/officer/reject.js
+++ b/src/pages/kyc/officer/reject.js
@@ -60,6 +60,7 @@ class RejectKyc extends React.Component {
               return (
                 <Select
                   name="rejection-reason"
+                  id="rejection-reason"
                   data-digix="KYC-Rejection-Reason"
                   onChange={this.onSelect}
                   items={options}


### PR DESCRIPTION
Ref [DGDG-546](https://tracker.digixdev.com/agiles/88-14/89-26?settings&tab=columns-and%20rows&issue=DGDG-546)

This fix is a refactor to the way KYC information is requested and displayed.
 - Only retrieve fields that are displayed on the table
 - Only pull the KYC detail of each user once the user clicks on an item from the table
 - Also resets the page to `1` when number of rows per page is change to better handle requests where page number is smaller than what is currently selected

Test Plan
 - Load multiple kyc's by seeding
 - Verify that kyc list is displaying
 - Verify that when a KYC row is clicked, it requests a separate query that retrieves the kyc detail
