### PR TITLE
[HOTFIX] Add safety conditions for rendering Edit Funding Button

### DIFF
--- a/src/components/common/blocks/overlay/change-funding/index.js
+++ b/src/components/common/blocks/overlay/change-funding/index.js
@@ -50,19 +50,21 @@ class ChangeFundingOverlay extends React.Component {
   componentWillMount = () => {
     const { proposalDetails } = this.props;
     const { form } = this.state;
-    if (proposalDetails) {
-      if (!proposalDetails.isFundingChanged) {
-        const currentVersion =
-          proposalDetails.proposalVersions[proposalDetails.proposalVersions.length - 1];
-        form.expectedReward = currentVersion.finalReward;
-        form.milestoneFundings = currentVersion.milestoneFundings;
-      } else {
-        const { changedFundings } = proposalDetails;
-        form.expectedReward = changedFundings.finalReward.updated;
-        form.milestoneFundings = changedFundings.milestones.map(ms => ms.updated);
-      }
-      this.setState({ form: { ...form } });
+    if (!proposalDetails) {
+      return;
     }
+
+    const { changedFundings, isFundingChanged, proposalVersions } = proposalDetails;
+    if (!isFundingChanged && !!proposalVersions) {
+      const currentVersion = proposalVersions[proposalVersions.length - 1];
+      form.expectedReward = currentVersion.finalReward;
+      form.milestoneFundings = currentVersion.milestoneFundings;
+    } else if (changedFundings) {
+      form.expectedReward = changedFundings.finalReward.updated;
+      form.milestoneFundings = changedFundings.milestones.map(ms => ms.updated);
+    }
+
+    this.setState({ form: { ...form } });
   };
 
   onExpectedRewardChange = e => {

--- a/src/pages/proposals/fundings.js
+++ b/src/pages/proposals/fundings.js
@@ -39,7 +39,7 @@ class ProposalFundings extends React.Component {
 
   getChangedFundings() {
     const proposal = this.props.proposalDetails.data;
-    if (!proposal.isFundingChanged) {
+    if (!proposal.isFundingChanged || !proposal.changedFundings) {
       return {
         milestoneFunds: null,
         milestoneFundDifference: null,

--- a/src/pages/proposals/index.js
+++ b/src/pages/proposals/index.js
@@ -220,7 +220,7 @@ class Proposal extends React.Component {
     let reward = null;
     let rewardDifference = null;
 
-    if (!proposal.isFundingChanged) {
+    if (!proposal.isFundingChanged || !proposal.changedFundings) {
       return {
         milestoneFunds,
         milestoneFundDifference,


### PR DESCRIPTION
Users are intermittently getting this error:

```
TypeError: Cannot read property 'finalReward' of undefined
```

The bug could be occurring in special proposals where the Edit Funding button encounters rendering problems because there's no `proposalVersions` field for special proposals. This diff adds the safety condition so the button renders without problems.
