### PR TITLE
Fix/participant count

### DIFF
--- a/src/components/proposal-card/stats.js
+++ b/src/components/proposal-card/stats.js
@@ -11,7 +11,11 @@ import { Details, Info } from '@digix/gov-ui/components/proposal-card/style';
 export default class ProposalCardStats extends React.Component {
   getVotingRoundDetails = proposal => {
     const { votingStage } = this.props;
-    const { currentVotingRound, draftVoting, votingRounds } = proposal;
+    const { currentVotingRound, draftVoting, votingRounds, isSpecial } = proposal;
+
+    if (isSpecial === true) {
+      return votingRounds[0];
+    }
 
     switch (votingStage) {
       case VotingStages.draft:


### PR DESCRIPTION
Issue: 
- participant count and approval percentage on dashboard page for special proposals are not showing the right numbers

solution:
- added a condition wherein to check if the proposal is special then get the correct values of it and display to dashboard page