### PR TITLE
[FEATURE] - Hardcoded content for Special Proposal

### DIFF
--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -12,7 +12,9 @@ import ParticipantButtons from '@digix/gov-ui/pages/proposals/proposal-buttons/p
 import ProjectDetails from '@digix/gov-ui/pages/proposals/details';
 import ProposalFundings from '@digix/gov-ui/pages/proposals/fundings';
 import ProposalVersionNav from '@digix/gov-ui/pages/proposals/version-nav';
-import SpecialProjectDetails from '@digix/gov-ui/pages/proposals/special-project-details';
+import SpecialProjectDetails, {
+  ShortenedProposal,
+} from '@digix/gov-ui/pages/proposals/special-project-details';
 import SpecialProjectVotingResult from '@digix/gov-ui/pages/proposals/special-project-voting-result';
 import AdditionalDocs from '@digix/gov-ui/pages/proposals/additional-docs';
 import VotingAccordion from '@digix/gov-ui/components/common/elements/accordion/voting-accordion';
@@ -620,10 +622,17 @@ class Proposal extends React.Component {
           daoInfo={daoInfo}
           translations={translations}
         />
-        <SpecialProjectDetails
-          uintConfigs={proposalDetails.data.uintConfigs}
-          translations={translations}
-        />
+        {proposal.id === '0xd75d13bc6e254db93f313ad7c880c195637ef3568e6495425d2e9b2842dff584' ? (
+          <SpecialProjectDetails
+            uintConfigs={proposalDetails.data.uintConfigs}
+            translations={translations}
+          />
+        ) : (
+          <ShortenedProposal
+            uintConfigs={proposalDetails.data.uintConfigs}
+            translations={translations}
+          />
+        )}
         {hasMoreDocs && <AdditionalDocs translations={translations} proposal={proposalDetails} />}
         <CommentThread
           proposalId={this.PROPOSAL_ID}

--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -622,7 +622,7 @@ class Proposal extends React.Component {
           daoInfo={daoInfo}
           translations={translations}
         />
-        {proposal.id === '0xd75d13bc6e254db93f313ad7c880c195637ef3568e6495425d2e9b2842dff584' ? (
+        {proposal.id !== '0xd75d13bc6e254db93f313ad7c880c195637ef3568e6495425d2e9b2842dff584' ? (
           <SpecialProjectDetails
             uintConfigs={proposalDetails.data.uintConfigs}
             translations={translations}

--- a/src/pages/proposals/special-project-details.js
+++ b/src/pages/proposals/special-project-details.js
@@ -114,6 +114,147 @@ const SpecialProjectDetails = props => (
     </Content>
   </DetailsContainer>
 );
+export const ShortenedProposal = () => (
+  <DetailsContainer>
+    <Content special>
+      <Title>
+        Title:{' '}
+        <span>
+          Configuration change - Shortening Voting Duration for voting rounds & Increasing maximum
+          hard-cap on Ether funding per project
+        </span>
+      </Title>
+      <SubTitle>Preamble</SubTitle>
+      <p>
+        We have decided to submit a project to change certain configurations of the DigixDAO
+        platform to improve efficiency of the governance process and encourage more participation.
+      </p>
+      <p>
+        In short, we are proposing to shorten the durations for the different types of voting that
+        can occur on the platform.
+      </p>
+      <p>
+        This would allow for faster rejection / approval of projects, which could help the proposer
+        better plan and allocate his time / resources to their projects.
+      </p>
+      <p>
+        Please note that there is no funding called for this project. The project has only to do
+        with changing certain voting round durations to improve the efficiency of future project
+        funding.
+      </p>
+      <p>
+        <strong>Note: </strong> Digix had proposed a Special Project at the end of Q1, to modify
+        these configuration changes. The project was not able to reach the minimum required quorum
+        (minimum number of DGDs to cast their vote on the project). Due to an issue in displaying
+        the voting results, we believed there were enough DGDs voting on that project. We put
+        forward the below described Special Project specifications, in order to bring about the same
+        changes in addition to one more change, that is, increasing the maximum hard-cap on Ether
+        funds that can be asked for from DigixDAO per project.
+      </p>
+      <SubTitle>Description</SubTitle>
+      <p>The current configuration of the voting durations is as such:</p>
+      <ul>
+        <li>A Moderator voting round takes 10 days</li>
+        <li>A Participant voting round takes 14 days of Commit phase and 7 days of Reveal phase</li>
+        <li>
+          A Special Project’s voting round takes 28 days of Commit phase and 7 days of Reveal phase
+        </li>
+        <li>
+          There needs to be a buffer of at least 10 days from the end of the voting rounds to the
+          end of the quarter, for the proposer to claim the result of the voting.
+        </li>
+        <li>
+          The maximum Ether funding that can be asked for, from DigixDAO by a participant, is
+          hard-capped at 100 ETH per project
+        </li>
+      </ul>
+      <p>
+        With this current configuration, as has been raised by some in the community, the voting
+        rounds are seemingly longer than needed, which lead to some concerns:
+      </p>
+      <p>
+        We also believe that we have seen productive projects being proposed to DigixDAO. We are
+        also now increasingly confident of the security of our entire system. After having
+        considered the opinions from our community members, we would like to raise this hard-cap to
+        a higher number.
+      </p>
+      <ul>
+        <li>
+          It delays the funding for projects that would pass. Even if a project receives a huge
+          amount of support from the community, it will still have to wait at least 31 days to get
+          its funding.
+        </li>
+        <li>
+          There is a situation where projects have to finalise before day 49 in the quarter, to be
+          funded in the same quarter (due to long voting periods). This is because there needs to be
+          a minimum of 41 days left in the quarter for all the voting to complete. These 41 days
+          consist of 10 days of Moderator voting round, 21 days of Participant voting round and 10
+          days buffer for claiming voting result.
+        </li>
+      </ul>
+
+      <p>
+        As such, we are proposing to shorten the voting periods for the following voting rounds:
+      </p>
+      <ul>
+        <li>
+          Participant voting round: from 14 days of Commit phase + 7 days of Reveal phase to 10 days
+          of Commit phase + 5 days of Reveal phase.
+        </li>
+        <li>
+          Special Project voting round: from 28 days of Commit phase + 7 days of Reveal phase to 14
+          days of Commit phase + 7 days of Reveal phase
+        </li>
+        <li>Buffer for claiming voting results: from 10 days to 7 days</li>
+        <li>
+          Maximum Ether funds that can be asked for from DigixDAO by a participant: from 100 ETH to
+          300 ETH
+        </li>
+      </ul>
+      <p>
+        With these changes in place, proposers can expect to receive their funding 25 days (instead
+        of 31 days) after they finalise their project, and they will have until day 58 to finalise
+        their project to be able to receive funding in the same quarter. We believe that these new
+        durations are more reasonable and would make the project filtering process more efficient in
+        DigixDAO.
+      </p>
+      <p>
+        In addition, with the max hard-cap for Ether funds per project being raised to 300 ETH,
+        DigixDAO participants would also be able to propose projects that require greater financial
+        resources.
+      </p>
+      <p>
+        If approved, the changes proposed by this Special Project will only take effects in Quarter
+        2. Hence, voting durations in Quarter 1 will still remain the same regardless.
+      </p>
+      <p>
+        As for the voting process for this Special Project, it follows a Commit and Reveal scheme
+        that is similar to a Participant voting round. If you have any problems or questions, do
+        contact us via the Help button below or raise the issue in room dgdao-help in our discord
+        channel.
+      </p>
+      <p>
+        <img src={DigixDAOConfigChange02} alt="Participant Voting - Special Project" width="100%" />
+      </p>
+      <p>
+        <img src={DigixDAOConfigChange01} alt="Participant Voting - Normal Project" width="100%" />
+      </p>
+      {/* TODO: re-instate this later once special proposals need to be displayed */}
+      {/* <SubTitle>Configuration Details</SubTitle>
+      {Object.keys(props.uintConfigs).map(key => {
+        if (key === '__typename') return null;
+        return (
+          <div key={key}>
+            <span>
+              <strong>{key}: </strong>
+            </span>
+            <span>{props.uintConfigs[key]}</span>
+          </div>
+        );
+      })} */}
+    </Content>
+  </DetailsContainer>
+);
 
 const { object } = PropTypes;
 SpecialProjectDetails.propTypes = {


### PR DESCRIPTION
This change is specific to handling the special proposal with id `0xd75d13bc6e254db93f313ad7c880c195637ef3568e6495425d2e9b2842dff584` to display specific details.

All other special proposals should have the old content displayed.

Note:
- This should be cherry-picked to `deploy-production` branch