### PR TITLE
[FIX] - Empty Data showing on Voting Result

### DIFF
--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -18,7 +18,11 @@ import AdditionalDocs from '@digix/gov-ui/pages/proposals/additional-docs';
 import VotingAccordion from '@digix/gov-ui/components/common/elements/accordion/voting-accordion';
 import VotingResult from '@digix/gov-ui/pages/proposals/voting-result';
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
-import { getAddressDetails } from '@digix/gov-ui/reducers/info-server/actions';
+import {
+  getAddressDetails,
+  getDaoConfig,
+  getDaoDetails,
+} from '@digix/gov-ui/reducers/info-server/actions';
 import { initializePayload } from '@digix/gov-ui/api';
 import { Message, Notifications } from '@digix/gov-ui/components/common/common-styles';
 import { ProjectActionableStatus, ProposalStages, VotingStages } from '@digix/gov-ui/constants';
@@ -133,6 +137,8 @@ class Proposal extends React.Component {
     const {
       clearDaoProposalDetailsAction,
       getAddressDetailsAction,
+      getDaoConfigAction,
+      getDaoDetailsAction,
       location,
       addressDetails,
       getTranslationsAction,
@@ -144,6 +150,8 @@ class Proposal extends React.Component {
         if (addressDetails.data.address) {
           getAddressDetailsAction(addressDetails.data.address);
         }
+        getDaoConfigAction();
+        getDaoDetailsAction();
         this.getProposalLikes();
       }
     }
@@ -814,6 +822,8 @@ Proposal.propTypes = {
   getUserProposalLikeStatusAction: func.isRequired,
   clearDaoProposalDetailsAction: func.isRequired,
   getAddressDetailsAction: func.isRequired,
+  getDaoConfigAction: func.isRequired,
+  getDaoDetailsAction: func.isRequired,
   likeProposalAction: func.isRequired,
   unlikeProposalAction: func.isRequired,
   addressDetails: object.isRequired,
@@ -858,6 +868,8 @@ export default withFetchUser(
     {
       getUserProposalLikeStatusAction: getUserProposalLikeStatus,
       getAddressDetailsAction: getAddressDetails,
+      getDaoConfigAction: getDaoConfig,
+      getDaoDetailsAction: getDaoDetails,
       likeProposalAction: likeProposal,
       unlikeProposalAction: unlikeProposal,
       clearDaoProposalDetailsAction: clearDaoProposalDetails,


### PR DESCRIPTION
This fixes an issue where Project Result is not displaying the proper values when Proposals/Projects are visited directly or when the page is refreshed.


## Description
Added a call to `getDaoInfo` and `getDaoConfigs` when the page is loaded to they are populated.

## Test Plan0
 - Visit any Proposals/Project
 - Take note of the Project Results
 - Refresh the page and verify if the Results are the same before the page has been refreshed
<!--- Add screenshots to make it easier to visually verify. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have squashed my commit with a meaningful message before merging.
- [ ] I have updated the documentation if needed and accordingly.
- [x] I have added a test plan to my commit message for QA to follow.
- [x] QA has tested and verified the PR.
- [ ] I have signed and submitted the *Contributors License Agreement*.
