### PR TITLE
[FIX] Skip KYC check for moderators when checking for proposal actions

### DIFF
--- a/src/pages/proposals/proposal-buttons/moderators/index.js
+++ b/src/pages/proposals/proposal-buttons/moderators/index.js
@@ -16,7 +16,7 @@ class ModeratorButtons extends React.Component {
   checkUnmetRequirements(proposalAction, customErrors) {
     const { client, DaoDetails, translations } = this.props;
 
-    getUnmetProposalRequirements(client, DaoDetails, translations).then(errors => {
+    getUnmetProposalRequirements(client, DaoDetails, translations, true).then(errors => {
       let totalErrors = errors;
       if (customErrors) {
         totalErrors = errors.concat(customErrors);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -88,7 +88,12 @@ export const inLockingPhase = DaoDetails => {
 };
 
 // checks general conditions that should be met when doing any proposal action
-export const getUnmetProposalRequirements = (apolloClient, DaoDetails, translations) => {
+export const getUnmetProposalRequirements = (
+  apolloClient,
+  DaoDetails,
+  translations,
+  skipKycCheck
+) => {
   const errors = [];
 
   const {
@@ -96,7 +101,7 @@ export const getUnmetProposalRequirements = (apolloClient, DaoDetails, translati
   } = translations;
 
   return isKycApproved(apolloClient).then(kycApproved => {
-    if (!kycApproved) {
+    if (!kycApproved && !skipKycCheck) {
       errors.push(proposalErrors.invalidKyc);
     }
 


### PR DESCRIPTION
As titled.

### Test Plan
- Load a moderator wallet
- They should see an error if they try to endorse or approve a proposal while they are not in the main phase
- They should not see an error if they try to endorse or approve a proposal while they are in the main phase and not KYC'd