### PR TITLE
[FIX] Refactor likes on dashboard

### DIFF
--- a/src/components/proposal-card/index.js
+++ b/src/components/proposal-card/index.js
@@ -7,7 +7,15 @@ import { Container, Item } from '@digix/gov-ui/components/proposal-card/style';
 
 export default class ProposalCard extends React.Component {
   render() {
-    const { history, proposal, userDetails, liked, likes, displayName, translations } = this.props;
+    const {
+      displayName,
+      history,
+      isLiked,
+      likeCount,
+      likeProposal,
+      proposal,
+      translations,
+    } = this.props;
     const { currentVotingRound, votingRounds } = proposal;
 
     const currentTime = Date.now() / 1000;
@@ -29,10 +37,10 @@ export default class ProposalCard extends React.Component {
             details={proposal}
             history={history}
             title={proposal.title}
-            userDetails={userDetails}
-            liked={liked}
-            likes={likes}
+            isLiked={isLiked}
+            likeCount={likeCount}
             translations={translations}
+            likeProposal={likeProposal}
           />
           <Stats details={proposal} votingStage={votingStage} translations={translations} />
         </Item>
@@ -41,19 +49,19 @@ export default class ProposalCard extends React.Component {
   }
 }
 
-const { object, bool, number, string } = PropTypes;
+const { bool, func, number, object, oneOfType, string } = PropTypes;
 ProposalCard.propTypes = {
+  displayName: oneOfType([object, string]),
   history: object.isRequired,
+  isLiked: bool,
+  likeCount: number,
+  likeProposal: func.isRequired,
   proposal: object.isRequired,
-  userDetails: object.isRequired,
   translations: object.isRequired,
-  displayName: string,
-  liked: bool,
-  likes: number,
 };
 
 ProposalCard.defaultProps = {
-  liked: false,
-  likes: undefined,
   displayName: '',
+  isLiked: false,
+  likeCount: 0,
 };

--- a/src/reducers/dao-server/actions.js
+++ b/src/reducers/dao-server/actions.js
@@ -259,16 +259,11 @@ export function getProposalLikesByUser(payload) {
   );
 }
 
-export function getProposalLikesStats(payload) {
-  const { client, stage, authToken, uid } = payload;
+export function getProposalLikesStats(stage) {
   return sendData(
     'GET',
     stage ? `${DAO_SERVER}/proposals?stage=${stage}` : `${DAO_SERVER}/proposals`,
-    actions.GET_PROPOSAL_LIKES_STATS,
-    undefined,
-    authToken,
-    client,
-    uid
+    actions.GET_PROPOSAL_LIKES_STATS
   );
 }
 


### PR DESCRIPTION
Ref: [DGDG-547](https://tracker.digixdev.com/issue/DGDG-547)

The following have been added to the `state` for the `<LandingPage/>` component:
- `displayNames`: object of `displayNames` for the project creators, with the `proposalId` as the key
- `proposals`: list of projects (from GraphQL fetch)
- `proposalLikes`: object of total like count for each project, with the `proposalId` as the key
- `userLikes`: list of `proposalId`s liked by the user

This diff sets these `state` objects as the source of truth, and removes the need to manually filter/search `ProposalLikes` for specific information during rendering. The logic for liking a project has been moved to this component as well.

The child components for the proposal cards are now just dumb components, which ensures that the data is always updated and in sync.

**Test Plan**
- Like projects on the dashboard
- Reload the dashboard. The projects should have the updated like status and like count.
- The same should be reflected for guest users.