### PR TITLE
[FEATURE] Show error overlay for moderator buttons (Resolves DGDG-586)

### DIFF
--- a/src/pages/proposals/proposal-buttons/approve.js
+++ b/src/pages/proposals/proposal-buttons/approve.js
@@ -27,6 +27,7 @@ class ApproveProjectButton extends React.PureComponent {
 
   render() {
     const {
+      checkProposalRequirements,
       isModerator,
       proposal,
       translations: { buttons },
@@ -42,7 +43,7 @@ class ApproveProjectButton extends React.PureComponent {
     }
 
     return (
-      <Button large onClick={this.showOverlay}>
+      <Button large onClick={() => checkProposalRequirements(this.showOverlay)}>
         {buttons.moderatorVote}
       </Button>
     );
@@ -52,6 +53,7 @@ class ApproveProjectButton extends React.PureComponent {
 const { bool, func, object, string } = PropTypes;
 
 ApproveProjectButton.propTypes = {
+  checkProposalRequirements: func.isRequired,
   isModerator: bool,
   proposal: object.isRequired,
   proposalId: string.isRequired,

--- a/src/pages/proposals/proposal-buttons/endorse.js
+++ b/src/pages/proposals/proposal-buttons/endorse.js
@@ -95,13 +95,14 @@ class EndorseProjectButton extends React.PureComponent {
 
     return executeContractFunction(payload);
   };
+
   render() {
-    const { stage, isModerator, endorser, translations } = this.props;
+    const { checkProposalRequirements, stage, isModerator, endorser, translations } = this.props;
     if (stage !== ProposalStages.idea || !isModerator || (endorser && endorser !== EMPTY_HASH))
       return null;
 
     return (
-      <Button kind="round" large onClick={this.handleSubmit}>
+      <Button kind="round" large onClick={() => checkProposalRequirements(this.handleSubmit)}>
         {translations.buttons.endorse}
       </Button>
     );
@@ -117,6 +118,7 @@ EndorseProjectButton.propTypes = {
   isModerator: bool,
   web3Redux: object.isRequired,
   ChallengeProof: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   gasLimitConfig: object,
   showHideAlert: func.isRequired,
   sendTransactionToDaoServer: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/moderators/index.js
+++ b/src/pages/proposals/proposal-buttons/moderators/index.js
@@ -1,10 +1,48 @@
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
+/* eslint-disable react/jsx-no-bind */
 
-import EndorseButton from '../endorse';
-import ApproveButton from '../approve';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { withApollo } from 'react-apollo';
+
+import EndorseButton from '@digix/gov-ui/pages/proposals/proposal-buttons/endorse';
+import ErrorMessageOverlay from '@digix/gov-ui/components/common/blocks/overlay/error-message';
+import ApproveButton from '@digix/gov-ui/pages/proposals/proposal-buttons/approve';
+import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
+import { getUnmetProposalRequirements } from '@digix/gov-ui/utils/helpers';
+import { showRightPanel } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 class ModeratorButtons extends React.Component {
+  checkUnmetRequirements(proposalAction, customErrors) {
+    const { client, DaoDetails, translations } = this.props;
+
+    getUnmetProposalRequirements(client, DaoDetails, translations).then(errors => {
+      let totalErrors = errors;
+      if (customErrors) {
+        totalErrors = errors.concat(customErrors);
+      }
+
+      if (totalErrors.length) {
+        this.showErrorOverlay(totalErrors);
+      } else {
+        proposalAction();
+      }
+    });
+  }
+
+  showErrorOverlay(errors) {
+    const {
+      translations: {
+        common: { proposalErrors },
+      },
+    } = this.props;
+
+    this.props.showRightPanel({
+      component: <ErrorMessageOverlay errors={errors} location={proposalErrors.returnToProject} />,
+      show: true,
+    });
+  }
+
   render() {
     const {
       addressDetails,
@@ -19,6 +57,7 @@ class ModeratorButtons extends React.Component {
 
     const txnTranslations = this.props.translations.signTransaction;
     const buttonTranslations = { buttons, project, snackbars };
+    const checkProposalRequirements = this.checkUnmetRequirements.bind(this);
 
     return (
       <Fragment>
@@ -28,6 +67,7 @@ class ModeratorButtons extends React.Component {
           endorser={data.endorser}
           proposalId={data.proposalId}
           history={history}
+          checkProposalRequirements={checkProposalRequirements}
           translations={buttonTranslations}
           txnTranslations={txnTranslations}
         />
@@ -36,6 +76,7 @@ class ModeratorButtons extends React.Component {
           isModerator={addressDetails.data.isModerator}
           proposal={data}
           proposalId={data.proposalId}
+          checkProposalRequirements={checkProposalRequirements}
           translations={buttonTranslations}
           txnTranslations={txnTranslations}
         />
@@ -43,12 +84,29 @@ class ModeratorButtons extends React.Component {
     );
   }
 }
-const { object } = PropTypes;
+const { func, object } = PropTypes;
 
 ModeratorButtons.propTypes = {
-  proposal: object.isRequired,
   addressDetails: object.isRequired,
+  client: object.isRequired,
+  DaoDetails: object.isRequired,
   history: object.isRequired,
+  proposal: object.isRequired,
+  showRightPanel: func.isRequired,
   translations: object.isRequired,
 };
-export default ModeratorButtons;
+
+const mapStateToProps = ({ infoServer }) => ({
+  DaoDetails: infoServer.DaoDetails.data,
+});
+
+export default withApollo(
+  web3Connect(
+    connect(
+      mapStateToProps,
+      {
+        showRightPanel,
+      }
+    )(ModeratorButtons)
+  )
+);


### PR DESCRIPTION
Ref: [DGDG-586](https://tracker.digixdev.com/issue/DGDG-586), [DGDG-311](https://tracker.digixdev.com/issue/DGDG-311)

This applies the same functionality as the changes in PR #106, but for moderator buttons. Project actions are not allowed in the locking phase, so this will prevent users from wasting gas.

### Test Plan
- Create a project as a participant during the main phase.
- Teleport to the locking phase: `npm run teleport:locking_phase`
- Load a moderator wallet
- Verify that endorsing or approving a project will show the error overlay if any of the following conditions are true:
   - User is in the locking phase
   - User is not KYC'd.