### PR TITLE
[FEATURE] - Remove name Popup for Metamask

### DIFF
--- a/src/components/common/blocks/wallet/metamask/index.js
+++ b/src/components/common/blocks/wallet/metamask/index.js
@@ -11,6 +11,16 @@ import Icon from '@digix/gov-ui/components/common/elements/icons';
 import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
 class Metamask extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      skipConfirmation: false,
+    };
+  }
+
+  handleClick = () => {
+    this.setState({ skipConfirmation: true });
+  };
   render() {
     return (
       (
@@ -35,13 +45,14 @@ class Metamask extends React.Component {
           data={{ type: 'metamask', updateDefaultAddress: true }}
           keystoreType="metamask"
           header="Load MetaMask Wallet"
+          skipConfirmation={this.state.skipConfirmation}
           hideSelector
           allowedKeystoreTypes={['metamask']}
           translations={this.props.translations}
           commonTranslations={this.props.commonTranslations}
           logLoadWallet={LogLoadWallet}
           trigger={
-            <Button kind="round" secondary fluid large showIcon>
+            <Button kind="round" secondary fluid large showIcon onClick={this.handleClick}>
               <Icon kind="metamask" />
               Metamask
             </Button>


### PR DESCRIPTION
Ref [DGDG-560](https://tracker.digixdev.com/issue/DGDG-560) 

Note: this feature requires https://github.com/DigixGlobal/governance-ui/pull/38 of the `governance-ui` project to work properly.

This feature/update sets the `skipConfirmation` prop to true when the Metamask Wallet button is clicked which triggers metamask wallet interaction to retrieve the default address.