### PR TITLE
Track filtering of projects on the dashboard

### DIFF
--- a/src/analytics/dashboard.js
+++ b/src/analytics/dashboard.js
@@ -3,10 +3,14 @@ import ReactGA from 'react-ga';
 const CATEGORY = 'DashboardEvent';
 
 const ACTIONS = {
+  filterProject: 'Filter Projects',
+  filterProjectByStage: 'Filter Projects By Stage',
   viewProject: 'View Project',
 };
 
 const LABELS = {
+  filter: 'Filter',
+  projectStage: 'Stage',
   userType: 'User Type',
 };
 
@@ -16,6 +20,22 @@ const LogDashboard = {
       category: CATEGORY,
       action: ACTIONS.viewProject,
       label: `${LABELS.userType}: ${userType}`,
+    });
+  },
+
+  filterProject: filter => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.filterProject,
+      label: `${LABELS.filter}: ${filter}`,
+    });
+  },
+
+  filterProjectByStage: stage => {
+    ReactGA.event({
+      category: CATEGORY,
+      action: ACTIONS.filterProject,
+      label: `${LABELS.projectStage}: ${stage}`,
     });
   },
 };

--- a/src/components/common/blocks/filter/category.js
+++ b/src/components/common/blocks/filter/category.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { Category, CategoryItem } from './style';
-
-import { getProposalsCount } from '../../../../reducers/info-server/actions';
+import LogDashboard from '@digix/gov-ui/analytics/dashboard';
+import { Category, CategoryItem } from '@digix/gov-ui/components/common/blocks/filter/style.js';
+import { getProposalsCount } from '@digix/gov-ui/reducers/info-server/actions';
 
 export class CategoryGroup extends React.Component {
   constructor(props) {
@@ -18,11 +18,12 @@ export class CategoryGroup extends React.Component {
     this.props.getProposalsCountAction();
   };
 
-  handleClick(param) {
+  handleClick(stage) {
     const { onStageChange, getProposalsCountAction } = this.props;
     if (onStageChange) {
-      this.setState({ stage: param });
-      onStageChange(param);
+      LogDashboard.filterProjectByStage(stage);
+      this.setState({ stage });
+      onStageChange(stage);
       getProposalsCountAction();
     }
   }

--- a/src/components/common/blocks/filter/index.js
+++ b/src/components/common/blocks/filter/index.js
@@ -5,6 +5,7 @@ import { withApollo } from 'react-apollo';
 
 import Category from '@digix/gov-ui/components/common/blocks/filter/category.js';
 import ErrorMessageOverlay from '@digix/gov-ui/components/common/blocks/overlay/error-message';
+import LogDashboard from '@digix/gov-ui/analytics/dashboard';
 import { Button, Icon, Select } from '@digix/gov-ui/components/common/elements/index';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
@@ -86,10 +87,13 @@ class ProposalCardFilter extends React.Component {
     });
   };
 
-  handleChange = e => {
+  changeFilter = e => {
     const { onOrderChange } = this.props;
+    const filter = e.target.value;
+
     if (onOrderChange) {
-      onOrderChange(e.target.value);
+      LogDashboard.filterProject(filter);
+      onOrderChange(filter);
     }
   };
 
@@ -154,7 +158,7 @@ class ProposalCardFilter extends React.Component {
               id="sortBy"
               data-digix="SORT-BY"
               items={filters}
-              onChange={this.handleChange}
+              onChange={this.changeFilter}
             />
           </Pulldown>
         </Filter>


### PR DESCRIPTION
This will track clicks on the filter tab. An event will be sent to Google Analytics if the user filters projects chronologically or by creation date.

### Test Plan
- In the development environment, set `debug` to `true` in `DEFAULT_OPTIONS` of `analytics/index`.
- Go to the dashboard and click on the project stages to filter the projects shown. Verify that the event is being tracked by checking the network or console logs.
- The same event should be tracked when you filter by `latest` or `oldest`.
- In the staging/production environment, the events should be logged with `DashboardEvent` as a category and `Filter Project` as the action.