### PR TITLE
wrap button in link

### DIFF
--- a/src/components/proposal-card/proposal.js
+++ b/src/components/proposal-card/proposal.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import LikeButton from '@digix/gov-ui/components/common/elements/like';
 import LogDashboard from '@digix/gov-ui/analytics/dashboard';
@@ -19,12 +20,10 @@ import {
 } from '@digix/gov-ui/components/proposal-card/style';
 
 class Proposal extends React.PureComponent {
-  redirectToProposalPage = () => {
-    const { AddressDetails, details, history } = this.props;
+  logClickToProposalPage = () => {
+    const { AddressDetails, details } = this.props;
     const userType = getUserStatus(AddressDetails.data, UserStatus);
-
     LogDashboard.viewProject(userType);
-    history.push(`/proposals/${details.proposalId}`);
   };
 
   render() {
@@ -103,15 +102,16 @@ class Proposal extends React.PureComponent {
             </p>
           </ShortDescr>
 
-          <ViewCta
-            small
-            reverse
-            role="link"
-            onClick={this.redirectToProposalPage}
-            data-digix="Participate-Btn"
-          >
-            {cardTranslation.view}
-          </ViewCta>
+          <Link to={`/proposals/${details.proposalId}`} onClick={this.logClickToProposalPage}>
+            <ViewCta
+              small
+              reverse
+              role="link"
+              data-digix="Participate-Btn"
+            >
+              {cardTranslation.view}
+            </ViewCta>
+          </Link>
         </AboutProposal>
       </Details>
     );


### PR DESCRIPTION
## WHY
1. it will be possible to open proposals in a new tab by holding down cmd + clicking.
2. the browser will show where an a-tag will take them in the lower left of the window .
3. Better Accessibility for handicapped people using screen readers and such

## WHAT
Saw similar logic at another place to make a button be an a-tag so i just followed that pattern. Wrapping a button in an ReactRouter link