### PR TITLE
[FIX] Use DaoConfig to set minimum quorum for special projects

### DIFF
--- a/src/components/common/elements/accordion/voting-accordion.js
+++ b/src/components/common/elements/accordion/voting-accordion.js
@@ -28,7 +28,7 @@ class VotingAccordion extends React.PureComponent {
 
   renderAccordionItem = (item, i) => {
     const { selectedIndex, accordionItems } = this.state;
-    const { translations } = this.props;
+    const { isSpecial, translations } = this.props;
     const acc = accordionItems.find(a => a.id === selectedIndex);
     const deadline = item.voting.votingDeadline
       ? item.voting.votingDeadline
@@ -55,7 +55,12 @@ class VotingAccordion extends React.PureComponent {
         </Header>
         {show && (
           <Content data-digix="Voting-Content">
-            <VotingResult voting={item.voting} daoInfo={item.daoInfo} translations={translations} />
+            <VotingResult
+              daoInfo={item.daoInfo}
+              isSpecial={isSpecial}
+              translations={translations}
+              voting={item.voting}
+            />
           </Content>
         )}
       </AccordionItem>
@@ -69,11 +74,16 @@ class VotingAccordion extends React.PureComponent {
   }
 }
 
-const { array, object } = PropTypes;
+const { array, bool, object } = PropTypes;
 
 VotingAccordion.propTypes = {
+  isSpecial: bool,
   votingResults: array.isRequired,
   translations: object.isRequired,
+};
+
+VotingAccordion.defaultProps = {
+  isSpecial: false,
 };
 
 export default VotingAccordion;

--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -557,7 +557,11 @@ class Proposal extends React.Component {
             </InfoItem>
           </FundingInfo>
         </ProjectSummary>
-        <VotingAccordion votingResults={this.getPastVotingResults()} translations={translations} />
+        <VotingAccordion
+          isSpecial
+          votingResults={this.getPastVotingResults()}
+          translations={translations}
+        />
         <SpecialProjectVotingResult
           proposal={proposalDetails.data}
           daoInfo={daoInfo}

--- a/src/pages/proposals/special-project-voting-result.js
+++ b/src/pages/proposals/special-project-voting-result.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import Countdown from 'react-countdown-now';
 
 import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
@@ -29,13 +30,16 @@ import VotingResultHeader from '@digix/gov-ui/pages/proposals/voting-result-head
 
 class SpecialProjectVotingResult extends React.Component {
   getProposalVotingPhaseStats = proposal => {
-    const { daoInfo } = this.props;
+    const { DaoConfig, daoInfo } = this.props;
+    const {
+      CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR,
+      CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR,
+    } = DaoConfig;
     const currentRound = proposal.votingRounds[0];
 
     const commitDeadline = new Date(currentRound.commitDeadline * 1000);
     const approvalDeadline = new Date(currentRound.revealDeadline * 1000);
 
-    const quorum = parseBigNumber(currentRound.quorum, 0, false);
     const quota = parseBigNumber(currentRound.quota, 0, false);
     const totalModeratorLockedDgds = parseBigNumber(daoInfo.totalModeratorLockedDgds, 0, false);
     const totalVoterStake = parseBigNumber(currentRound.totalVoterStake, 0, false);
@@ -44,7 +48,9 @@ class SpecialProjectVotingResult extends React.Component {
     const yesVotes = currentRound.yes;
     const noVotes = currentRound.no;
 
-    const minimumQuorum = formatPercentage(quorum / totalModeratorLockedDgds);
+    const minimumQuorum = formatPercentage(
+      CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR / CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
+    );
     const quorumProgress = formatPercentage(totalVoterStake / totalModeratorLockedDgds);
 
     const minimumApproval = formatPercentage(quota);
@@ -86,10 +92,10 @@ class SpecialProjectVotingResult extends React.Component {
 
   render() {
     const { proposal, translations } = this.props;
-
     const stats = this.getProposalVotingPhaseStats(proposal);
-
-    if (Date.now() > stats.approvalDeadline) return null;
+    if (Date.now() > stats.approvalDeadline) {
+      return null;
+    }
 
     const yesVotes = truncateNumber(stats.yesVotes);
     const noVotes = truncateNumber(stats.noVotes);
@@ -191,8 +197,9 @@ class SpecialProjectVotingResult extends React.Component {
 const { object } = PropTypes;
 
 SpecialProjectVotingResult.propTypes = {
-  proposal: object,
+  DaoConfig: object.isRequired,
   daoInfo: object.isRequired,
+  proposal: object,
   translations: object.isRequired,
 };
 
@@ -200,4 +207,11 @@ SpecialProjectVotingResult.defaultProps = {
   proposal: undefined,
 };
 
-export default SpecialProjectVotingResult;
+const mapStateToProps = ({ infoServer }) => ({
+  DaoConfig: infoServer.DaoConfig.data,
+});
+
+export default connect(
+  mapStateToProps,
+  {}
+)(SpecialProjectVotingResult);


### PR DESCRIPTION
Ref: [DGDG-556](https://tracker.digixdev.com/issue/DGDG-556)

The minimum quorum for special projects should now use the following formula:

```
DaoConfig.CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR / DaoConfig.CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
```

**Test Plan**
- Check that the minimum quorum for special projects is 70%.
- Normal projects should have a minimum quorum that follows the formula `totalVoterStake / totalModeratorLockedDgds`.