### PR TITLE
Add fetchProposals GraphQL query and refactor how we fetch proposals on dashboard

### DIFF
--- a/src/api/graphql-queries/proposal.js
+++ b/src/api/graphql-queries/proposal.js
@@ -5,306 +5,184 @@ import gql from 'graphql-tag';
 
 import { Query } from 'react-apollo';
 
+const ProposalFragment = gql`
+  fragment proposal on Proposal {
+    id
+    proposalId
+    actionableStatus
+    proposer
+    endorser
+    stage
+    timeCreated
+    finalVersionIpfsDoc
+    prl
+    title
+    isDigix
+    isActive
+    isSpecial
+    claimableFunding
+    currentMilestone
+    currentVotingRound
+    isFundingChanged
+    uintConfigs {
+      CONFIG_LOCKING_PHASE_DURATION
+      CONFIG_QUARTER_DURATION
+      CONFIG_VOTING_COMMIT_PHASE
+      CONFIG_VOTING_PHASE_TOTAL
+      CONFIG_INTERIM_COMMIT_PHASE
+      CONFIG_INTERIM_PHASE_TOTAL
+      CONFIG_DRAFT_QUORUM_FIXED_PORTION_NUMERATOR
+      CONFIG_DRAFT_QUORUM_FIXED_PORTION_DENOMINATOR
+      CONFIG_DRAFT_QUORUM_SCALING_FACTOR_NUMERATOR
+      CONFIG_DRAFT_QUORUM_SCALING_FACTOR_DENOMINATOR
+      CONFIG_VOTING_QUORUM_FIXED_PORTION_NUMERATOR
+      CONFIG_VOTING_QUORUM_FIXED_PORTION_DENOMINATOR
+      CONFIG_VOTING_QUORUM_SCALING_FACTOR_NUMERATOR
+      CONFIG_VOTING_QUORUM_SCALING_FACTOR_DENOMINATOR
+      CONFIG_DRAFT_QUOTA_NUMERATOR
+      CONFIG_DRAFT_QUOTA_DENOMINATOR
+      CONFIG_VOTING_QUOTA_NUMERATOR
+      CONFIG_VOTING_QUOTA_DENOMINATOR
+      CONFIG_QUARTER_POINT_DRAFT_VOTE
+      CONFIG_QUARTER_POINT_VOTE
+      CONFIG_QUARTER_POINT_INTERIM_VOTE
+      CONFIG_MINIMAL_QUARTER_POINT
+      CONFIG_QUARTER_POINT_MILESTONE_COMPLETION_PER_10000ETH
+      CONFIG_BONUS_REPUTATION_NUMERATOR
+      CONFIG_BONUS_REPUTATION_DENOMINATOR
+      CONFIG_SPECIAL_PROPOSAL_COMMIT_PHASE
+      CONFIG_SPECIAL_PROPOSAL_PHASE_TOTAL
+      CONFIG_SPECIAL_QUOTA_NUMERATOR
+      CONFIG_SPECIAL_QUOTA_DENOMINATOR
+      CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR
+      CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
+      CONFIG_MAXIMUM_REPUTATION_DEDUCTION
+      CONFIG_PUNISHMENT_FOR_NOT_LOCKING
+      CONFIG_REPUTATION_PER_EXTRA_QP_NUM
+      CONFIG_REPUTATION_PER_EXTRA_QP_DEN
+      CONFIG_QUARTER_POINT_SCALING_FACTOR
+      CONFIG_REPUTATION_POINT_SCALING_FACTOR
+      CONFIG_MODERATOR_MINIMAL_QUARTER_POINT
+      CONFIG_MODERATOR_QUARTER_POINT_SCALING_FACTOR
+      CONFIG_MODERATOR_REPUTATION_POINT_SCALING_FACTOR
+      CONFIG_PORTION_TO_MODERATORS_NUM
+      CONFIG_PORTION_TO_MODERATORS_DEN
+      CONFIG_DRAFT_VOTING_PHASE
+      CONFIG_REPUTATION_POINT_BOOST_FOR_BADGE
+      CONFIG_FINAL_REWARD_SCALING_FACTOR_NUMERATOR
+      CONFIG_FINAL_REWARD_SCALING_FACTOR_DENOMINATOR
+      CONFIG_MAXIMUM_MODERATOR_REPUTATION_DEDUCTION
+      CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_NUM
+      CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_DEN
+      CONFIG_VOTE_CLAIMING_DEADLINE
+      CONFIG_MINIMUM_LOCKED_DGD
+      CONFIG_MINIMUM_DGD_FOR_MODERATOR
+      CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR
+      CONFIG_PREPROPOSAL_COLLATERAL
+      CONFIG_MAX_FUNDING_FOR_NON_DIGIX
+      CONFIG_MAX_MILESTONES_FOR_NON_DIGIX
+      CONFIG_NON_DIGIX_PROPOSAL_CAP_PER_QUARTER
+      CONFIG_PROPOSAL_DEAD_DURATION
+      CONFIG_CARBON_VOTE_REPUTATION_BONUS
+    }
+    changedFundings {
+      milestones {
+        original
+        updated
+      }
+      finalReward {
+        original
+        updated
+      }
+    }
+    draftVoting {
+      startTime
+      votingDeadline
+      totalVoterStake
+      totalVoterCount
+      yes
+      no
+      quorum
+      quota
+      passed
+      claimed
+      funded
+      currentClaimStep
+    }
+    proposalVersions {
+      id
+      docIpfsHash
+      created
+      milestoneFundings
+      finalReward
+      moreDocs {
+        docs
+        created
+      }
+      totalFunding
+      dijixObject {
+        title
+        description
+        details
+        milestones {
+          title
+          fund
+          description
+        }
+        finalReward
+        images
+      }
+    }
+    votingStage
+    votingRounds {
+      startTime
+      commitDeadline
+      revealDeadline
+      quorum
+      quota
+      totalCommitCount
+      totalVoterCount
+      totalVoterStake
+      yes
+      no
+      claimed
+      passed
+      funded
+      currentClaimStep
+    }
+    currentMilestoneIndex
+    currentMilestoneStart
+  }
+`;
+
+export const fetchProposalList = gql`
+  query fetchProposalList($stage: String!) {
+    fetchProposals(stage: $stage) {
+      ...proposal
+    }
+  }
+
+  ${ProposalFragment}
+`;
+
 export const fetchProposal = gql`
   query findProposal($proposalId: String!) {
     fetchProposal(proposalId: $proposalId) {
-      id
-      proposalId
-      proposer
-      endorser
-      stage
-      timeCreated
-      finalVersionIpfsDoc
-      prl
-      title
-      isDigix
-      isActive
-      isSpecial
-      claimableFunding
-      currentMilestone
-      currentVotingRound
-      isFundingChanged
-      uintConfigs {
-        CONFIG_LOCKING_PHASE_DURATION
-        CONFIG_QUARTER_DURATION
-        CONFIG_VOTING_COMMIT_PHASE
-        CONFIG_VOTING_PHASE_TOTAL
-        CONFIG_INTERIM_COMMIT_PHASE
-        CONFIG_INTERIM_PHASE_TOTAL
-        CONFIG_DRAFT_QUORUM_FIXED_PORTION_NUMERATOR
-        CONFIG_DRAFT_QUORUM_FIXED_PORTION_DENOMINATOR
-        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_NUMERATOR
-        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_DENOMINATOR
-        CONFIG_VOTING_QUORUM_FIXED_PORTION_NUMERATOR
-        CONFIG_VOTING_QUORUM_FIXED_PORTION_DENOMINATOR
-        CONFIG_VOTING_QUORUM_SCALING_FACTOR_NUMERATOR
-        CONFIG_VOTING_QUORUM_SCALING_FACTOR_DENOMINATOR
-        CONFIG_DRAFT_QUOTA_NUMERATOR
-        CONFIG_DRAFT_QUOTA_DENOMINATOR
-        CONFIG_VOTING_QUOTA_NUMERATOR
-        CONFIG_VOTING_QUOTA_DENOMINATOR
-        CONFIG_QUARTER_POINT_DRAFT_VOTE
-        CONFIG_QUARTER_POINT_VOTE
-        CONFIG_QUARTER_POINT_INTERIM_VOTE
-        CONFIG_MINIMAL_QUARTER_POINT
-        CONFIG_QUARTER_POINT_MILESTONE_COMPLETION_PER_10000ETH
-        CONFIG_BONUS_REPUTATION_NUMERATOR
-        CONFIG_BONUS_REPUTATION_DENOMINATOR
-        CONFIG_SPECIAL_PROPOSAL_COMMIT_PHASE
-        CONFIG_SPECIAL_PROPOSAL_PHASE_TOTAL
-        CONFIG_SPECIAL_QUOTA_NUMERATOR
-        CONFIG_SPECIAL_QUOTA_DENOMINATOR
-        CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR
-        CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
-        CONFIG_MAXIMUM_REPUTATION_DEDUCTION
-        CONFIG_PUNISHMENT_FOR_NOT_LOCKING
-        CONFIG_REPUTATION_PER_EXTRA_QP_NUM
-        CONFIG_REPUTATION_PER_EXTRA_QP_DEN
-        CONFIG_QUARTER_POINT_SCALING_FACTOR
-        CONFIG_REPUTATION_POINT_SCALING_FACTOR
-        CONFIG_MODERATOR_MINIMAL_QUARTER_POINT
-        CONFIG_MODERATOR_QUARTER_POINT_SCALING_FACTOR
-        CONFIG_MODERATOR_REPUTATION_POINT_SCALING_FACTOR
-        CONFIG_PORTION_TO_MODERATORS_NUM
-        CONFIG_PORTION_TO_MODERATORS_DEN
-        CONFIG_DRAFT_VOTING_PHASE
-        CONFIG_REPUTATION_POINT_BOOST_FOR_BADGE
-        CONFIG_FINAL_REWARD_SCALING_FACTOR_NUMERATOR
-        CONFIG_FINAL_REWARD_SCALING_FACTOR_DENOMINATOR
-        CONFIG_MAXIMUM_MODERATOR_REPUTATION_DEDUCTION
-        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_NUM
-        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_DEN
-        CONFIG_VOTE_CLAIMING_DEADLINE
-        CONFIG_MINIMUM_LOCKED_DGD
-        CONFIG_MINIMUM_DGD_FOR_MODERATOR
-        CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR
-        CONFIG_PREPROPOSAL_COLLATERAL
-        CONFIG_MAX_FUNDING_FOR_NON_DIGIX
-        CONFIG_MAX_MILESTONES_FOR_NON_DIGIX
-        CONFIG_NON_DIGIX_PROPOSAL_CAP_PER_QUARTER
-        CONFIG_PROPOSAL_DEAD_DURATION
-        CONFIG_CARBON_VOTE_REPUTATION_BONUS
-      }
-      changedFundings {
-        milestones {
-          original
-          updated
-        }
-        finalReward {
-          original
-          updated
-        }
-      }
-      draftVoting {
-        startTime
-        votingDeadline
-        totalVoterStake
-        totalVoterCount
-        yes
-        no
-        quorum
-        quota
-        passed
-        claimed
-        funded
-        currentClaimStep
-      }
-      proposalVersions {
-        id
-        docIpfsHash
-        created
-        milestoneFundings
-        finalReward
-        moreDocs {
-          docs
-          created
-        }
-        totalFunding
-        dijixObject {
-          title
-          description
-          details
-          milestones {
-            title
-            fund
-            description
-          }
-          finalReward
-          images
-        }
-      }
-      votingStage
-      votingRounds {
-        startTime
-        commitDeadline
-        revealDeadline
-        quorum
-        quota
-        totalCommitCount
-        totalVoterCount
-        totalVoterStake
-        yes
-        no
-        claimed
-        passed
-        funded
-        currentClaimStep
-      }
-      currentMilestoneIndex
-      currentMilestoneStart
+      ...proposal
     }
   }
+
+  ${ProposalFragment}
 `;
 
 const proposalSubscription = gql`
   subscription {
     proposalUpdated {
-      id
-      proposalId
-      proposer
-      endorser
-      stage
-      timeCreated
-      finalVersionIpfsDoc
-      prl
-      title
-      isDigix
-      isActive
-      isSpecial
-      claimableFunding
-      currentMilestone
-      currentVotingRound
-      isFundingChanged
-      uintConfigs {
-        CONFIG_LOCKING_PHASE_DURATION
-        CONFIG_QUARTER_DURATION
-        CONFIG_VOTING_COMMIT_PHASE
-        CONFIG_VOTING_PHASE_TOTAL
-        CONFIG_INTERIM_COMMIT_PHASE
-        CONFIG_INTERIM_PHASE_TOTAL
-        CONFIG_DRAFT_QUORUM_FIXED_PORTION_NUMERATOR
-        CONFIG_DRAFT_QUORUM_FIXED_PORTION_DENOMINATOR
-        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_NUMERATOR
-        CONFIG_DRAFT_QUORUM_SCALING_FACTOR_DENOMINATOR
-        CONFIG_VOTING_QUORUM_FIXED_PORTION_NUMERATOR
-        CONFIG_VOTING_QUORUM_FIXED_PORTION_DENOMINATOR
-        CONFIG_VOTING_QUORUM_SCALING_FACTOR_NUMERATOR
-        CONFIG_VOTING_QUORUM_SCALING_FACTOR_DENOMINATOR
-        CONFIG_DRAFT_QUOTA_NUMERATOR
-        CONFIG_DRAFT_QUOTA_DENOMINATOR
-        CONFIG_VOTING_QUOTA_NUMERATOR
-        CONFIG_VOTING_QUOTA_DENOMINATOR
-        CONFIG_QUARTER_POINT_DRAFT_VOTE
-        CONFIG_QUARTER_POINT_VOTE
-        CONFIG_QUARTER_POINT_INTERIM_VOTE
-        CONFIG_MINIMAL_QUARTER_POINT
-        CONFIG_QUARTER_POINT_MILESTONE_COMPLETION_PER_10000ETH
-        CONFIG_BONUS_REPUTATION_NUMERATOR
-        CONFIG_BONUS_REPUTATION_DENOMINATOR
-        CONFIG_SPECIAL_PROPOSAL_COMMIT_PHASE
-        CONFIG_SPECIAL_PROPOSAL_PHASE_TOTAL
-        CONFIG_SPECIAL_QUOTA_NUMERATOR
-        CONFIG_SPECIAL_QUOTA_DENOMINATOR
-        CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR
-        CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
-        CONFIG_MAXIMUM_REPUTATION_DEDUCTION
-        CONFIG_PUNISHMENT_FOR_NOT_LOCKING
-        CONFIG_REPUTATION_PER_EXTRA_QP_NUM
-        CONFIG_REPUTATION_PER_EXTRA_QP_DEN
-        CONFIG_QUARTER_POINT_SCALING_FACTOR
-        CONFIG_REPUTATION_POINT_SCALING_FACTOR
-        CONFIG_MODERATOR_MINIMAL_QUARTER_POINT
-        CONFIG_MODERATOR_QUARTER_POINT_SCALING_FACTOR
-        CONFIG_MODERATOR_REPUTATION_POINT_SCALING_FACTOR
-        CONFIG_PORTION_TO_MODERATORS_NUM
-        CONFIG_PORTION_TO_MODERATORS_DEN
-        CONFIG_DRAFT_VOTING_PHASE
-        CONFIG_REPUTATION_POINT_BOOST_FOR_BADGE
-        CONFIG_FINAL_REWARD_SCALING_FACTOR_NUMERATOR
-        CONFIG_FINAL_REWARD_SCALING_FACTOR_DENOMINATOR
-        CONFIG_MAXIMUM_MODERATOR_REPUTATION_DEDUCTION
-        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_NUM
-        CONFIG_REPUTATION_PER_EXTRA_MODERATOR_QP_DEN
-        CONFIG_VOTE_CLAIMING_DEADLINE
-        CONFIG_MINIMUM_LOCKED_DGD
-        CONFIG_MINIMUM_DGD_FOR_MODERATOR
-        CONFIG_MINIMUM_REPUTATION_FOR_MODERATOR
-        CONFIG_PREPROPOSAL_COLLATERAL
-        CONFIG_MAX_FUNDING_FOR_NON_DIGIX
-        CONFIG_MAX_MILESTONES_FOR_NON_DIGIX
-        CONFIG_NON_DIGIX_PROPOSAL_CAP_PER_QUARTER
-        CONFIG_PROPOSAL_DEAD_DURATION
-        CONFIG_CARBON_VOTE_REPUTATION_BONUS
-      }
-      changedFundings {
-        milestones {
-          original
-          updated
-        }
-        finalReward {
-          original
-          updated
-        }
-      }
-      draftVoting {
-        startTime
-        votingDeadline
-        totalVoterStake
-        totalVoterCount
-        yes
-        no
-        quorum
-        quota
-        passed
-        claimed
-        funded
-        currentClaimStep
-      }
-      proposalVersions {
-        id
-        docIpfsHash
-        created
-        milestoneFundings
-        finalReward
-        moreDocs {
-          docs
-          created
-        }
-        totalFunding
-        dijixObject {
-          title
-          description
-          details
-          milestones {
-            title
-            fund
-            description
-          }
-          finalReward
-          images
-        }
-      }
-      votingStage
-      votingRounds {
-        startTime
-        commitDeadline
-        revealDeadline
-        quorum
-        quota
-        totalCommitCount
-        totalVoterCount
-        totalVoterStake
-        yes
-        no
-        claimed
-        passed
-        funded
-        currentClaimStep
-      }
-      currentMilestoneIndex
-      currentMilestoneStart
+      ...proposal
     }
   }
+
+  ${ProposalFragment}
 `;
 
 export const withFetchProposal = Component => props => {

--- a/src/components/common/blocks/filter/index.js
+++ b/src/components/common/blocks/filter/index.js
@@ -126,7 +126,7 @@ class ProposalCardFilter extends React.Component {
   }
 
   render() {
-    const { AddressDetails, translations } = this.props;
+    const { AddressDetails, setProposalList, translations } = this.props;
     const { filters } = this.state;
     const canCreate = AddressDetails && AddressDetails.data.isParticipant;
     const {
@@ -151,7 +151,7 @@ class ProposalCardFilter extends React.Component {
           )}
         </Heading>
         <Filter>
-          <Category {...this.props} translations={translations} />
+          <Category {...this.props} setProposalList={setProposalList} translations={translations} />
           <Pulldown>
             <Select
               small
@@ -178,8 +178,9 @@ ProposalCardFilter.propTypes = {
   history: object.isRequired,
   onOrderChange: func.isRequired,
   showRightPanel: func.isRequired,
-  web3Redux: object.isRequired,
+  setProposalList: func.isRequired,
   translations: object.isRequired,
+  web3Redux: object.isRequired,
 };
 
 const mapStateToProps = ({ infoServer }) => ({

--- a/src/components/proposal-card/index.js
+++ b/src/components/proposal-card/index.js
@@ -9,13 +9,18 @@ import { Container, Item } from '@digix/gov-ui/components/proposal-card/style';
 export default class ProposalCard extends React.Component {
   render() {
     const { history, proposal, userDetails, liked, likes, displayName, translations } = this.props;
-    const currentTime = Date.now();
-    const { currentVotingRound } = proposal;
-    const withinDeadline =
-      currentVotingRound > -1
-        ? proposal.votingRounds[currentVotingRound].commitDeadline * 1000 < currentTime &&
-          currentTime < proposal.votingRounds[currentVotingRound].revealDeadline * 1000
-        : false;
+    const { currentVotingRound, votingRounds } = proposal;
+
+    const currentTime = Date.now() / 1000;
+    const hasCurrentVotingRound = currentVotingRound && currentVotingRound > -1;
+    const votingRound = hasCurrentVotingRound ? votingRounds[currentVotingRound] : null;
+
+    let withinDeadline = false;
+    if (votingRound) {
+      const { commitDeadline, revealDeadline } = votingRound;
+      withinDeadline = commitDeadline < currentTime && currentTime < revealDeadline;
+    }
+
     const votingStage = withinDeadline ? 'reveal' : proposal.votingStage;
     return (
       <Container data-digix="Proposal-Card">

--- a/src/reducers/info-server/actions.js
+++ b/src/reducers/info-server/actions.js
@@ -67,10 +67,6 @@ export function setAddressDetails(details) {
   };
 }
 
-export function getProposals(stage = 'all') {
-  return fetchData(`${INFO_SERVER}/proposals/${stage}`, actions.GET_PROPOSALS);
-}
-
 export function getProposalsCount() {
   return fetchData(`${INFO_SERVER}/proposals/count`, actions.GET_PROPOSALS_COUNT);
 }

--- a/src/reducers/info-server/index.js
+++ b/src/reducers/info-server/index.js
@@ -106,25 +106,6 @@ export default function(state = defaultState, action) {
                 .slice(0, 100),
         },
       };
-
-    case actions.GET_PROPOSALS:
-      return {
-        ...state,
-        Proposals: {
-          ...state.Proposals,
-          ...action.payload,
-          history: !action.payload.data
-            ? state.Proposals.history
-            : [
-                {
-                  ...action.payload.data,
-                  updated: action.payload.updated,
-                },
-              ]
-                .concat(state.Proposals.history)
-                .slice(0, 100),
-        },
-      };
     case actions.GET_PROPOSALS_COUNT:
       return {
         ...state,


### PR DESCRIPTION
Ref: [DGDG-548](https://tracker.digixdev.com/issue/DGDG-548)

This cleans up the code and uses the new `fetchProposals` query for showing and filtering proposals. This deprecates usage of the REST endpoint on the `info-server` to fetch proposals.

### Test Plan
- Load the dashboard. All projects should be shown.
- Filter the projects by project stage. They should be filtered correctly.
- Regression test on: view project.