### PR TITLE
[FEATURE] Dashboard for 'Quarter Overview' and 'Your Stakes and Rewards'

### DIFF
--- a/src/components/common/blocks/timeline/index.js
+++ b/src/components/common/blocks/timeline/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import PropTypes, { bool } from 'prop-types';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
 
@@ -244,7 +244,7 @@ class Timeline extends React.Component {
   }
 }
 
-const { func, object } = PropTypes;
+const { func, object, bool } = PropTypes;
 
 Timeline.propTypes = {
   DaoConfig: object.isRequired,

--- a/src/components/common/blocks/timeline/index.js
+++ b/src/components/common/blocks/timeline/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import PropTypes, { bool } from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
 
@@ -8,11 +8,13 @@ import { DEFAULT_LOCKED_DGD } from '@digix/gov-ui/constants';
 import { getDaoConfig, getPriceInfo } from '@digix/gov-ui/reducers/info-server/actions';
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 import { withFetchDaoInfo } from '@digix/gov-ui/api/graphql-queries/dao';
+import UserAddressStats from '@digix/gov-ui/components/common/blocks/user-address-stats/index';
 
 import { ToolTip, Icon } from '@digix/gov-ui/components/common/index';
 import {
   MainPhase,
   Qtr,
+  Toggle,
   Stats,
   Item,
   Data,
@@ -29,6 +31,7 @@ class Timeline extends React.Component {
     super(props);
     this.state = {
       quarterDurationInDays: 90,
+      isQuarterOverview: true,
     };
 
     this.hasSubscribed = false;
@@ -102,6 +105,12 @@ class Timeline extends React.Component {
     return 100 * (timeEllapsed / duration);
   };
 
+  toggleTimeline = () => {
+    this.setState({
+      isQuarterOverview: !this.state.isQuarterOverview,
+    });
+  };
+
   priceFormatter = num => {
     if (Math.abs(num) > 999 && Math.abs(num) < 999999) {
       return `${Math.sign(num) * (Math.abs(num) / 1000).toFixed(2)}K`;
@@ -113,7 +122,7 @@ class Timeline extends React.Component {
   };
 
   render() {
-    const { stats, translations } = this.props;
+    const { stats, translations, isWalletLoaded } = this.props;
     if (!translations.data) return null;
     const { dashboard } = translations.data;
     const { Timeline: timeline } = dashboard;
@@ -121,7 +130,8 @@ class Timeline extends React.Component {
       return null;
     }
 
-    const { quarterDurationInDays } = this.state;
+    const { toggleTimeline } = this;
+    const { quarterDurationInDays, isQuarterOverview } = this.state;
     const { currentQuarter } = stats.data;
     let { startOfMainphase, startOfNextQuarter, startOfQuarter, remainingFunds } = stats.data;
 
@@ -138,76 +148,96 @@ class Timeline extends React.Component {
 
     return (
       <Wrapper>
-        <Qtr>Q{currentQuarter} Overview</Qtr>
+        <Qtr>
+          {isQuarterOverview
+            ? `Q${currentQuarter} ${dashboard.Timeline.overview}`
+            : `${dashboard.Timeline.yourStakesAndReward}`}
+        </Qtr>
+        {isWalletLoaded && (
+          <Toggle onClick={toggleTimeline}>
+            {isQuarterOverview
+              ? `${dashboard.Timeline.yourStakesAndReward}`
+              : `${dashboard.Timeline.quarter} ${dashboard.Timeline.overview}`}
+            <Icon kind="arrow" />
+          </Toggle>
+        )}
         <TimelineBar>
-          <Stats>
-            <Item>
-              <Data data-digix="Dashboard-Timeline-DaysEllpased">
-                {dashboard.Timeline.day} {daysEllapsed} of {quarterDurationInDays}
-              </Data>
-              <span className="equiv">
-                <span>{dashboard.Timeline.remainingDays}</span>
-              </span>
-            </Item>
-            <Item>
-              <Data data-digix="Dashboard-Timeline-TotalStake">
-                {lockedDgd} {dashboard.Timeline.stake}
-              </Data>
-              <span className="equiv">
-                <span>{dashboard.Timeline.totalLockedStakes}</span>
-              </span>
-            </Item>
-            <Item>
-              <Data data-digix="Dashboard-Timeline-RemainingFunds">
-                {remainingFunds} ETH (US${remainingPrice})
-              </Data>
-              <span className="equiv">
-                <span>{dashboard.Timeline.currentDigixDAOFunding}</span>
-              </span>
-            </Item>
-          </Stats>
-          <LockPhase>
-            <Label locking>
-              <div>
-                <Phase>{dashboard.Timeline.lockingPhase}</Phase>
-                <ToolTip
-                  title={timeline.stakinPhase || 'Staking Phase'}
-                  content={`${timeline.startsOn || `Starts on`} ${' '} ${moment(
-                    startOfQuarter
-                  ).format('dddd MMMM DD YYYY, h:mm:ss a')} ${timeline.endsOn ||
-                    'and ends on'} ${' '} ${moment(startOfMainphase).format(
-                    'dddd MMMM DD YYYY, h:mm:ss a'
-                  )}.`}
-                >
-                  <Icon kind="info" />
-                </ToolTip>
-              </div>
-            </Label>
-            <Progress locking>
-              <ProgressBar variant="determinate" value={lockingPhaseProgress || -1} />
-            </Progress>
-          </LockPhase>
-          <MainPhase>
-            <Label>
-              <div>
-                <Phase>{dashboard.Timeline.mainPhase}</Phase>
-                <ToolTip
-                  title={timeline.mainPhase || 'Main Phase'}
-                  content={`${timeline.startsOn || `Starts on`} ${' '} ${moment(
-                    startOfMainphase
-                  ).format('dddd MMMM DD YYYY, h:mm:ss a')} ${timeline.endsOn ||
-                    'and ends on'} ${' '} ${moment(startOfNextQuarter).format(
-                    'dddd MMMM DD YYYY, h:mm:ss a'
-                  )}`}
-                >
-                  <Icon kind="info" />
-                </ToolTip>
-              </div>
-            </Label>
-            <Progress main>
-              <ProgressBar variant="determinate" value={mainPhaseProgress || -1} />
-            </Progress>
-          </MainPhase>
+          {isQuarterOverview ? (
+            <Stats>
+              <Item>
+                <Data data-digix="Dashboard-Timeline-DaysEllpased">
+                  {dashboard.Timeline.day} {daysEllapsed} of {quarterDurationInDays}
+                </Data>
+                <span className="equiv">
+                  <span>{dashboard.Timeline.remainingDays}</span>
+                </span>
+              </Item>
+              <Item>
+                <Data data-digix="Dashboard-Timeline-TotalStake">
+                  {lockedDgd} {dashboard.Timeline.stake}
+                </Data>
+                <span className="equiv">
+                  <span>{dashboard.Timeline.totalLockedStakes}</span>
+                </span>
+              </Item>
+              <Item>
+                <Data data-digix="Dashboard-Timeline-RemainingFunds">
+                  {remainingFunds} ETH (US${remainingPrice})
+                </Data>
+                <span className="equiv">
+                  <span>{dashboard.Timeline.currentDigixDAOFunding}</span>
+                </span>
+              </Item>
+            </Stats>
+          ) : (
+            <UserAddressStats translations={translations} />
+          )}
+          {isQuarterOverview && (
+            <Fragment>
+              <LockPhase>
+                <Label locking>
+                  <div>
+                    <Phase>{dashboard.Timeline.lockingPhase}</Phase>
+                    <ToolTip
+                      title={timeline.stakinPhase || 'Staking Phase'}
+                      content={`${timeline.startsOn || `Starts on`} ${' '} ${moment(
+                        startOfQuarter
+                      ).format('dddd MMMM DD YYYY, h:mm:ss a')} ${timeline.endsOn ||
+                        'and ends on'} ${' '} ${moment(startOfMainphase).format(
+                        'dddd MMMM DD YYYY, h:mm:ss a'
+                      )}.`}
+                    >
+                      <Icon kind="info" />
+                    </ToolTip>
+                  </div>
+                </Label>
+                <Progress locking>
+                  <ProgressBar variant="determinate" value={lockingPhaseProgress || -1} />
+                </Progress>
+              </LockPhase>
+              <MainPhase>
+                <Label>
+                  <div>
+                    <Phase>{dashboard.Timeline.mainPhase}</Phase>
+                    <ToolTip
+                      title={timeline.mainPhase || 'Main Phase'}
+                      content={`${timeline.startsOn || `Starts on`} ${' '} ${moment(
+                        startOfMainphase
+                      ).format('dddd MMMM DD YYYY, h:mm:ss a')} ${timeline.endsOn ||
+                        'and ends on'} ${' '} ${moment(startOfNextQuarter).format(
+                        'dddd MMMM DD YYYY, h:mm:ss a'
+                      )}`}
+                    >
+                      <Icon kind="info" />
+                    </ToolTip>
+                  </div>
+                </Label>
+                <Progress main>
+                  <ProgressBar variant="determinate" value={mainPhaseProgress || -1} />
+                </Progress>
+              </MainPhase>
+            </Fragment>
+          )}
         </TimelineBar>
       </Wrapper>
     );
@@ -225,6 +255,7 @@ Timeline.propTypes = {
   stats: object.isRequired,
   translations: object.isRequired,
   subscribeToDao: func,
+  isWalletLoaded: bool.isRequired,
 };
 
 Timeline.defaultProps = {

--- a/src/components/common/blocks/timeline/style.js
+++ b/src/components/common/blocks/timeline/style.js
@@ -32,6 +32,35 @@ export const Qtr = styled.div`
   display: flex;
   align-items: left;
   margin-bottom: 5rem;
+  ${media.mobile`
+    margin-bottom: 2.5rem;
+  `};
+`;
+
+export const Toggle = styled.a`
+  color: ${props => props.theme.textColor.secondary.base.toString()};
+  font-family: 'Futura PT Book', sans-serif;
+  font-size: 1.4em;
+  text-transform: uppercase;
+  position: absolute;
+  right: 5rem;
+  top: 6rem;
+  > div {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-left: 1rem;
+
+    svg {
+      transform: rotate(-90deg);
+    }
+    
+  ${media.mobile`
+    position: relative;
+    text-align: right;
+    right: 0;
+    top: 0;
+    margin-bottom: 2.5rem;
+  `};
 `;
 
 export const Stats = styled(Card)`

--- a/src/components/common/blocks/timeline/style.js
+++ b/src/components/common/blocks/timeline/style.js
@@ -107,7 +107,7 @@ export const Data = styled.div`
   justify-content: flex-start;
   align-items: flex-end;
   font-family: 'Futura PT Medium';
-  font-size: 1.8em;
+  font-size: 2.5rem;
   text-align: left;
   margin-bottom: 0.5em;
 

--- a/src/components/common/blocks/user-address-stats/index.js
+++ b/src/components/common/blocks/user-address-stats/index.js
@@ -3,12 +3,7 @@ import PropTypes from 'prop-types';
 import { truncateNumber } from '@digix/gov-ui/utils/helpers';
 import { withFetchAddress } from '@digix/gov-ui/api/graphql-queries/address';
 
-import {
-  Data,
-  Item,
-  Label,
-  UserStats,
-} from '@digix/gov-ui/components/common/blocks/user-address-stats/style';
+import { Data, Item, Stats } from '@digix/gov-ui/components/common/blocks/user-address-stats/style';
 
 class UserAddressStats extends React.Component {
   componentDidMount() {
@@ -37,36 +32,38 @@ class UserAddressStats extends React.Component {
     const stake = truncateNumber(lockedDgdStake || 0);
     const dgd = truncateNumber(lockedDgd || 0);
     return (
-      <UserStats>
+      <Stats>
         <Item>
-          <Label>{dashboard.UserStats.quarterPoints}</Label>
-          <Data>
-            <span data-digix="Dashboard-Stats-QuarterPoints">{quarterPoint || 0}</span>
+          <Data data-digix="Dashboard-Stats-QuarterPoints">
+            {quarterPoint || 0} Points
             {isModerator && (
-              <span className="equiv">
-                <span>( </span>
-                <span data-digix="Dashboard-Mod-QtrPts">{moderatorQuarterPoint}</span>
-                <span>&nbsp; {dashboard.UserStats.moderatorPoints} )</span>
+              <span data-digix="Dashboard-Mod-QtrPts" className="small-info">
+                ({moderatorQuarterPoint} {dashboard.UserStats.moderatorPoints})
               </span>
             )}
           </Data>
+          <span className="equiv">
+            <span>{dashboard.UserStats.quarterPoints}</span>
+          </span>
         </Item>
         <Item>
-          <Label>{dashboard.UserStats.reputationPoints}</Label>
-          <Data data-digix="Dashboard-Stats-ReputationPoints">{reputationPoint || 0}</Data>
+          <Data data-digix="Dashboard-Stats-ReputationPoints">{reputationPoint || 0} Points</Data>
+          <span className="equiv">
+            <span>{dashboard.UserStats.reputationPoints}</span>
+          </span>
         </Item>
         <Item>
-          <Label>{dashboard.UserStats.stake}</Label>
           <Data data-digix="Dashboard-Stats-Stake">
-            <span data-digix="Dashboard-Locked-Stake">{stake}</span>
-            <span className="equiv">
-              <span>( </span>
-              <span data-digix="Dashboard-Locked-DGD">{dgd}</span>
-              <span>&nbsp;{dashboard.UserStats.dgdLocked} )</span>
+            {stake} ETH
+            <span data-digix="Dashboard-Locked-DGD" className="small-info">
+              ({dgd} {dashboard.UserStats.dgdLocked})
             </span>
           </Data>
+          <span className="equiv">
+            <span>{dashboard.UserStats.stake}</span>
+          </span>
         </Item>
-      </UserStats>
+      </Stats>
     );
   }
 }

--- a/src/components/common/blocks/user-address-stats/style.js
+++ b/src/components/common/blocks/user-address-stats/style.js
@@ -46,7 +46,7 @@ export const Data = styled.div`
   justify-content: flex-start;
   align-items: flex-end;
   font-family: 'Futura PT Medium';
-  font-size: 1.8em;
+  font-size: 2.5rem;
   text-align: left;
   margin-bottom: 0.5em;
 

--- a/src/components/common/blocks/user-address-stats/style.js
+++ b/src/components/common/blocks/user-address-stats/style.js
@@ -2,10 +2,11 @@ import styled, { css } from 'styled-components';
 import { Card } from '@digix/gov-ui/components/common/common-styles';
 import { media } from '@digix/gov-ui/components/common/breakpoints';
 
-export const UserStats = styled(Card)`
+export const Stats = styled(Card)`
   text-transform: uppercase;
   padding: 0;
-
+  background-color: ${props => props.theme.backgroundTertiary.lightest.toString()};
+  box-shadow: none;
   ${props =>
     props.dashboard &&
     css`
@@ -13,8 +14,8 @@ export const UserStats = styled(Card)`
     `};
 
   ${media.mobile`
-    padding: 3rem 5rem;
-      flex-direction: column;
+    padding: 3rem 3rem;
+    flex-direction: column;
   `};
 `;
 
@@ -31,7 +32,7 @@ export const Item = styled.div`
   ${media.mobile`
     border-right: none;
     margin-bottom: 2rem;
-    padding: 0;
+    padding: 0 0 1rem 0;
     
     &:last-child {
       margin-bottom: 0;
@@ -39,24 +40,20 @@ export const Item = styled.div`
   `};
 `;
 
-export const Label = styled.div`
-  text-align: left;
-  font-family: 'Futura PT Heavy', sans-serif;
-`;
-
 export const Data = styled.div`
-  margin-top: 1rem;
   display: flex;
+  text-transform: none;
   justify-content: flex-start;
   align-items: flex-end;
-  font-family: 'Futura PT Heavy';
-  font-size: 3.8rem;
+  font-family: 'Futura PT Medium';
+  font-size: 1.8em;
   text-align: left;
+  margin-bottom: 0.5em;
 
   span {
     &.equiv {
       font-family: 'Futura PT Light', sans-serif;
-      font-size: 1.6rem;
+      font-size: 1.2em;
       color: ${props => props.theme.textColor.default.base.toString()};
       margin-left: 1rem;
       margin-bottom: 0.75rem;
@@ -67,6 +64,13 @@ export const Data = styled.div`
       ${media.mobile`
         margin-left: 1rem;
       `};
+    }
+    &.small-info {
+      font-family: 'Futura PT Light', sans-serif;
+      font-size: 0.75em;
+      margin-bottom: 0.2em;
+      margin-left: 0.5em;
+      color: ${props => props.theme.textColor.default.base.toString()};
     }
   }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,6 @@ import CountdownPage from '@digix/gov-ui/components/common/blocks/loader/countdo
 import ProposalCard from '@digix/gov-ui/components/proposal-card';
 import Timeline from '@digix/gov-ui/components/common/blocks/timeline';
 import ToS from '@digix/gov-ui/tos.md';
-import UserAddressStats from '@digix/gov-ui/components/common/blocks/user-address-stats/index';
 import ProposalFilter from '@digix/gov-ui/components/common/blocks/filter/index';
 import { Content, Title, TosOverlay } from '@digix/gov-ui/pages/style';
 import { CONFIRM_PARTICIPATION_CACHE } from '@digix/gov-ui/constants';
@@ -289,8 +288,7 @@ class LandingPage extends React.PureComponent {
 
     return (
       <Fragment>
-        <Timeline stats={DaoDetails} translations={Translations} />
-        {isWalletLoaded && <UserAddressStats translations={Translations} />}
+        <Timeline stats={DaoDetails} translations={Translations} isWalletLoaded={isWalletLoaded} />
         <ProposalFilter
           setProposalList={this.setProposalList}
           onOrderChange={this.onOrderChange}

--- a/src/translations/chinese/dashboard.json
+++ b/src/translations/chinese/dashboard.json
@@ -13,7 +13,10 @@
     "totalLockedStakes": "总锁定金额",
     "currentDigixDAOFunding": "目前DigixDao资金",
     "startsOn": "起始日期",
-    "endsOn": "终止日期"
+    "endsOn": "终止日期",
+    "yourStakesAndReward": "您锁定的金额&奖励",
+    "overview": "总览",
+    "quarter": "季度"
   },
   "UserStats": {
     "quarterPoints": "季度积分",

--- a/src/translations/english/dashboard.json
+++ b/src/translations/english/dashboard.json
@@ -16,7 +16,10 @@
     "reputationPoints": "Reputation Points",
     "dgdLocked": "DGD Locked",
     "startsOn": "Starts on",
-    "endsOn": "and ends on"
+    "endsOn": "and ends on",
+    "yourStakesAndReward": "Your Stakes & Rewards",
+    "overview": "Overview",
+    "quarter": "Quarter"
   },
   "UserStats": {
     "quarterPoints": "Quarter Points",


### PR DESCRIPTION
Expansion from this ref: [DGDG-561](https://tracker.digixdev.com/issue/DGDG-561)

## Description
This PR is for the new timeline dashboard based on vi's design. Which allows the dashboard to be toggled between `Quarter Review` and `Your Stakes and Rewards` dashboards.

## Test Plan
- Load the DAO
- You'll see the dashboard with no `Your Stakes and Rewards` toggle option.
![no-wallet](https://i.imgur.com/NFi1LoD.png)

- Load the right wallet which has access to `Your Stakes and Rewards`, then you'll see the option.
![with-wallet](https://i.imgur.com/CnOHAOX.png)

- Now you should be able to toggle between two dashboards.
![toggle](https://i.imgur.com/gF8cg15.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
