### PR TITLE
[HOTFIX] Change gas and smart gas price for unlock step (Resolves EL_v2-1210)

### DIFF
--- a/src/pages/dissolution/index.js
+++ b/src/pages/dissolution/index.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withApolloClient } from '@digix/gov-ui/pages/dissolution/api/queries';
 import React, { Fragment } from 'react';
+import { setSmartGasRatio } from '@digix/gov-ui/reducers/gov-ui/actions';
 
 const {
   NavButton,
@@ -37,6 +38,10 @@ class Dissolution extends React.PureComponent {
     };
   }
 
+  componentWillMount() {
+    this.props.setSmartGasRatio(3);
+  }
+
   componentWillReceiveProps(nextProps) {
     const {
       isAddressLoaded,
@@ -47,6 +52,7 @@ class Dissolution extends React.PureComponent {
     if (!this.props.isAddressLoaded && isAddressLoaded) {
       const isDgdUnlocked = isAddressLoaded && lockedDgd <= 0;
       if (isDgdUnlocked && loadWalletBalance <= 0) {
+        this.props.setSmartGasRatio(1);
         this.setState({
           step: STEPS.success,
           stepOffset: -2,
@@ -60,6 +66,7 @@ class Dissolution extends React.PureComponent {
         ? STEPS.approve
         : STEPS.unlock;
 
+      this.props.setSmartGasRatio(isDgdUnlocked ? 1 : 3);
       this.setState({ step, stepOffset });
     }
   }
@@ -139,6 +146,7 @@ class Dissolution extends React.PureComponent {
     }
 
     this.setState(({ step }) => {
+      this.props.setSmartGasRatio(1);
       if (step < 4) {
         return {
           step: step + 1,
@@ -246,6 +254,7 @@ Dissolution.propTypes = {
   isBurnApproved: bool.isRequired,
   loadWalletBalance: number,
   lockedDgd: number.isRequired,
+  setSmartGasRatio: func.isRequired,
   t: func.isRequired,
 };
 
@@ -262,6 +271,8 @@ const mapStateToProps = state => ({
 
 export default withTranslation(['Dissolution', 'Snackbar'])(
   withApolloClient(
-    connect(mapStateToProps, {})(Dissolution)
+    connect(mapStateToProps, {
+      setSmartGasRatio,
+    })(Dissolution)
   )
 );

--- a/src/pages/dissolution/steps/unlock.js
+++ b/src/pages/dissolution/steps/unlock.js
@@ -106,7 +106,7 @@ class UnlockStep extends React.PureComponent {
 
     const web3Params = {
       gasPrice: DEFAULT_GAS_PRICE,
-      gas: 4000000,
+      gas: 2000000,
       ui,
     };
 

--- a/src/reducers/gov-ui/actions.js
+++ b/src/reducers/gov-ui/actions.js
@@ -22,6 +22,7 @@ export const actions = {
   SET_IS_BURN_APPROVED: `${REDUX_PREFIX}SET_IS_BURN_APPROVED`,
   SET_IS_ADDRESS_LOADED: `${REDUX_PREFIX}SET_IS_ADDRESS_LOADED`,
   SET_LOAD_WALLET_BALANCE: `${REDUX_PREFIX}SET_LOAD_WALLET_BALANCE`,
+  SET_SMART_GAS_RATIO: `${REDUX_PREFIX}SET_SMART_GAS_RATIO`,
 };
 
 function fetchData(url, type) {
@@ -179,6 +180,17 @@ export function setLoadWalletBalance(loadWalletBalance = 0) {
     dispatch({
       type: actions.SET_LOAD_WALLET_BALANCE,
       payload: { loadWalletBalance },
+    });
+  };
+}
+
+export function setSmartGasRatio(smartGasRatio = 1) {
+  return (dispatch) => {
+    dispatch({
+      type: actions.SET_SMART_GAS_RATIO,
+      payload: {
+        smartGasRatio: Number(smartGasRatio),
+      },
     });
   };
 }

--- a/src/reducers/gov-ui/index.js
+++ b/src/reducers/gov-ui/index.js
@@ -7,6 +7,7 @@ const defaultState = {
     loadWalletBalance: undefined,
     isAddressLoaded: false,
     isBurnApproved: false,
+    smartGasRatio: 1
   },
   lockDgdOverlay: {
     show: false,
@@ -33,6 +34,14 @@ const defaultState = {
 
 export default function(state = defaultState, action) {
   switch (action.type) {
+    case actions.SET_SMART_GAS_RATIO:
+      return {
+        ...state,
+        Dissolution: {
+          ...state.Dissolution,
+          ...action.payload,
+        },
+      };
     case actions.SET_LOAD_WALLET_BALANCE:
       return {
         ...state,


### PR DESCRIPTION
For unlock step:
- Set gas limit to 2M
- Multiply smart gas price by 3

Smart gas for unlock:
![Unlock](https://user-images.githubusercontent.com/45159226/78746941-ba8dc880-799a-11ea-8ab7-0f982919f92e.png)

Smart gas for approve/burn:
![Approve and Burn](https://user-images.githubusercontent.com/45159226/78746934-b6fa4180-799a-11ea-9a08-0afeff829af8.png)

summary
![image](https://user-images.githubusercontent.com/44765455/78747348-c8901900-799b-11ea-9363-e5ec25146747.png)

