### PR TITLE
[FIX] Update behavior for Continue Participation Modal (Resolves DGDG-584)

### DIFF
--- a/src/pages/continue-participation.js
+++ b/src/pages/continue-participation.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -13,7 +13,7 @@ import { Content, Title, Intro } from '@digix/gov-ui/pages/style';
 import { CONFIRM_PARTICIPATION_CACHE, DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getHash } from '@digix/gov-ui/utils/helpers';
+import { getHash, inLockingPhase } from '@digix/gov-ui/utils/helpers';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { sendTransactionToDaoServer } from '@digix/gov-ui/reducers/dao-server/actions';
 import {
@@ -28,6 +28,11 @@ registerUIs({ txVisualization: { component: TxVisualization } });
 const network = SpectrumConfig.defaultNetworks[0];
 
 class ConfirmParticipation extends React.Component {
+  constructor(props) {
+    super(props);
+    this.CONTINUE_PARTICIPATION_FEE = 1;
+  }
+
   setError = error => {
     this.props.showHideAlert({
       message: JSON.stringify(error && error.message) || error,
@@ -93,12 +98,12 @@ class ConfirmParticipation extends React.Component {
     const payload = {
       address: sourceAddress,
       contract,
-      func: contract.confirmContinuedParticipation,
+      func: contract.withdrawDGD,
       network,
       onFailure: this.setError,
       onFinally: txHash => onTransactionAttempt(txHash),
       onSuccess: txHash => onTransactionSuccess(txHash),
-      params: undefined,
+      params: [this.CONTINUE_PARTICIPATION_FEE],
       showTxSigningModal: this.props.showTxSigningModal,
       translations: this.props.txnTranslations,
       ui,
@@ -131,14 +136,15 @@ class ConfirmParticipation extends React.Component {
   }
 
   render() {
+    const { DaoInfo } = this.props;
     const t = this.props.translations;
     const tOptions = this.props.translations.options;
+    const isLockingPhase = inLockingPhase(DaoInfo);
 
     return (
       <Content>
         <Title>{t.title}</Title>
         <Intro>{t.instructions}</Intro>
-
         <Button
           fluid
           large
@@ -149,27 +155,30 @@ class ConfirmParticipation extends React.Component {
         >
           {tOptions.lockDgd}
         </Button>
-        {/* HOTIFIX: hide button until contract for it is fixed */}
-        {/* <Button
-          fluid
-          large
-          reverse
-          data-digix="Confirm-Participation-Continue-Lock-Up"
-          style={{ marginLeft: '0' }}
-          onClick={() => this.continueParticipation()}
-        >
-          {tOptions.continueCurrentLockup}
-        </Button> */}
-        <Button
-          fluid
-          large
-          reverse
-          data-digix="Confirm-Participation-Unlock-Dgd"
-          style={{ marginLeft: '0' }}
-          onClick={() => this.showUnlockDgdOverlay()}
-        >
-          {tOptions.unlockDgd}
-        </Button>
+        {isLockingPhase && (
+          <Fragment>
+            <Button
+              fluid
+              large
+              reverse
+              data-digix="Confirm-Participation-Continue-Lock-Up"
+              style={{ marginLeft: '0' }}
+              onClick={() => this.continueParticipation()}
+            >
+              {tOptions.continueCurrentLockup}
+            </Button>
+            <Button
+              fluid
+              large
+              reverse
+              data-digix="Confirm-Participation-Unlock-Dgd"
+              style={{ marginLeft: '0' }}
+              onClick={() => this.showUnlockDgdOverlay()}
+            >
+              {tOptions.unlockDgd}
+            </Button>
+          </Fragment>
+        )}
       </Content>
     );
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -202,7 +202,9 @@ class LandingPage extends React.PureComponent {
     const { ChallengeProof } = this.props;
     const { CONFIG_MINIMUM_LOCKED_DGD } = this.props.DaoConfig;
     const { currentQuarter, isGlobalRewardsSet } = this.props.DaoDetails.data;
+
     const AddressDetails = this.props.AddressDetails.data;
+    const isParticipant = AddressDetails && AddressDetails.isParticipant;
     const lastParticipatedQuarter = AddressDetails && AddressDetails.lastParticipatedQuarter;
 
     const hasLoadedWallet = ChallengeProof.data;
@@ -218,14 +220,15 @@ class LandingPage extends React.PureComponent {
 
     // always include the currentQuarter so that we have unique hashes per quarter
     const expectedHash = getHash(`${value}_${currentQuarter}_${AddressDetails.address}`);
-    const alreadyParticipating = storedHash && storedHash === expectedHash;
+    const alreadyChoseModalOption = storedHash && storedHash === expectedHash;
 
     const showModal =
       hasLoadedWallet &&
       isGlobalRewardsSet &&
       isPastParticipant &&
       hasEnoughDgd &&
-      !alreadyParticipating;
+      isParticipant === false &&
+      !alreadyChoseModalOption;
 
     if (showModal) {
       localStorage.removeItem(key, expectedHash);


### PR DESCRIPTION
Ref: [DGDG-584](https://tracker.digixdev.com/issue/DGDG-584). Reverts PR #354.

The Continue Participation modal will have the same conditions as before (see PR #245), but with the additional condition of `AddressDetails.isParticipant === false`.

The contract function to be callled is now `withdrawDGD(1)` instead of `confirmContinuedParticipation()`.

If the user skips visiting the site during the locking phase of a new quarter, they will still see the modal but it will only give them the option to lock more DGDs.

### Test Plan

**Setup**
- Ensure that the account you're using satisfies the following conditions:
  - User has loaded their wallet
  - User was a past participant with locked DGDs >= `DaoConfig.CONFIG_MINIMUM_LOCKED_DGD`
  - `DaoInfo.isGlobalRewardsSet` is `true`
  - `AddressDetails.isParticipant` is `false`
  - User has not taken action from the modal before

**Test Case 1: Locking Phase**
- Teleport to the locking phase of the next quarter then load your wallet by running `npm run teleport:locking_phase` on the `dao-contracts` terminal.
- The modal should pop up and ask you if you want to lock DGDs, continue with your current stake, or unlock DGDs. All three options should function as intended.

**Test Case 2: Main Phase**
- Teleport to the main phase of the next quarter by running `npm run teleport:main_phase` twice.
- The modal should pop up and only give you the option to lock DGDs. It should work as intended