### PR TITLE
[Fix] - Funding display on Dashboard

### DIFF
--- a/src/components/proposal-card/stats.js
+++ b/src/components/proposal-card/stats.js
@@ -57,6 +57,21 @@ export default class ProposalCardStats extends React.Component {
 
     const versionCount = details.proposalVersions ? details.proposalVersions.length : undefined;
     let funding = versionCount ? details.proposalVersions[versionCount - 1].totalFunding : 0;
+
+    if (details.isFundingChanged && details.changedFundings !== null) {
+      const { changedFundings } = details;
+      const expectedReward =
+        changedFundings.finalReward.updated !== null
+          ? changedFundings.finalReward.updated
+          : changedFundings.finalReward.original;
+
+      const fundingReducer = (acc, currentValue) => Number(acc) + Number(currentValue);
+      const fundings = changedFundings.milestones
+        .map(ms => (ms.updated !== null ? ms.updated : ms.original))
+        .reduce(fundingReducer);
+
+      funding = Number(expectedReward) + Number(fundings);
+    }
     funding = truncateNumber(funding);
 
     const {


### PR DESCRIPTION
This fixes an issue where Funding is not updated when a proposal funding has been updated using the `change funding` function.

Test Plan
 - Create a proposal with at least 2 milestones
 - Complete the voting process and claim approvals
 - Peform `change funding` then verify that funding displayed on the dashboard reflected the edited values