### PR TITLE
[FIX] Added checks on 'finalReward' so it won't be rendered 'undefined'

### DIFF
--- a/src/pages/proposals/fundings.js
+++ b/src/pages/proposals/fundings.js
@@ -60,7 +60,7 @@ class ProposalFundings extends React.Component {
     milestoneFunds = truncateNumber(milestoneFunds);
 
     let reward;
-    if (typeof finalReward === 'undefined') {
+    if (!finalReward) {
       reward = 0;
       return {
         milestoneFunds,
@@ -100,7 +100,7 @@ class ProposalFundings extends React.Component {
       const { finalReward, milestoneFundings } = proposalVersion;
       milestoneFunds = milestoneFundings.reduce((total, milestone) => total + Number(milestone), 0);
       milestoneFunds = truncateNumber(milestoneFunds);
-      if (typeof finalReward === 'undefined') {
+      if (!finalReward) {
         reward = 0;
         return;
       }

--- a/src/pages/proposals/fundings.js
+++ b/src/pages/proposals/fundings.js
@@ -62,7 +62,12 @@ class ProposalFundings extends React.Component {
     let reward;
     if (typeof finalReward === 'undefined') {
       reward = 0;
-      return;
+      return {
+        milestoneFunds,
+        milestoneFundDifference,
+        reward,
+        rewardDifference,
+      };
     }
     reward = finalReward.original;
     reward = truncateNumber(reward);

--- a/src/pages/proposals/fundings.js
+++ b/src/pages/proposals/fundings.js
@@ -57,9 +57,15 @@ class ProposalFundings extends React.Component {
     const milestoneFundDifference = this.getMilestonFundDifference(milestoneFunds);
     const rewardDifference = this.getRewardDifference();
 
-    let reward = finalReward.original;
-    reward = truncateNumber(reward);
     milestoneFunds = truncateNumber(milestoneFunds);
+
+    let reward;
+    if (typeof finalReward === 'undefined') {
+      reward = 0;
+      return;
+    }
+    reward = finalReward.original;
+    reward = truncateNumber(reward);
 
     return {
       milestoneFunds,
@@ -89,6 +95,10 @@ class ProposalFundings extends React.Component {
       const { finalReward, milestoneFundings } = proposalVersion;
       milestoneFunds = milestoneFundings.reduce((total, milestone) => total + Number(milestone), 0);
       milestoneFunds = truncateNumber(milestoneFunds);
+      if (typeof finalReward === 'undefined') {
+        reward = 0;
+        return;
+      }
       reward = truncateNumber(finalReward);
     }
 

--- a/src/pages/proposals/fundings.js
+++ b/src/pages/proposals/fundings.js
@@ -59,23 +59,10 @@ class ProposalFundings extends React.Component {
 
     milestoneFunds = truncateNumber(milestoneFunds);
 
-    let reward;
-    if (!finalReward) {
-      reward = 0;
-      return {
-        milestoneFunds,
-        milestoneFundDifference,
-        reward,
-        rewardDifference,
-      };
-    }
-    reward = finalReward.original;
-    reward = truncateNumber(reward);
-
     return {
       milestoneFunds,
       milestoneFundDifference,
-      reward,
+      reward: finalReward ? truncateNumber(finalReward.original) : 0,
       rewardDifference,
     };
   }
@@ -100,11 +87,7 @@ class ProposalFundings extends React.Component {
       const { finalReward, milestoneFundings } = proposalVersion;
       milestoneFunds = milestoneFundings.reduce((total, milestone) => total + Number(milestone), 0);
       milestoneFunds = truncateNumber(milestoneFunds);
-      if (!finalReward) {
-        reward = 0;
-        return;
-      }
-      reward = truncateNumber(finalReward);
+      reward = finalReward ? truncateNumber(finalReward) : 0;
     }
 
     return (


### PR DESCRIPTION
<!--- Before filing a PR, make sure an accepted and open issue is tied -->
<!--- to this request. PRs without an accompanying issue will not be -->
<!--- accepted. -->

<!--- Provide a general summary of your changes in the Title above -->
<!--- Prepend with [FEATURE] or [FIX] to describe the type of change -->

## Description
<!--- Describe your changes in detail and link the open and accepted -->
<!--- issue here to easily track it. -->
Ref: [DGDG-582](https://tracker.digixdev.com/issue/DGDG-582)

This PR is another attempt at fixing the issue on the users having a white screen of the death when viewing a proposal. 

The log appearing on the console: 
```sh
Failed to load resource: the server responded with a status of 404 ()
www.google-analytics.com/analytics.js:1 Failed to load resource: net::ERR_CONNECTION_REFUSED
static.zdassets.com/web_widget/latest/common_vendor.eb3555beadc8d02cdc54.js:1 Our embeddable contains third-party, open source software and/or libraries. To view them and their license terms, go to http://goto.zendesk.com/embeddable-legal-notices
main.57a53be343ac5630d012.js:1 WebSocket connection to 'wss://info.digix.global/websocket' failed: WebSocket is closed before the connection is established.
value @ main.57a53be343ac5630d012.js:1
/vendor.24fa41b2294ad394225d.js:180 TypeError: Cannot read property 'finalReward' of undefined
    at t.value (/main.57a53be343ac5630d012.js:1)
    at Ca (/vendor.24fa41b2294ad394225d.js:180)
    at xa (/vendor.24fa41b2294ad394225d.js:180)
...
uo @ /vendor.24fa41b2294ad394225d.js:180
/vendor.24fa41b2294ad394225d.js:237 Uncaught TypeError: Cannot read property 'finalReward' of undefined
    at t.value (/main.57a53be343ac5630d012.js:1)
    at Ca (/vendor.24fa41b2294ad394225d.js:180)
...
``` 

the `finalReward` is being displayed on the funding tab:

![funding](https://i.imgur.com/E0fB2FQ.png)

the `finalReward` coming from the graphql:

![network](https://i.imgur.com/xuHtvqy.png)

## What i did

I make sure the javascript event loop is not stuck on looping because `finalReward` is undefined, therefore it should prevent the white screen appearing, with just simple `if (typeof)`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have squashed my commit with a meaningful message before merging.
- [ ] I have updated the documentation if needed and accordingly.
- [ ] I have added a test plan to my commit message for QA to follow.
- [ ] QA has tested and verified the PR.
- [ ] I have signed and submitted the *Contributors License Agreement*.
