### PR TITLE
[FIX] Fix bug in rendering PDF files

### DIFF
--- a/src/api/graphql-queries/kyc-officer.js
+++ b/src/api/graphql-queries/kyc-officer.js
@@ -59,6 +59,9 @@ export const getKycDetail = gql`
         expirationDate
         type
         image {
+          contentType
+          filename
+          fileSize
           dataUrl
         }
       }

--- a/src/components/common/elements/pdf-viewer/index.js
+++ b/src/components/common/elements/pdf-viewer/index.js
@@ -57,7 +57,7 @@ export default class PdfViewer extends React.PureComponent {
     const { showNav } = this.props;
 
     const { file } = this.props;
-    if (!file || !file.startsWith('data:application/pdf')) {
+    if (!file || file.startsWith('data:image')) {
       return null;
     }
 


### PR DESCRIPTION
This fixes a bug introduced in PR #286. PDF files for projects are not rendering properly because the source is a url. The condition has been fixed to just check that we're not rendering images.