### PR TITLE
[HOTFIX] Remove fetching of proposal details from info-server and update subscription handling

### DIFF
--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -157,8 +157,12 @@ class Proposal extends React.Component {
 
   componentWillReceiveProps = nextProps => {
     const { proposalDetails } = nextProps;
-
-    if (!proposalDetails.fetching && proposalDetails.data && proposalDetails.data.proposalId) {
+    if (
+      !proposalDetails.fetching &&
+      proposalDetails.data &&
+      proposalDetails.data.proposalId &&
+      proposalDetails.data.proposalId === this.PROPOSAL_ID
+    ) {
       const currentVersion = proposalDetails.data.proposalVersions
         ? proposalDetails.data.proposalVersions.length - 1
         : 0;
@@ -169,8 +173,14 @@ class Proposal extends React.Component {
     }
   };
 
-  shouldComponentUpdate = (nextProps, nextState) =>
-    !_.isEqual(nextProps, this.props) || !_.isEqual(nextState, this.state);
+  shouldComponentUpdate = (nextProps, nextState) => {
+    const proposalDetails = nextProps.proposalDetails.data;
+    const stateHasChanged = !_.isEqual(nextState, this.state);
+    const propsHaveChanged = !_.isEqual(nextProps, this.props);
+    const isProposalIdSame = proposalDetails && proposalDetails.id === this.PROPOSAL_ID;
+
+    return stateHasChanged || (propsHaveChanged && isProposalIdSame);
+  };
 
   getProposalLikes = () => {
     const { challengeProof, getUserProposalLikeStatusAction } = this.props;
@@ -830,7 +840,6 @@ export default withFetchUser(
   connect(
     ({
       infoServer: {
-        ProposalDetails,
         AddressDetails,
         DaoConfig,
         DaoDetails: { data },
@@ -838,7 +847,6 @@ export default withFetchUser(
       daoServer: { ChallengeProof, UserProposalLike, Translations },
       govUI: { Language },
     }) => ({
-      proposalDetails: ProposalDetails,
       addressDetails: AddressDetails,
       challengeProof: ChallengeProof,
       daoInfo: data,


### PR DESCRIPTION
There is a caching bug where users will see a different proposal load on the page after viewing. The bug is difficult to catch since it's intermittent and hard to replicate.

This diff makes sure we're only using the GraphQL data for viewing the proposal details, and eliminate any bugs that might occur because we're loading the proposal details from the `info-server` (which might have been the source of the outdated cached data).

This also makes sure that we only update the component if the `ProposalDetails` props has the same proposal id as the one in the URL. It's possible that it could be a mishandling of the subscription, where we accidentally update the proposal page when an action has been done by the user, without checking if we are on the correct proposal.

### Test Plan
- Projects can still be viewed normally.
- When taking an action (such as endorsing a project), try to view a different project immediately. The page should not refresh with a different set of data.
- Regression tests should pass.