### PR TITLE
[FIX] Fix timing issue with fetching data from dao-server

### DIFF
--- a/src/api/graphql-queries/users.js
+++ b/src/api/graphql-queries/users.js
@@ -119,7 +119,7 @@ export const UserMutations = {
 };
 
 export const renderDisplayName = (dataDigixAttribute, welcome) => (
-  <Query query={fetchDisplayName}>
+  <Query query={fetchDisplayName} fetchPolicy="cache-only">
     {({ loading, error, data }) => {
       if (loading || error || !data.currentUser) {
         return null;
@@ -147,7 +147,7 @@ export const withAppUser = Component => props => (
 );
 
 export const withFetchUser = Component => props => (
-  <Query query={fetchUserQuery} fetchPolicy="network-only">
+  <Query query={fetchUserQuery}>
     {({ loading, error, data, refetch, subscribeToMore }) => {
       if (loading || error) {
         return null;

--- a/src/components/common/blocks/collapsible-menu/index.js
+++ b/src/components/common/blocks/collapsible-menu/index.js
@@ -139,9 +139,9 @@ class CollapsibleMenu extends React.Component {
   };
 
   renderAdminMenuItem = menu => (
-    <Query query={fetchUserQuery} key={menu.title}>
+    <Query query={fetchUserQuery} key={menu.title} fetchPolicy="cache-only">
       {({ loading, error, data }) => {
-        if (loading || error) {
+        if (loading || error || !data.currentUser) {
           return null;
         }
 

--- a/src/pages/user/profile/sections/activity-summary.js
+++ b/src/pages/user/profile/sections/activity-summary.js
@@ -83,11 +83,8 @@ class ProfileActivitySummary extends React.Component {
   }
 
   renderKyc() {
-    if (!this.props.userData) {
-      return null;
-    }
-
     const { email, kyc } = this.props.userData;
+
     const currentKycStatus = this.getKycStatus();
     const hasPendingKyc = kyc && kyc.status === KycStatus.pending;
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -77,7 +77,7 @@ export const getUserStatus = (addressDetails, translation) => {
 };
 
 export const isKycApproved = apolloClient =>
-  apolloClient.query({ query: fetchUserQuery, fetchPolicy: 'network-only' }).then(response => {
+  apolloClient.query({ query: fetchUserQuery }).then(response => {
     const { kyc } = response.data.currentUser;
     return kyc && kyc.status === KycStatus.approved;
   });


### PR DESCRIPTION
We have been getting issues where `currentUser` is `null` when we fetch data from the dao-server after loading a wallet. This is due to certain components in the sidebar (`renderDisplayName` and `renderAdminItem`) that try to fetch data before the authorization headers have been set. They are re-rendered when the `ChallengeProof` is set, but it doesn't check if the authorization headers are set.

This diff fixes that by setting the `fetchPolicy` of these components to `cache-only`, since the `AddressWatcher` component ensures that the query will be fetched correctly after the wallet is loaded.

This also reverts commit `bb541f1cd26d6e3f6f76c2c65e2f0e341931c27b` and `0b61d265f55b21d63755246950950790da2ff53a`, which were hotfixes for the issue.

### Test Plan
- Load the wallet for the KYC officer. They should be able to view the KYC dashboard.
- Load a participant wallet. They shouldn't have issues creating a project or checking their profile.