### PR TITLE
[FIX] - Fix quorum progress for Special Proposals

### DIFF
--- a/src/components/common/elements/accordion/voting-result.js
+++ b/src/components/common/elements/accordion/voting-result.js
@@ -52,19 +52,24 @@ class VotingResult extends React.Component {
     const quorum = parseBigNumber(voting.quorum, 0, false);
     const quota = parseBigNumber(voting.quota, 0, false);
     const totalModeratorLockedDgds = parseBigNumber(daoInfo.totalModeratorLockedDgds, 0, false);
+    const totalLockedDgds = parseBigNumber(daoInfo.totalLockedDgds, 0, false);
     const totalVoterStake = parseBigNumber(voting.totalVoterStake, 0, false);
 
     const votes = Number(voting.totalVoterCount);
     const yesVotes = Number(voting.yes);
     const noVotes = Number(voting.no);
 
-    let minimumQuorum = formatPercentage(quorum / totalModeratorLockedDgds);
+    let minimumQuorum = formatPercentage(
+      quorum / (isSpecial ? totalLockedDgds : totalModeratorLockedDgds)
+    );
     if (isSpecial) {
       minimumQuorum = formatPercentage(
         CONFIG_SPECIAL_PROPOSAL_QUORUM_NUMERATOR / CONFIG_SPECIAL_PROPOSAL_QUORUM_DENOMINATOR
       );
     }
-    const quorumProgress = formatPercentage(totalVoterStake / totalModeratorLockedDgds);
+    const quorumProgress = formatPercentage(
+      totalVoterStake / (isSpecial ? totalLockedDgds : totalModeratorLockedDgds)
+    );
 
     const minimumApproval = formatPercentage(quota);
     const approvalProgress = formatPercentage(voting.yes / totalVoterStake);

--- a/src/pages/proposals/proposal-buttons/claim-results.js
+++ b/src/pages/proposals/proposal-buttons/claim-results.js
@@ -137,7 +137,9 @@ class ClaimResultsButton extends React.PureComponent {
       this.props.showRightPanel({
         show: false,
       });
-      this.setState({ claimingStep: proposal.votingRounds[currentVotingRound].currentClaimStep });
+      this.setState({
+        claimingStep: proposal.votingRounds[currentVotingRound].currentClaimStep,
+      });
     };
 
     const payload = {
@@ -183,12 +185,15 @@ class ClaimResultsButton extends React.PureComponent {
     const {
       isProposer,
       proposal,
-      proposal: { currentVotingRound = 0 },
       daoConfig,
       translations: { buttons },
     } = this.props;
 
     const { isMultiStep, claimingStep, totalTransactions } = this.state;
+
+    let { currentVotingRound } = proposal;
+
+    if (!currentVotingRound || currentVotingRound === null) currentVotingRound = 0;
 
     if (
       !isProposer ||
@@ -237,9 +242,7 @@ class ClaimResultsButton extends React.PureComponent {
         data-digix="ProposalAction-Results"
       >
         {withinDeadline && tentativePassed
-          ? `${claimCaption} ${
-              proposal.votingRounds[currentVotingRound].currentClaimStep
-            }/${totalTransactions}`
+          ? `${claimCaption} ${proposal.votingRounds[currentVotingRound].currentClaimStep}/${totalTransactions}`
           : buttons.claimFailedProject}
       </Button>
     );


### PR DESCRIPTION
This fixes an issue on Special Proposals where the Accordion Progress is not showing the right value and causes confusion on whether it has passed or not.

The fix is to use `totalLockedDgds` for special proposals and `totalModeratorLockedDgds` for normal proposals

Test Plan
 - Create a Special Project from  truffle console
 - Vote on the project either by letting it pass or fail
 - Claim the voting result