### PR TITLE
Revert web3 hotfix for negative balance issue

### DIFF
--- a/src/components/common/blocks/navbar/translator.js
+++ b/src/components/common/blocks/navbar/translator.js
@@ -31,7 +31,7 @@ class Translator extends React.Component {
 
   render() {
     const storedLng = localStorage.getItem('i18nextLng');
-    const selectedLanguage = LANGUAGES.find(l => l.code === storedLng);
+    const selectedLanguage = LANGUAGES.find(l => l.code === storedLng) || LANGUAGES[0];
     const options = LANGUAGES.filter(l => l.code !== storedLng);
 
     return (

--- a/src/components/common/blocks/wallet/index.js
+++ b/src/components/common/blocks/wallet/index.js
@@ -1,16 +1,11 @@
-import DaoInformation from '@digix/dao-contracts/build/contracts/DaoInformation.json';
-import DgdToken from '@digix/acid-contracts/build/contracts/DGDInterface.json';
 import Intro from '@digix/gov-ui/components/common/blocks/wallet/intro';
 import LoadWallet from '@digix/gov-ui/components/common/blocks/wallet/load-wallet';
 import PropTypes from 'prop-types';
 import React from 'react';
-import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
-import getContract from '@digix/gov-ui/utils/contracts';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
 import { Container } from '@digix/gov-ui/components/common/blocks/wallet/style';
 import { Stage } from '@digix/gov-ui/components/common/blocks/wallet/constants';
 import { connect } from 'react-redux';
-import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
 import {
   fetchUser,
   withApolloClient,
@@ -38,8 +33,6 @@ import {
   setLockedDgd,
 } from '@digix/gov-ui/reducers/gov-ui/actions';
 
-const network = SpectrumConfig.defaultNetworks[0];
-
 export class Wallet extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -56,28 +49,6 @@ export class Wallet extends React.PureComponent {
 
   componentWillUnmount() {
     this._isMounted = false;
-  }
-
-  getDgdBalance(userAddress) {
-    const { web3Redux } = this.props;
-    const { abi, address } = getContract(DgdToken, network);
-    const { web3 } = web3Redux.networks[network];
-    const contract = web3.eth.contract(abi).at(address);
-
-    return contract.balanceOf
-      .call(userAddress)
-      .then(balance => parseBigNumber(balance, 9, false));
-  }
-
-  getLockedDgd(userAddress) {
-    const { web3Redux } = this.props;
-    const { abi, address } = getContract(DaoInformation, network);
-    const { web3 } = web3Redux.networks[network];
-    const contract = web3.eth.contract(abi).at(address);
-
-    return contract.readUserInfo
-      .call(userAddress)
-      .then(result => parseBigNumber(result[7], 9, false));
   }
 
   updateStage = (stage) => {
@@ -97,7 +68,7 @@ export class Wallet extends React.PureComponent {
     document.body.classList.remove('modal-is-open');
   };
 
-  handleLoadedWallet = async () => {
+  handleLoadedWallet = () => {
     const { defaultAddress: { address } } = this.props;
     this.props.client.query({
       query: fetchUser,
@@ -110,20 +81,14 @@ export class Wallet extends React.PureComponent {
         if (!user) {
           this.props.setLockedDgd(0);
           this.props.setLoadWalletBalance(0);
-          this.props.setIsAddressLoaded(true);
-          this.handleCloseWallet();
-          return;
+        } else {
+          const { dgdLocked, dgdBalance } = user;
+          this.props.setLockedDgd(Number(dgdLocked));
+          this.props.setLoadWalletBalance(Number(dgdBalance));
         }
 
-        this.getLockedDgd(address).then((dgdLocked) => {
-          this.props.setLockedDgd(Number(dgdLocked));
-          this.getDgdBalance(address)
-            .then((dgdBalance) => {
-              this.props.setLoadWalletBalance(Number(dgdBalance));
-              this.props.setIsAddressLoaded(true);
-              this.handleCloseWallet();
-            });
-        });
+        this.props.setIsAddressLoaded(true);
+        this.handleCloseWallet();
       });
   }
 
@@ -179,7 +144,6 @@ Wallet.propTypes = {
   showHideWalletOverlay: func.isRequired,
   showWallet: object,
   signingModal: object,
-  web3Redux: object.isRequired,
 };
 
 Wallet.defaultProps = {

--- a/src/pages/dissolution/index.js
+++ b/src/pages/dissolution/index.js
@@ -43,17 +43,17 @@ class Dissolution extends React.PureComponent {
       loadWalletBalance,
     } = nextProps;
 
-    if (loadWalletBalance <= 0) {
-      this.setState({
-        step: STEPS.success,
-        stepOffset: -2,
-      });
-
-      return;
-    }
-
     if (!this.props.isAddressLoaded && isAddressLoaded) {
       const isDgdUnlocked = isAddressLoaded && lockedDgd <= 0;
+      if (isDgdUnlocked && loadWalletBalance <= 0) {
+        this.setState({
+          step: STEPS.success,
+          stepOffset: -2,
+        });
+
+        return;
+      }
+
       const stepOffset = isDgdUnlocked ? -1 : 0;
       const step = isDgdUnlocked
         ? STEPS.approve

--- a/src/pages/dissolution/index.js
+++ b/src/pages/dissolution/index.js
@@ -3,13 +3,13 @@ import BurnStep from '@digix/gov-ui/pages/dissolution/steps/burn';
 import DissolutionModal from '@digix/gov-ui/pages/dissolution/modal';
 import UnlockStep from '@digix/gov-ui/pages/dissolution/steps/unlock';
 import Modal from 'react-responsive-modal';
-import PropTypes, { object } from 'prop-types';
+import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import React, { Fragment } from 'react';
 import { withApolloClient } from '@digix/gov-ui/pages/dissolution/api/queries';
+import React, { Fragment } from 'react';
 
 const {
   NavButton,
@@ -43,17 +43,17 @@ class Dissolution extends React.PureComponent {
       loadWalletBalance,
     } = nextProps;
 
-    if (loadWalletBalance <= 0) {
-      this.setState({
-        step: STEPS.success,
-        stepOffset: -2,
-      });
-
-      return;
-    }
-
     if (!this.props.isAddressLoaded && isAddressLoaded) {
       const isDgdUnlocked = isAddressLoaded && lockedDgd <= 0;
+      if (isDgdUnlocked && loadWalletBalance <= 0) {
+        this.setState({
+          step: STEPS.success,
+          stepOffset: -2,
+        });
+
+        return;
+      }
+
       const stepOffset = isDgdUnlocked ? -1 : 0;
       const step = isDgdUnlocked
         ? STEPS.approve
@@ -232,7 +232,6 @@ const {
 Dissolution.propTypes = {
   isAddressLoaded: bool.isRequired,
   isBurnApproved: bool.isRequired,
-  client: object.isRequired,
   loadWalletBalance: number,
   lockedDgd: number.isRequired,
   t: func.isRequired,

--- a/src/pages/dissolution/index.js
+++ b/src/pages/dissolution/index.js
@@ -3,13 +3,13 @@ import BurnStep from '@digix/gov-ui/pages/dissolution/steps/burn';
 import DissolutionModal from '@digix/gov-ui/pages/dissolution/modal';
 import UnlockStep from '@digix/gov-ui/pages/dissolution/steps/unlock';
 import Modal from 'react-responsive-modal';
-import PropTypes from 'prop-types';
+import PropTypes, { object } from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { withApolloClient } from '@digix/gov-ui/pages/dissolution/api/queries';
 import React, { Fragment } from 'react';
+import { withApolloClient } from '@digix/gov-ui/pages/dissolution/api/queries';
 
 const {
   NavButton,
@@ -43,17 +43,17 @@ class Dissolution extends React.PureComponent {
       loadWalletBalance,
     } = nextProps;
 
+    if (loadWalletBalance <= 0) {
+      this.setState({
+        step: STEPS.success,
+        stepOffset: -2,
+      });
+
+      return;
+    }
+
     if (!this.props.isAddressLoaded && isAddressLoaded) {
       const isDgdUnlocked = isAddressLoaded && lockedDgd <= 0;
-      if (isDgdUnlocked && loadWalletBalance <= 0) {
-        this.setState({
-          step: STEPS.success,
-          stepOffset: -2,
-        });
-
-        return;
-      }
-
       const stepOffset = isDgdUnlocked ? -1 : 0;
       const step = isDgdUnlocked
         ? STEPS.approve
@@ -232,6 +232,7 @@ const {
 Dissolution.propTypes = {
   isAddressLoaded: bool.isRequired,
   isBurnApproved: bool.isRequired,
+  client: object.isRequired,
   loadWalletBalance: number,
   lockedDgd: number.isRequired,
   t: func.isRequired,

--- a/src/pages/dissolution/steps/burn.js
+++ b/src/pages/dissolution/steps/burn.js
@@ -5,18 +5,20 @@ import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import getContract from '@digix/gov-ui/utils/contracts';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-import web3Utils from 'web3-utils';
 import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getSignTransactionTranslation } from '@digix/gov-ui/utils/helpers';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { withTranslation } from 'react-i18next';
 import { Button } from '@digix/gov-ui/components/common/elements';
+import {
+  getSignTransactionTranslation,
+  truncateNumber,
+} from '@digix/gov-ui/utils/helpers';
 import {
   burnSubscription,
   fetchUser,
@@ -37,13 +39,13 @@ const {
 
 registerUIs({ txVisualization: { component: TxVisualization } });
 const network = SpectrumConfig.defaultNetworks[0];
+const DGD_TO_ETH_RATIO = 0.193054178;
 
 class BurnStep extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
       dgd: 0,
-      dgdToWei: 0,
       eth: 0,
       isTxBroadcasted: false,
     };
@@ -70,7 +72,6 @@ class BurnStep extends React.PureComponent {
     })
       .then((response) => {
         const { user } = response.data;
-        const { dgdToWei } = user;
         const dgd = user
           ? Number(user.dgdBalance) / 10e8
           : 0;
@@ -79,7 +80,7 @@ class BurnStep extends React.PureComponent {
           ? Number(user.ethRefund) / 10e17
           : 0;
 
-        this.setState({ dgd, dgdToWei, eth });
+        this.setState({ dgd, eth });
         if (dgd <= 0) {
           goToNext();
         }
@@ -196,7 +197,6 @@ class BurnStep extends React.PureComponent {
   render() {
     const {
       dgd,
-      dgdToWei,
       eth,
       isTxBroadcasted,
     } = this.state;
@@ -207,22 +207,18 @@ class BurnStep extends React.PureComponent {
       ? t('Dissolution:Burn.button')
       : <SuccessIcon kind="check" />;
 
-    const dgdToEth = Number(dgdToWei) > 0
-      ? web3Utils.fromWei(dgdToWei, 'ether')
-      : 0;
-
     return (
       <Container>
         <Title>{t('Dissolution:Burn.title')}</Title>
-        <Subtitle>1 DGD = 0.193054178 ETH</Subtitle>
+        <Subtitle>1 DGD = {DGD_TO_ETH_RATIO} ETH</Subtitle>
         <Content>
           <Currency>
-            <CurrencyValue>{dgd.toFixed(3)}</CurrencyValue>
+            <CurrencyValue>{truncateNumber(dgd)}</CurrencyValue>
             <CurrencyLabel>DGD</CurrencyLabel>
           </Currency>
           <Arrow kind="conversionArrow" />
           <Currency>
-            <CurrencyValue>{eth.toFixed(3)}</CurrencyValue>
+            <CurrencyValue>{truncateNumber(eth)}</CurrencyValue>
             <CurrencyLabel>ETH</CurrencyLabel>
           </Currency>
         </Content>

--- a/src/pages/dissolution/steps/burn.js
+++ b/src/pages/dissolution/steps/burn.js
@@ -1,25 +1,28 @@
 import Acid from '@digix/acid-contracts/build/contracts/Acid.json';
+import DgdToken from '@digix/acid-contracts/build/contracts/DGDInterface.json';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SpectrumConfig from 'spectrum-lightsuite/spectrum.config';
 import TxVisualization from '@digix/gov-ui/components/common/blocks/tx-visualization';
 import getContract from '@digix/gov-ui/utils/contracts';
 import web3Connect from 'spectrum-lightsuite/src/helpers/web3/connect';
-import web3Utils from 'web3-utils';
 import { DEFAULT_GAS_PRICE } from '@digix/gov-ui/constants';
 import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getSignTransactionTranslation } from '@digix/gov-ui/utils/helpers';
+import { parseBigNumber } from 'spectrum-lightsuite/src/helpers/stringUtils';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { showHideAlert } from '@digix/gov-ui/reducers/gov-ui/actions';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { withTranslation } from 'react-i18next';
 import { Button } from '@digix/gov-ui/components/common/elements';
 import {
+  getSignTransactionTranslation,
+  truncateNumber,
+} from '@digix/gov-ui/utils/helpers';
+import {
   burnSubscription,
-  fetchUser,
   withApolloClient,
 } from '@digix/gov-ui/pages/dissolution/api/queries';
 
@@ -37,13 +40,13 @@ const {
 
 registerUIs({ txVisualization: { component: TxVisualization } });
 const network = SpectrumConfig.defaultNetworks[0];
+const DGD_TO_ETH_RATIO = 0.193054178;
 
 class BurnStep extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
       dgd: 0,
-      dgdToWei: 0,
       eth: 0,
       isTxBroadcasted: false,
     };
@@ -52,38 +55,34 @@ class BurnStep extends React.PureComponent {
   }
 
   componentWillMount = () => {
-    const {
-      addresses,
-      client,
-      goToNext,
-    } = this.props;
+    const { addresses, goToNext } = this.props;
     const sourceAddress = addresses.find(({ isDefault }) => isDefault);
     if (!sourceAddress) {
       return;
     }
 
-    client.query({
-      query: fetchUser,
-      variables: {
-        id: sourceAddress.address.toLowerCase(),
-      },
-    })
-      .then((response) => {
-        const { user } = response.data;
-        const { dgdToWei } = user;
-        const dgd = user
-          ? Number(user.dgdBalance) / 10e8
-          : 0;
+    let dgd = 0;
+    this.getDgdBalance().then((dgdBalance) => {
+      dgd = dgdBalance;
+      const eth = dgd * DGD_TO_ETH_RATIO;
 
-        const eth = user
-          ? Number(user.ethRefund) / 10e17
-          : 0;
+      this.setState({ dgd, eth });
+      if (dgd <= 0) {
+        goToNext();
+      }
+    });
+  }
 
-        this.setState({ dgd, dgdToWei, eth });
-        if (dgd <= 0) {
-          goToNext();
-        }
-      });
+  getDgdBalance() {
+    const { addresses, web3Redux } = this.props;
+    const sourceAddress = addresses.find(({ isDefault }) => isDefault);
+    const { abi, address } = getContract(DgdToken, network);
+    const { web3 } = web3Redux.networks[network];
+    const contract = web3.eth.contract(abi).at(address);
+
+    return contract.balanceOf
+      .call(sourceAddress.address)
+      .then(balance => parseBigNumber(balance, 9, false));
   }
 
   burnDgd() {
@@ -196,7 +195,6 @@ class BurnStep extends React.PureComponent {
   render() {
     const {
       dgd,
-      dgdToWei,
       eth,
       isTxBroadcasted,
     } = this.state;
@@ -207,22 +205,18 @@ class BurnStep extends React.PureComponent {
       ? t('Dissolution:Burn.button')
       : <SuccessIcon kind="check" />;
 
-    const dgdToEth = Number(dgdToWei) > 0
-      ? web3Utils.fromWei(dgdToWei, 'ether')
-      : 0;
-
     return (
       <Container>
         <Title>{t('Dissolution:Burn.title')}</Title>
-        <Subtitle>1 DGD = 0.193054178 ETH</Subtitle>
+        <Subtitle>1 DGD = {DGD_TO_ETH_RATIO} ETH</Subtitle>
         <Content>
           <Currency>
-            <CurrencyValue>{dgd.toFixed(3)}</CurrencyValue>
+            <CurrencyValue>{truncateNumber(dgd)}</CurrencyValue>
             <CurrencyLabel>DGD</CurrencyLabel>
           </Currency>
           <Arrow kind="conversionArrow" />
           <Currency>
-            <CurrencyValue>{eth.toFixed(3)}</CurrencyValue>
+            <CurrencyValue>{truncateNumber(eth)}</CurrencyValue>
             <CurrencyLabel>ETH</CurrencyLabel>
           </Currency>
         </Content>

--- a/src/pages/dissolution/steps/unlock.js
+++ b/src/pages/dissolution/steps/unlock.js
@@ -9,12 +9,15 @@ import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getSignTransactionTranslation } from '@digix/gov-ui/utils/helpers';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { withTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import { Button } from '@digix/gov-ui/components/common/elements';
+import {
+  getSignTransactionTranslation,
+  truncateNumber,
+} from '@digix/gov-ui/utils/helpers';
 import {
   showHideAlert,
   setLockedDgd,
@@ -157,7 +160,6 @@ class UnlockStep extends React.PureComponent {
       t,
     } = this.props;
 
-    const lockedAmount = lockedDgd / 10e8;
     const isButtonEnabled = lockedDgd > 0;
     const buttonLabel = isButtonEnabled
       ? t('Dissolution:Unlock.button')
@@ -168,13 +170,13 @@ class UnlockStep extends React.PureComponent {
         <Title>{t('Dissolution:Unlock.title')}</Title>
         <Content>
           <Currency>
-            <CurrencyValue>{lockedAmount.toFixed(3)}</CurrencyValue>
+            <CurrencyValue>{truncateNumber(lockedDgd)}</CurrencyValue>
             <CurrencyLabel>DGD</CurrencyLabel>
           </Currency>
         </Content>
         <Button
           disabled={isTxBroadcasted || !isButtonEnabled}
-          onClick={() => this.unlockDgd(lockedAmount)}
+          onClick={() => this.unlockDgd(lockedDgd)}
           secondary
         >
           {buttonLabel}

--- a/src/pages/dissolution/steps/unlock.js
+++ b/src/pages/dissolution/steps/unlock.js
@@ -9,12 +9,15 @@ import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
-import { getSignTransactionTranslation } from '@digix/gov-ui/utils/helpers';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { withTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import { Button } from '@digix/gov-ui/components/common/elements';
+import {
+  getSignTransactionTranslation,
+  truncateNumber,
+} from '@digix/gov-ui/utils/helpers';
 import {
   showHideAlert,
   setLockedDgd,
@@ -168,7 +171,7 @@ class UnlockStep extends React.PureComponent {
         <Title>{t('Dissolution:Unlock.title')}</Title>
         <Content>
           <Currency>
-            <CurrencyValue>{lockedAmount.toFixed(3)}</CurrencyValue>
+            <CurrencyValue>{truncateNumber(lockedAmount)}</CurrencyValue>
             <CurrencyLabel>DGD</CurrencyLabel>
           </Currency>
         </Content>

--- a/src/pages/dissolution/steps/unlock.js
+++ b/src/pages/dissolution/steps/unlock.js
@@ -9,15 +9,12 @@ import { Step } from '@digix/gov-ui/pages/dissolution/style';
 import { connect } from 'react-redux';
 import { executeContractFunction } from '@digix/gov-ui/utils/web3Helper';
 import { getAddresses } from 'spectrum-lightsuite/src/selectors';
+import { getSignTransactionTranslation } from '@digix/gov-ui/utils/helpers';
 import { registerUIs } from 'spectrum-lightsuite/src/helpers/uiRegistry';
 import { showTxSigningModal } from 'spectrum-lightsuite/src/actions/session';
 import { withTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import { Button } from '@digix/gov-ui/components/common/elements';
-import {
-  getSignTransactionTranslation,
-  truncateNumber,
-} from '@digix/gov-ui/utils/helpers';
 import {
   showHideAlert,
   setLockedDgd,
@@ -160,6 +157,7 @@ class UnlockStep extends React.PureComponent {
       t,
     } = this.props;
 
+    const lockedAmount = lockedDgd / 10e8;
     const isButtonEnabled = lockedDgd > 0;
     const buttonLabel = isButtonEnabled
       ? t('Dissolution:Unlock.button')
@@ -170,13 +168,13 @@ class UnlockStep extends React.PureComponent {
         <Title>{t('Dissolution:Unlock.title')}</Title>
         <Content>
           <Currency>
-            <CurrencyValue>{truncateNumber(lockedDgd)}</CurrencyValue>
+            <CurrencyValue>{lockedAmount.toFixed(3)}</CurrencyValue>
             <CurrencyLabel>DGD</CurrencyLabel>
           </Currency>
         </Content>
         <Button
           disabled={isTxBroadcasted || !isButtonEnabled}
-          onClick={() => this.unlockDgd(lockedDgd)}
+          onClick={() => this.unlockDgd(lockedAmount)}
           secondary
         >
           {buttonLabel}


### PR DESCRIPTION
Summary of two commits:
- Revert `[HOTFIX] Fetch data via web3 instead of subgraph` PR #420
- Minor UI fixes
  - Truncate values instead of using toFixed
  - Set `DGD_TO_ETH_RATIO` constant
  - Make sure `Dissolution::componentWillReceiveProps` will trigger only when the wallet is loaded

### Note
- Do **NOT** squash the commits when merging.
- Merge this only when the negative balance issue is fixed for the backend.
