### PR TITLE
Create Ragnarok announcement pop up (Needed for DGDG-604)

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,8 +9,9 @@ import CountdownPage from '@digix/gov-ui/components/common/blocks/loader/countdo
 import ProposalCard from '@digix/gov-ui/components/proposal-card';
 import Timeline from '@digix/gov-ui/components/common/blocks/timeline';
 import ToS from '@digix/gov-ui/tos.md';
+import RagnarokSpProposal from '@digix/gov-ui/pages/sp-ragnarok';
 import ProposalFilter from '@digix/gov-ui/components/common/blocks/filter/index';
-import { Content, Title, TosOverlay } from '@digix/gov-ui/pages/style';
+import { Content, Title, TosOverlay, SpProposal } from '@digix/gov-ui/pages/style';
 import { CONFIRM_PARTICIPATION_CACHE } from '@digix/gov-ui/constants';
 import { Button } from '@digix/gov-ui/components/common/elements/index';
 import { fetchProposalList } from '@digix/gov-ui/api/graphql-queries/proposal';
@@ -33,6 +34,8 @@ import {
   getUserProposalLikeStatus,
 } from '@digix/gov-ui/reducers/dao-server/actions';
 
+const { SpContainer, SpTitle, SpParagraph, SpButton } = SpProposal;
+
 class LandingPage extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -43,6 +46,7 @@ class LandingPage extends React.PureComponent {
       proposals: [],
       proposalLikes: {},
       showParticipateModal: false,
+      showRagnarokModal: true,
       showTos: true,
       userLikes: [],
     };
@@ -167,6 +171,12 @@ class LandingPage extends React.PureComponent {
     });
   };
 
+  handleRagnarokClose = () => {
+    this.setState({
+      showRagnarokModal: false,
+    });
+  };
+
   likeProposal = proposalId => {
     const { ChallengeProof } = this.props;
     const payload = initializePayload(ChallengeProof);
@@ -270,7 +280,14 @@ class LandingPage extends React.PureComponent {
   renderLandingPage() {
     this.fixScrollbar(this.props.ShowWallet);
 
-    const { disableButton, order, proposals, showParticipateModal, showTos } = this.state;
+    const {
+      disableButton,
+      order,
+      proposals,
+      showParticipateModal,
+      showRagnarokModal,
+      showTos,
+    } = this.state;
     const { AddressDetails, DaoDetails, history, Translations } = this.props;
     if (!Translations.data) {
       return null;
@@ -323,6 +340,16 @@ class LandingPage extends React.PureComponent {
               I have read and agreed
             </Button>
           </Content>
+        </Modal>
+
+        <Modal
+          open={!showTos && showRagnarokModal}
+          onClose={this.handleRagnarokClose}
+          showCloseIcon={false}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}
+        >
+          <RagnarokSpProposal closeModal={this.handleRagnarokClose} />
         </Modal>
         <Modal open={showParticipateModal} onClose={() => true} showCloseIcon={false}>
           <ConfirmParticipation closeModal={this.handleModalClose} />
@@ -403,19 +430,16 @@ const mapStateToProps = state => {
 };
 
 export default withApollo(
-  connect(
-    mapStateToProps,
-    {
-      getAddressDetails,
-      getDaoConfig,
-      getDaoDetails,
-      getProposalLikesByUser,
-      getProposalLikesStats,
-      getTranslations,
-      getUserProposalLikeStatus,
-      likeProposal,
-      unlikeProposal,
-      showCountdownPage,
-    }
-  )(LandingPage)
+  connect(mapStateToProps, {
+    getAddressDetails,
+    getDaoConfig,
+    getDaoDetails,
+    getProposalLikesByUser,
+    getProposalLikesStats,
+    getTranslations,
+    getUserProposalLikeStatus,
+    likeProposal,
+    unlikeProposal,
+    showCountdownPage,
+  })(LandingPage)
 );

--- a/src/pages/sp-ragnarok.js
+++ b/src/pages/sp-ragnarok.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { SpProposal } from '@digix/gov-ui/pages/style';
+
+const { SpContainer, SpTitle, SpParagraph, SpButton } = SpProposal;
+
+class RagnarokSpProposal extends React.Component {
+  render() {
+    const { closeModal } = this.props;
+    return (
+      <Fragment>
+        <SpContainer>
+          <SpTitle>RAGNAROK HAS PASSED. WHAT DOES THIS MEAN FOR YOU?</SpTitle>
+          <SpParagraph>
+            Now that the dissolution vote has passed, the current Quarter will be the final DigixDAO
+            Quarter.
+          </SpParagraph>
+          <SpParagraph>
+            All activities in DigixDAO will cease. As such, the creation of new projects and any
+            voting on the platform will be disabled.
+          </SpParagraph>
+          <SpParagraph>
+            All ETH in the DigixDAO Treasury (minus the 2 ETH collateral submitted by each Proposer
+            per active project) from DigixDAO will reside in the DigixDAO Refund Contract before the
+            end of the current Quarter. The claiming process will only be active after the end of
+            current Quarter. More details and the tutorial to do that will be published closer to
+            date.
+          </SpParagraph>
+          <SpParagraph>
+            More information about Project Ragnarok can be found at&nbsp;
+            <a href="https://community.digix.global/#/proposals/0xe7d5d8aefc5f73c4c8bbc716f0c3c2dd52d5282d18217db331da4435b8e6966e">
+              https://community.digix.global/#/proposals/0xe7d5d8aefc5f73c4c8bbc716f0c3c2dd52d5282d18217db331da4435b8e6966e
+            </a>
+          </SpParagraph>
+          <SpButton data-digix="TOC-READ-AGREE" onClick={closeModal} primary>
+            Dismiss
+          </SpButton>
+        </SpContainer>
+      </Fragment>
+    );
+  }
+}
+
+const { func } = PropTypes;
+RagnarokSpProposal.propTypes = {
+  closeModal: func.isRequired,
+};
+
+export default RagnarokSpProposal;

--- a/src/pages/style.js
+++ b/src/pages/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { H2 } from '@digix/gov-ui/components/common/common-styles';
+import { Button } from '@digix/gov-ui/components/common/elements/index';
 
 export const Container = styled.div`
   display: flex;
@@ -48,3 +49,22 @@ export const TosOverlay = styled.div`
     font-family: 'Futura PT Medium', sans-serif;
   }
 `;
+
+export const SpProposal = {
+  SpContainer: styled.div`
+    padding: 3.2rem 2.4rem 2.4rem 2.4rem;
+  `,
+  SpTitle: styled.h1`
+    color: ${props => props.theme.textColor.primary.light.toString()};
+    font-size: 2.4rem;
+    margin-bottom: 2.4rem;
+  `,
+  SpParagraph: styled.p`
+    line-height: 1.5;
+    word-break: break-all;
+  `,
+  SpButton: styled(Button)`
+    margin: 2.4rem 0 0 0;
+    width: 100%;
+  `,
+};


### PR DESCRIPTION
Ref: DGDG-604 [#604](https://tracker.digixdev.com/issue/DGDG-604#u=1579679642660)

### Description
This creates a modal pop up with the Ragnarok Special Announcement. It will appear after the Terms & Conditions popup for 1st time users; and before the Dashboard for the non-first time users.

**Recorded Screen:**
https://tracker.digixdev.com/_persistent/ragnarok-record.webm?file=6-2205&c=true

### PENDING JS Work (JS Dev to Assist)
Display the Ragnarok modal for non-first time users and dismiss it when button is clicked, Currently, it only shows for first-time users after the user have accepted the T&C.

<img width="922" alt="Screen Shot 2020-01-23 at 10 18 43 AM" src="https://user-images.githubusercontent.com/37611942/72951809-b1915000-3dca-11ea-9f1c-554ca7457f6d.png">


### Test Plan
**First-time users:**
1. Browse the DigixDao Dashboard using Incognito mode.
2. Accept the T&C conditions notification.
3. Ragnarok pop up should appear.

**Non first-time users:**
1. Browse the DigixDao Dashboard with any browsers.
2. Ragnarok pop up should appear.
3. Dismissing the button will show the Dashboard.
