### PR TITLE
Fix/add time to proposal comments

### DIFF
--- a/src/pages/proposals/comment/author.js
+++ b/src/pages/proposals/comment/author.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { UserInfo } from '@digix/gov-ui/pages/proposals/comment/style';
+import { getElapsedTime } from '@digix/gov-ui/utils/timeDateUtils';
 
 export default class CommentAuthor extends React.Component {
   render() {
     const {
       hide,
       user,
+      createdAt,
       translations: {
         data: {
           dashboard: { UserStats },
@@ -30,19 +32,27 @@ export default class CommentAuthor extends React.Component {
         <span data-digix="CommentAuthor-QuarterPoints">
           {UserStats.quarterPoints}: {user.quarterPoint}
         </span>
+        {createdAt && (
+          <React.Fragment>
+            <span>&bull;</span>
+            <span data-digix="CommentAuthor-QuarterPoints">{getElapsedTime(createdAt)}</span>
+          </React.Fragment>
+        )}
       </UserInfo>
     );
   }
 }
 
-const { bool, object } = PropTypes;
+const { bool, object, string } = PropTypes;
 
 CommentAuthor.propTypes = {
   hide: bool,
   user: object.isRequired,
   translations: object.isRequired,
+  createdAt: string,
 };
 
 CommentAuthor.defaultProps = {
   hide: false,
+  createdAt: '',
 };

--- a/src/pages/proposals/comment/comment.js
+++ b/src/pages/proposals/comment/comment.js
@@ -190,7 +190,7 @@ class Comment extends React.Component {
   render() {
     const { currentUser, translations } = this.props;
     const { comment } = this.state;
-    const { body, isBanned, user } = comment;
+    const { body, isBanned, user, createdAt } = comment;
     const isForumAdmin = currentUser != null ? currentUser : false;
 
     const isDeleted = !body;
@@ -201,7 +201,12 @@ class Comment extends React.Component {
 
     return (
       <CommentListItem>
-        <CommentAuthor hide={isDeleted} user={user} translations={translations} />
+        <CommentAuthor
+          hide={isDeleted}
+          user={user}
+          translations={translations}
+          createdAt={createdAt}
+        />
         <CommentPost isHidden={isHidden} deleted={isDeleted}>
           <Content data-digix="Comment-Message">
             <Markdown source={commentMessage} escapeHtml={false} />

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -1,5 +1,6 @@
 import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
 import { REDUX_PREFIX, CMC_ENDPOINT } from './constants';
+import { updateMomentLocale } from '@digix/gov-ui/utils/timeDateUtils';
 
 export const actions = {
   SHOW_LOCK_DGD_OVERLAY: `${REDUX_PREFIX}SHOW_LOCK_DGD_OVERLAY`,
@@ -138,6 +139,8 @@ export function getTokenUsdValue() {
 }
 
 export function setLanguageTranslation(payload = 'en') {
+  updateMomentLocale(payload);
+
   return dispatch => {
     dispatch({ type: actions.SET_TRANSLATION_LANGUAGE, payload });
   };

--- a/src/utils/timeDateUtils.js
+++ b/src/utils/timeDateUtils.js
@@ -1,5 +1,30 @@
 import moment from 'moment';
 
+export function updateMomentLocale(lang) {
+  if (lang) {
+    switch (lang) {
+      case 'cn': {
+        moment.updateLocale('zh-cn', {
+          relativeTime: {
+            past: '%s 前',
+          },
+        });
+        break;
+      }
+      case 'en': {
+        moment.updateLocale('en', {
+          relativeTime: {
+            past: '%s ago',
+          },
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}
+
 export function getElapsedTime(date) {
   const timeElapsed = moment(date);
 

--- a/src/utils/timeDateUtils.js
+++ b/src/utils/timeDateUtils.js
@@ -1,0 +1,7 @@
+import moment from 'moment';
+
+export function getElapsedTime(date) {
+  const timeElapsed = moment(date);
+
+  return timeElapsed.fromNow();
+}


### PR DESCRIPTION
## WHY
From the GUI there is no way of knowing how long time ago a comment was posted. And neither how long time ago someone replied to your comment. We need some way of showing time, i copied the time format logic used on reddit since i think it fits well for comments. Would be nice to add a time stamp to proposals as well.

## WHAT
Created a timeDateUtils file which will handle formatting and changing of locale. So when changing language though the action `setLanguageTranslation` we also update moments locale.

## HOW TO TEST
1. Go to a proposal page with comments and see that time is now in the comment header. 
2. Change language and verify that the time text changes to the correct language.