### PR TITLE
[HOTFIX] Hide button to continue participation with current locked DGD

### DIFF
--- a/src/pages/continue-participation.js
+++ b/src/pages/continue-participation.js
@@ -149,7 +149,8 @@ class ConfirmParticipation extends React.Component {
         >
           {tOptions.lockDgd}
         </Button>
-        <Button
+        {/* HOTIFIX: hide button until contract for it is fixed */}
+        {/* <Button
           fluid
           large
           reverse
@@ -158,7 +159,7 @@ class ConfirmParticipation extends React.Component {
           onClick={() => this.continueParticipation()}
         >
           {tOptions.continueCurrentLockup}
-        </Button>
+        </Button> */}
         <Button
           fluid
           large

--- a/src/translations/english/confirmParticipation.json
+++ b/src/translations/english/confirmParticipation.json
@@ -1,6 +1,6 @@
 {
   "title": "Confirming Participation For New Quarter",
-  "instructions": "In order to continue participating in the new quarter, we need you to sign a transaction confirming the amount of stake you have on the platform. There are 3 options of transactions you can make:",
+  "instructions": "In order to continue participating in the new quarter, we need you to sign a transaction confirming the amount of stake you have on the platform. If you want to keep the same amount of locked DGDs, you will need to unlock some and lock back the same amount.",
   "options": {
     "lockDgd": "I want to lock more DGD",
     "continueCurrentLockup": "I want to continue with my current lock-up of DGD",


### PR DESCRIPTION
There is a bug in the contracts, so we'll hide this functionality for now until the bug is fixed.