### PR TITLE
Move active project tab (stage) to redux instead of in the react stat…

### DIFF
--- a/src/components/common/blocks/filter/category.js
+++ b/src/components/common/blocks/filter/category.js
@@ -9,13 +9,6 @@ import { fetchProposalList } from '@digix/gov-ui/api/graphql-queries/proposal';
 import { getProposalsCount } from '@digix/gov-ui/reducers/info-server/actions';
 
 export class CategoryGroup extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      stage: 'all',
-    };
-  }
-
   componentDidMount = () => {
     this.props.getProposalsCount();
   };
@@ -36,7 +29,6 @@ export class CategoryGroup extends React.Component {
 
   handleClick(stage) {
     LogDashboard.filterProjectByStage(stage);
-    this.setState({ stage });
     this.getProposalList(stage);
     this.props.getProposalsCount();
     this.props.setStage(stage);
@@ -44,8 +36,8 @@ export class CategoryGroup extends React.Component {
   }
 
   render() {
-    const { stage } = this.state;
-    const { ProposalsCount, translations } = this.props;
+    const { ProposalsCount, translations, activeProjectTab } = this.props;
+    const stage = activeProjectTab;
 
     const {
       data: {
@@ -116,7 +108,7 @@ export class CategoryGroup extends React.Component {
   }
 }
 
-const { func, object } = PropTypes;
+const { func, object, string } = PropTypes;
 
 CategoryGroup.propTypes = {
   client: object.isRequired,
@@ -126,6 +118,7 @@ CategoryGroup.propTypes = {
   setShowActionableItems: func.isRequired,
   setStage: func.isRequired,
   translations: object.isRequired,
+  activeProjectTab: string.isRequired,
 };
 
 const mapStateToProps = ({ infoServer }) => ({

--- a/src/components/common/blocks/filter/index.js
+++ b/src/components/common/blocks/filter/index.js
@@ -15,7 +15,7 @@ import { getUnmetProposalRequirements } from '@digix/gov-ui/utils/helpers';
 import { H1 } from '@digix/gov-ui/components/common/common-styles';
 import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
 import { ProposalErrors } from '@digix/gov-ui/constants';
-import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
+import { showRightPanel, setActiveProjectTab } from '@digix/gov-ui/reducers/gov-ui/actions';
 import {
   Heading,
   Filter,
@@ -33,7 +33,6 @@ class ProposalCardFilter extends React.Component {
     this.state = {
       filters: [],
       showActionable: false,
-      stage: 'all',
     };
   }
 
@@ -111,7 +110,7 @@ class ProposalCardFilter extends React.Component {
   };
 
   setStage = stage => {
-    this.setState({ stage });
+    this.props.setActiveProjectTab(stage);
   };
 
   changeFilter = e => {
@@ -153,7 +152,7 @@ class ProposalCardFilter extends React.Component {
   }
 
   toggleActionableItems = e => {
-    const { stage } = this.state;
+    const stage = this.props.activeProjectTab;
     const showActionable = !!e.target.checked;
     LogDashboard.toggleActionableProjects(stage, showActionable);
     this.setState({ showActionable });
@@ -231,7 +230,7 @@ class ProposalCardFilter extends React.Component {
   }
 }
 
-const { func, object } = PropTypes;
+const { func, object, string } = PropTypes;
 
 ProposalCardFilter.propTypes = {
   AddressDetails: object.isRequired,
@@ -246,12 +245,15 @@ ProposalCardFilter.propTypes = {
   setProposalList: func.isRequired,
   translations: object.isRequired,
   web3Redux: object.isRequired,
+  setActiveProjectTab: func.isRequired,
+  activeProjectTab: string.isRequired,
 };
 
-const mapStateToProps = ({ daoServer, infoServer }) => ({
+const mapStateToProps = ({ daoServer, infoServer, govUI }) => ({
   ChallengeProof: daoServer.ChallengeProof,
   DaoConfig: infoServer.DaoConfig.data,
   DaoDetails: infoServer.DaoDetails.data,
+  activeProjectTab: govUI.activeProjectTab,
 });
 
 export default withApollo(
@@ -261,6 +263,7 @@ export default withApollo(
       {
         getDaoConfig,
         showRightPanel,
+        setActiveProjectTab
       }
     )(ProposalCardFilter)
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -49,10 +49,10 @@ class LandingPage extends React.PureComponent {
   }
 
   componentWillMount = () => {
-    const { Language } = this.props;
+    const { Language, activeProjectTab } = this.props;
     this.setTosStatus();
     this.setCountdownPageStatus();
-    this.getProposalList('all');
+    this.getProposalList(activeProjectTab);
     this.props.getTranslations(Language);
   };
 
@@ -72,7 +72,7 @@ class LandingPage extends React.PureComponent {
   };
 
   getProposalLikes = () => {
-    this.props.getProposalLikesStats().then(() => {
+    this.props.getProposalLikesStats(this.props.activeProjectTab).then(() => {
       const displayNames = {};
       const proposalLikes = {};
       const proposals = this.props.ProposalLikes.data;
@@ -341,6 +341,7 @@ class LandingPage extends React.PureComponent {
 const { bool, object, func, string } = PropTypes;
 
 LandingPage.propTypes = {
+  activeProjectTab: string.isRequired,
   client: object.isRequired,
   DaoConfig: object.isRequired,
   DaoDetails: object.isRequired,
@@ -381,7 +382,7 @@ const mapStateToProps = state => {
   const {
     infoServer: { DaoDetails, AddressDetails, DaoConfig },
     daoServer: { ChallengeProof, UserLikedProposals, ProposalLikes, Translations },
-    govUI: { HasCountdown, ShowWallet, Language },
+    govUI: { HasCountdown, ShowWallet, Language, activeProjectTab },
   } = state;
 
   return {
@@ -395,6 +396,7 @@ const mapStateToProps = state => {
     HasCountdown,
     ShowWallet,
     Language,
+    activeProjectTab,
     defaultAddress: getDefaultAddress(state),
   };
 };

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -18,6 +18,7 @@ export const actions = {
   GET_TOKEN_USD_VALUE: `${REDUX_PREFIX}GET_TOKEN_USD_VALUE`,
 
   SET_TRANSLATION_LANGUAGE: `${REDUX_PREFIX}SET_TRANSLATION_LANGUAGE`,
+  SET_ACTIVE_PROJECT_TAB: `${REDUX_PREFIX}SET_ACTIVE_PROJECT_TAB`,
 };
 
 function fetchData(url, type) {
@@ -140,5 +141,12 @@ export function getTokenUsdValue() {
 export function setLanguageTranslation(payload = 'en') {
   return dispatch => {
     dispatch({ type: actions.SET_TRANSLATION_LANGUAGE, payload });
+  };
+}
+
+export function setActiveProjectTab(payload = 'all') {
+  console.log('setActiveProjectTab payload: ', payload);
+  return dispatch => {
+    dispatch({ type: actions.SET_ACTIVE_PROJECT_TAB, payload });
   };
 }

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -145,7 +145,6 @@ export function setLanguageTranslation(payload = 'en') {
 }
 
 export function setActiveProjectTab(payload = 'all') {
-  console.log('setActiveProjectTab payload: ', payload);
   return dispatch => {
     dispatch({ type: actions.SET_ACTIVE_PROJECT_TAB, payload });
   };

--- a/src/reducers/gov-ui/index.js
+++ b/src/reducers/gov-ui/index.js
@@ -121,7 +121,6 @@ export default function(state = defaultState, action) {
         Language: action.payload,
       };
     case actions.SET_ACTIVE_PROJECT_TAB:
-      console.log('SET_ACTIVE_PROJECT_TAB: ', action.payload);
       return {
         ...state,
         activeProjectTab: action.payload,

--- a/src/reducers/gov-ui/index.js
+++ b/src/reducers/gov-ui/index.js
@@ -23,6 +23,7 @@ const defaultState = {
   isAuthenticated: false,
   tokenUsdValues: undefined,
   Language: 'en',
+  activeProjectTab: 'all',
 };
 
 export default function(state = defaultState, action) {
@@ -118,6 +119,12 @@ export default function(state = defaultState, action) {
       return {
         ...state,
         Language: action.payload,
+      };
+    case actions.SET_ACTIVE_PROJECT_TAB:
+      console.log('SET_ACTIVE_PROJECT_TAB: ', action.payload);
+      return {
+        ...state,
+        activeProjectTab: action.payload,
       };
 
     default:


### PR DESCRIPTION
## WHY
Going to a proposal page from the `review tab` and then clicking back button takes you to the `All tab`. It would be more logical to go back to the tab where you left off.

## WHAT
Move the stage react state to redux to preserv that data even if a user moves to another page. That way the state will be preserved even if a user moves to another page.

## HOW TO TEST
1. Go to https://localhost:3000/#/
2. Go to Review tab and click on a proposal
3. Click back button
4. Expected -> You should be at the Review tab

## PS
I would consider refactoring the menu logic a bit. Make links of them so it would be  https://localhost:3000/#/all,  https://localhost:3000/#/review, etc..
That way we get a lot of good UX for free from the way the browser behaves. It would also be easier to maintain and codesplit if needed and also fix the issue that the whole components get rerendered even if the data is the same.