### PR TITLE
[FEATURE] Show error overlay for participants buttons (Resolves DGDG-587)

### DIFF
--- a/src/pages/proposals/proposal-buttons/add-documents.js
+++ b/src/pages/proposals/proposal-buttons/add-documents.js
@@ -18,6 +18,7 @@ class AddDocumentsButton extends React.PureComponent {
 
   render() {
     const {
+      checkProposalRequirements,
       stage,
       isProposer,
       proposal,
@@ -33,7 +34,11 @@ class AddDocumentsButton extends React.PureComponent {
     ) {
       return (
         <div>
-          <Button large data-digix="ADD-UPDATES" onClick={this.redirectToAddDocuments}>
+          <Button
+            large
+            data-digix="ADD-UPDATES"
+            onClick={() => checkProposalRequirements(this.redirectToAddDocuments)}
+          >
             {buttons.addUpdates || 'Add Updates'}
           </Button>
         </div>
@@ -46,6 +51,7 @@ class AddDocumentsButton extends React.PureComponent {
 const { object, bool, string } = PropTypes;
 
 AddDocumentsButton.propTypes = {
+  checkProposalRequirements: func.isRequired,
   stage: string.isRequired,
   translations: object.isRequired,
   history: object.isRequired,

--- a/src/pages/proposals/proposal-buttons/add-documents.js
+++ b/src/pages/proposals/proposal-buttons/add-documents.js
@@ -48,7 +48,7 @@ class AddDocumentsButton extends React.PureComponent {
   }
 }
 
-const { object, bool, string } = PropTypes;
+const { func, object, bool, string } = PropTypes;
 
 AddDocumentsButton.propTypes = {
   checkProposalRequirements: func.isRequired,

--- a/src/pages/proposals/proposal-buttons/participants/index.js
+++ b/src/pages/proposals/proposal-buttons/participants/index.js
@@ -148,6 +148,7 @@ class ParticipantButtons extends React.Component {
           proposalId={data.proposalId}
           votingStage={data.votingStage}
           votes={addressDetails.data.votes}
+          checkProposalRequirements={checkProposalRequirements}
           translations={buttonTranslations}
           txnTranslations={txnTranslations}
         />
@@ -159,6 +160,7 @@ class ParticipantButtons extends React.Component {
           votingStage={data.votingStage}
           votes={addressDetails.data.votes}
           translations={buttonTranslations}
+          checkProposalRequirements={checkProposalRequirements}
           txnTranslations={txnTranslations}
         />
         <ClaimResultsButton

--- a/src/pages/proposals/proposal-buttons/reveal-button.js
+++ b/src/pages/proposals/proposal-buttons/reveal-button.js
@@ -41,6 +41,7 @@ class RevealVoteButton extends React.PureComponent {
 
   render() {
     const {
+      checkProposalRequirements,
       isParticipant,
       proposal,
       proposal: { currentVotingRound, isSpecial, isActive },
@@ -71,7 +72,12 @@ class RevealVoteButton extends React.PureComponent {
       currentTime < proposal.votingRounds[isSpecial ? 0 : currentVotingRound].revealDeadline * 1000;
     if (!withinDeadline) return null;
     return (
-      <Button kind="round" large onClick={this.showOverlay} data-digix="Proposal-Reveal-Vote">
+      <Button
+        kind="round"
+        large
+        onClick={() => checkProposalRequirements(this.showOverlay)}
+        data-digix="Proposal-Reveal-Vote"
+      >
         {buttons.revealVote}
       </Button>
     );
@@ -82,6 +88,7 @@ const { bool, func, object, string } = PropTypes;
 
 RevealVoteButton.propTypes = {
   AddressDetails: object.isRequired,
+  checkProposalRequirements: func.isRequired,
   isParticipant: bool,
   proposal: object.isRequired,
   proposalId: string.isRequired,

--- a/src/pages/proposals/proposal-buttons/vote-commit.js
+++ b/src/pages/proposals/proposal-buttons/vote-commit.js
@@ -46,6 +46,7 @@ class CommitVoteButton extends React.PureComponent {
 
   render() {
     const {
+      checkProposalRequirements,
       isParticipant,
       proposal,
       proposal: { currentVotingRound, isSpecial, isActive },
@@ -75,7 +76,11 @@ class CommitVoteButton extends React.PureComponent {
     if (!withinDeadline) return null;
 
     return (
-      <Button kind="round" large onClick={() => this.showOverlay(hasVoted)}>
+      <Button
+        kind="round"
+        large
+        onClick={() => checkProposalRequirements(this.showOverlay(hasVoted))}
+      >
         {hasVoted ? buttons.changeVote : buttons.vote}
       </Button>
     );
@@ -85,6 +90,7 @@ class CommitVoteButton extends React.PureComponent {
 const { bool, func, object, string } = PropTypes;
 
 CommitVoteButton.propTypes = {
+  checkProposalRequirements: func.isRequired,
   AddressDetails: object.isRequired,
   isParticipant: bool,
   proposal: object.isRequired,


### PR DESCRIPTION
Ref: [DGDG-587](https://tracker.digixdev.com/issue/DGDG-587)

This PR is essentially the same as this [PR](https://github.com/DigixGlobal/governance-ui-components/pull/394), but instead of moderator, this one is for participant.

### Test Plan
Given user is in locking_phase
And user had pending action on proposal
When user clicks the action
Then show notice overlay