### PR TITLE
[UI] Remove actionable items for locking DGD (Needed for EL_v2-1035)

### DIFF
--- a/src/components/common/blocks/navbar/wallet.js
+++ b/src/components/common/blocks/navbar/wallet.js
@@ -18,6 +18,7 @@ import {
   showRightPanel,
 } from '@digix/gov-ui/reducers/gov-ui/actions';
 
+import UnlockDgdOverlay from '@digix/gov-ui/components/common/blocks/overlay/unlock-dgd';
 import ErrorMessageOverlay from '@digix/gov-ui/components/common/blocks/overlay/error-message';
 import { LogLoadWallet } from '@digix/gov-ui/analytics/loadWallet';
 
@@ -40,6 +41,18 @@ class WalletButton extends React.Component {
   showLockDgdOverlay = () => {
     this.props.showHideLockDgd(true, null, 'Header');
   };
+
+  showUnlockDgdOverlay() {
+    const {
+      data: { lockedDgd },
+    } = this.props.addressDetails;
+    const tUnlock = this.props.translations.wallet.LockedDgd.UnlockDgd;
+
+    this.props.showRightPanel({
+      component: <UnlockDgdOverlay maxAmount={Number(lockedDgd)} translations={tUnlock} />,
+      show: true,
+    });
+  }
 
   showErrorOverlay(errors) {
     const {
@@ -68,6 +81,10 @@ class WalletButton extends React.Component {
       loadWallet: { banned },
     } = this.props.translations;
 
+    const {
+      data: { lockedDgd },
+    } = this.props.addressDetails;
+
     return (
       <Fragment>
         <NavItem cta>
@@ -92,7 +109,7 @@ class WalletButton extends React.Component {
               {tHeader.loadWallet || 'Load Wallet'}
             </Button>
           )}
-          {canLockDgd && canLockDgd.show && (
+          {/* {canLockDgd && canLockDgd.show && (
             <Button
               primary
               xsmall
@@ -100,6 +117,17 @@ class WalletButton extends React.Component {
               onClick={() => this.showLockDgdOverlay()}
             >
               {tHeader.lockDgd || 'Lock DGD'}
+            </Button>
+          )} */}
+          {defaultAddress && (
+            <Button
+              disabled={Number(lockedDgd) <= 0}
+              primary
+              xsmall
+              data-digix="Header-UnlockDgd"
+              onClick={() => this.showUnlockDgdOverlay()}
+            >
+              {tHeader.unlockDgd || 'Unlock DGD'}
             </Button>
           )}
         </NavItem>
@@ -137,6 +165,7 @@ class WalletButton extends React.Component {
 
 const { bool, func, string, object, oneOfType } = PropTypes;
 WalletButton.propTypes = {
+  addressDetails: object,
   showHideLockDgd: func.isRequired,
   showHideWalletOverlay: func.isRequired,
   defaultAddress: oneOfType([string, object]),
@@ -148,6 +177,12 @@ WalletButton.propTypes = {
 };
 
 WalletButton.defaultProps = {
+  addressDetails: {
+    data: {
+      address: undefined,
+      lockDgd: undefined,
+    },
+  },
   defaultAddress: undefined,
   canLockDgd: undefined,
   translations: {
@@ -163,11 +198,8 @@ const mapStateToProps = state => ({
   translations: state.daoServer.Translations.data,
 });
 
-export default connect(
-  mapStateToProps,
-  {
-    showHideLockDgd: showHideLockDgdOverlay,
-    showHideWalletOverlay,
-    showRightPanel,
-  }
-)(withAppUser(WalletButton));
+export default connect(mapStateToProps, {
+  showHideLockDgd: showHideLockDgdOverlay,
+  showHideWalletOverlay,
+  showRightPanel,
+})(withAppUser(WalletButton));

--- a/src/components/common/blocks/wallet/connected-wallet/index.js
+++ b/src/components/common/blocks/wallet/connected-wallet/index.js
@@ -287,7 +287,7 @@ class ConnectedWallet extends React.Component {
             </Amount>
           </Token>
           <HR style={{ marginBottom: '4rem' }} />
-          <Header uppercase>{tLockDgd.title}</Header>
+          {/* <Header uppercase>{tLockDgd.title}</Header>
           <p>{tLockDgd.description}</p>
           <Button
             secondary
@@ -298,7 +298,7 @@ class ConnectedWallet extends React.Component {
             data-digx="Connect-Wallet-Locked-DGD"
           >
             {tLockDgd.button}
-          </Button>
+          </Button> */}
           <Notes>
             <NotesTitle>{tNotes.title}</NotesTitle>
             <ul>
@@ -384,17 +384,14 @@ const mapStateToProps = state => ({
   gasLimitConfig: state.infoServer.TxConfig.data.gas,
 });
 
-export default connect(
-  mapStateToProps,
-  {
-    showHideAlert,
-    showHideWalletOverlay,
-    showHideLockDgdOverlayAction: showHideLockDgdOverlay,
-    canLockDgd,
-    getDaoDetails,
-    getTxConfig,
-    fetchMaxAllowance,
-    showTxSigningModal,
-    sendTransactionToDaoServer,
-  }
-)(ConnectedWallet);
+export default connect(mapStateToProps, {
+  showHideAlert,
+  showHideWalletOverlay,
+  showHideLockDgdOverlayAction: showHideLockDgdOverlay,
+  canLockDgd,
+  getDaoDetails,
+  getTxConfig,
+  fetchMaxAllowance,
+  showTxSigningModal,
+  sendTransactionToDaoServer,
+})(ConnectedWallet);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -67,7 +67,7 @@ class LandingPage extends React.PureComponent {
     Promise.all(promises).then(() => {
       this.getUserLikes();
       this.getProposalLikes();
-      this.showContinueParticipationModal();
+      // this.showContinueParticipationModal();
     });
   };
 

--- a/src/pages/user/profile/sections/moderator-requirements.js
+++ b/src/pages/user/profile/sections/moderator-requirements.js
@@ -81,13 +81,13 @@ class ModeratorRequirements extends React.Component {
         </Criteria>
         <Actions>
           <RedeemBadge history={this.props.history} />
-          <Button
+          {/* <Button
             primary
             data-digix="Profile-LockMoreDgd-Cta"
             onClick={() => this.showLockDgdOverlay()}
           >
             {t.lockDgd}
-          </Button>
+          </Button> */}
         </Actions>
       </Moderation>
     );
@@ -116,11 +116,8 @@ const mapStateToProps = ({ infoServer }) => ({
 });
 
 export default withFetchAddress(
-  connect(
-    mapStateToProps,
-    {
-      getDaoConfig,
-      showHideLockDgdOverlay,
-    }
-  )(ModeratorRequirements)
+  connect(mapStateToProps, {
+    getDaoConfig,
+    showHideLockDgdOverlay,
+  })(ModeratorRequirements)
 );

--- a/src/pages/user/wallet/sections/voting-stake.js
+++ b/src/pages/user/wallet/sections/voting-stake.js
@@ -73,14 +73,14 @@ class VotingStake extends React.Component {
           </Data>
           <Desc>{t.instructions}</Desc>
           <Actions>
-            <Button
+            {/* <Button
               primary
               data-digix="Wallet-LockDgd"
               disabled={!canLockDgd}
               onClick={() => this.showLockDgdOverlay()}
             >
               {t.lockDgd}
-            </Button>
+            </Button> */}
             <Button
               primary
               disabled={!canUnlockDgd}
@@ -123,14 +123,11 @@ const mapStateToProps = state => ({
 });
 
 const VotingStakeComponent = web3Connect(
-  connect(
-    mapStateToProps,
-    {
-      showHideAlert,
-      showRightPanel,
-      showHideLockDgdOverlay,
-    }
-  )(VotingStake)
+  connect(mapStateToProps, {
+    showHideAlert,
+    showRightPanel,
+    showHideLockDgdOverlay,
+  })(VotingStake)
 );
 
 export default withFetchAddress(VotingStakeComponent);

--- a/src/translations/chinese/header.json
+++ b/src/translations/chinese/header.json
@@ -1,5 +1,6 @@
 {
   "loadWallet": "加载钱包",
   "lockDgd": "锁定DGD",
+  "unlockDgd": "解锁DGD",
   "logout": "登出"
 }

--- a/src/translations/chinese/wallet.json
+++ b/src/translations/chinese/wallet.json
@@ -4,7 +4,7 @@
   "LockedDgd": {
     "title": "已锁定DGD",
     "currentLockup": "当前锁定",
-    "instructions": "您可以锁定更多DGD来获取更大的投票权或者在季度末解锁DGD并把DGD转回钱包.",
+    "instructions": "您可以度末解锁DGD并把DGD转回钱包.",
     "lockDgd": "锁定DGD",
     "UnlockDgd": {
       "overlayButton": "解锁DGD",

--- a/src/translations/english/header.json
+++ b/src/translations/english/header.json
@@ -1,5 +1,6 @@
 {
   "loadWallet": "Load Wallet",
   "lockDgd": "Lock DGD",
+  "unlockDgd": "Unlock DGD",
   "logout": "Logout"
 }

--- a/src/translations/english/wallet.json
+++ b/src/translations/english/wallet.json
@@ -4,7 +4,7 @@
   "LockedDgd": {
     "title": "Your Locked DGD",
     "currentLockup": "Your Current Lock-Up",
-    "instructions": "You can lock more DGD to increase your voting power or unlock after a quarter to move your DGD back into your wallet.",
+    "instructions": "You can unlock your DGD and move your it back into your wallet after a quarter has passed.",
     "lockDgd": "Lock DGD",
     "UnlockDgd": {
       "overlayButton": "Unlock DGD",


### PR DESCRIPTION
Ref: [EL_v2-1035](https://tracker.digixdev.com/issue/EL_v2-1035)

The DigixDAO will be dissolved within the quarter. To prepare for this, the UI should discourage users from needlessly staking or locking more DGDs into the system.

### Test Plan

**Setup:**
- Set up your local environment. Make sure to replace the `dao-contracts` package in `package.json` and point it to your local copy.
- Run `npm run ui:generate-translations` in `governance-ui-components` to load new translations.
- Run `npm run teleport:locking_phase` in `dao_contracts` to move to the Locking Phase.
- Load a Participant (non-Moderator) wallet

**Test Cases:**
- When you load your wallet, you should NOT see the Continue Participation modal.
- The `Lock DGD` button should be missing from the following:
  - Header
  - Wallet (in the current lock-up section)
  - Profile (in the section to gain moderator status)
- The `Lock DGD` button in the header should be replaced with an `Unlock DGD` button. It will open the overlay that allows the user to unlock their DGD.

**Wallet**
![Wallet - After](https://user-images.githubusercontent.com/45159226/74821161-24480980-533e-11ea-951a-3b588bc81821.png)

**Profile**
![Profile - After](https://user-images.githubusercontent.com/45159226/74821169-26aa6380-533e-11ea-907f-eafaac441f7b.png)

**Header**
![Header](https://user-images.githubusercontent.com/45159226/74821172-27db9080-533e-11ea-8926-31648e0d06e1.png)
