### PR TITLE
[FIX] Allow PRL to sign message and login to the site

### DIFF
--- a/src/components/common/blocks/address-watcher/index.js
+++ b/src/components/common/blocks/address-watcher/index.js
@@ -54,17 +54,19 @@ class AddressWatcher extends React.PureComponent {
         .then(({ json: { result } }) => result)
         .then(details => {
           const hasDgdLocked = Number(details.lockedDgd) > 0;
-          if (
-            !details.isParticipant &&
-            !details.isKycOfficer &&
-            !details.isForumAdmin &&
-            !hasDgdLocked
-          ) {
+          const isValidUser =
+            details.isParticipant ||
+            details.isKycOfficer ||
+            details.isForumAdmin ||
+            details.isPrl ||
+            hasDgdLocked;
+
+          if (!isValidUser) {
             this.props.setUserAddress(address);
             this.setState({ verifyingUser: false });
-
             return undefined;
           }
+
           return this.getChallengeAndProof({ nextProps, details });
         });
     }


### PR DESCRIPTION
The role was not included in the check for valid users. This diff should fix that.

## Test Plan

**Setup**

The test account for PRL is `account`. Check that it's recognized by `info-server` by going to `localhost:3001/address/$ADDRESS`. If the result is `notFound`, you need to add the address as a PRL account to the `info-server` and `dao-server`.

For `info-server`, you can add it via `mongodb`:

```
$ mongo
> use digixdao
> db.addresses.insertOne({ address: "$ADDRESS", isPrl: true })
```

For the `dao-server`, you can add it via `rails console`:

```
$ rails c
> User.create(address: "$ADDRESS", uid: SecureRandom.rand(1000000..1999999))
```

**Test**

- Use `account1` in `development` environment and try to load the wallet.
- The user should be able to sign the message and use the site successfully.