### PR TITLE
[Feature] Add redeem instructions for advanced users

### DIFF
--- a/src/pages/dissolution/modal.js
+++ b/src/pages/dissolution/modal.js
@@ -9,9 +9,13 @@ import React, { Fragment } from 'react';
 
 const {
   Container,
+  Instruction,
   Title,
   Paragraph,
   Button,
+  ButtonRagnarok,
+  Steps,
+  StepItem
 } = Modal;
 
 class DissolutionModal extends React.Component {
@@ -28,20 +32,57 @@ class DissolutionModal extends React.Component {
       <Fragment>
         <Container>
           <Title>{t('Modal.title')}</Title>
-          <Paragraph>{t('Modal.content')}</Paragraph>
-          <Paragraph>
-            <ReactMarkdown
-              escapeHtml={false}
-              renderers={{ paragraph: 'span' }}
-              source={t('Modal.ethRecommendation')}
-            />
-          </Paragraph>
+          <Paragraph
+            escapeHtml={false}
+            source={t('Modal.message')}
+          />
+          <Steps>
+            <StepItem>
+              <Paragraph
+                escapeHtml={false}
+                source={t('Modal.step1')}
+              />
+            </StepItem>
+            <StepItem>
+              <Paragraph
+                escapeHtml={false}
+                source={t('Modal.step2')}
+              />
+              <Instruction>
+                {t('Modal.approveContract')} <br />
+                {t('Modal.approveGasLimit')} <br />
+                {t('Modal.approveTxnAmount')} <br />
+                {t('Modal.approveTxnData')}
+              </Instruction>
+            </StepItem>
+            <StepItem>
+              <Paragraph
+                escapeHtml={false}
+                source={t('Modal.step3')}
+              />
+              <Instruction>
+                {t('Modal.burnContract')} <br />
+                {t('Modal.burnGasLimit')} <br />
+                {t('Modal.burnTxnAmount')} <br />
+                {t('Modal.burnTxnData')}
+              </Instruction>
+            </StepItem>
+          </Steps>
+          <Paragraph
+            escapeHtml={false}
+            source={t('Modal.message2')}
+          />
           <Button
-            onClick={this.openLoadWalletPanel}
+            onClick={() => window.open('https://app.mycrypto.com/interact-with-contracts', '_blank')}
             primary
           >
-            {t('Modal.button')}
+            {t('Modal.button1')}
           </Button>
+          <ButtonRagnarok
+            onClick={this.openLoadWalletPanel}
+          >
+            {t('Modal.button2')}
+          </ButtonRagnarok>
         </Container>
       </Fragment>
     );

--- a/src/pages/dissolution/style.js
+++ b/src/pages/dissolution/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import ReactMarkdown from 'react-markdown';
 import { Card } from '@digix/gov-ui/components/common/common-styles';
 import { TextBox } from '@digix/gov-ui/components/common/blocks/overlay/unlock-dgd/style';
 import { Button, Icon } from '@digix/gov-ui/components/common/elements/index';
@@ -12,16 +13,58 @@ export const Modal = {
     color: ${props => props.theme.textColor.primary.light.toString()};
     font-size: 2.4rem;
     margin-bottom: 2.4rem;
-    text-transform: uppercase;
   `,
 
-  Paragraph: styled.p`
+  Paragraph: styled(ReactMarkdown)`
     line-height: 1.5;
+
+    strong {
+      font-family: 'Futura PT Medium', sans-serif;
+    }
+  `,
+
+  Steps: styled.ul`
+    list-style: none;
+  `,
+
+  StepItem: styled.li`
+    margin-bottom: 1.2rem;
+
+    strong {
+      font-family: 'Futura PT Medium', sans-serif;
+    }
+
+    div code {
+      color: #BB8C22;
+      font-weight: 400;
+      font-size: 1.2rem;
+    }
+  `,
+
+  Instruction: styled.code`
+    background: #fbfbfb;
+    border: 1px solid #dfdfdf;
+    border-radius: 0.5rem;
+    color: rgb(70, 78, 91);
+    display: block;
+    font-size: 1.1rem;
+    padding: 0.8rem 1.2rem;
+    margin: 1rem 0;
+    overflow-wrap: break-word;
   `,
 
   Button: styled(Button)`
     margin: 2.4rem 0 0 0;
-    width: 100%;
+    width: auto;
+  `,
+
+  ButtonRagnarok: styled(Button)`
+    margin: 2.4rem 0 0 1.6rem;
+    background-color: #fff;
+    border: 2px solid #131F34;
+    color: #131F34;
+    box-shadow: none;
+    width: auto;
   `,
 };
 

--- a/src/translations/english/dissolution.json
+++ b/src/translations/english/dissolution.json
@@ -1,5 +1,23 @@
 {
   "Modal": {
+    "title": "DGD Redemption for Advanced Users",
+    "message": "Advanced users now have the option to redeem DGD balances via **MyCrypto** site. Follow these simple steps on how to unlock your DGDs and claim your ETH.",
+    "step1": "**Step 1: Unlock account.** Access your account wallet on MyCrypto.com.",
+    "step2": "**Step 2: Approve transfer.** On Interact with Contract, enter the dissolution contract address with the JSON ABI. Invoke `DGD.approve` method, write and sign the transaction and wait for it to be approved.",
+    "step3": "**Step 3: Burn token.** Next, access the contract to burn your DGD and JSON ABI. Invoke the `Acid.burn` method, write and sign the transaction.",
+    "approveContract": "Contract Address: 0xe0b7927c4af23765cb51314a0e0521a9645f0e2a",
+    "approveGasLimit": "Gas Limit: 1000000",
+    "approveTxnAmount": "Transaction Amount: 0",
+    "approveTxnData": "Transaction Data: 0x095ea7b300000000000000000000000023Ea10CC1e6EBdB499D24E45369A35f43627062f00000000000000000000000000000000000000000000000000071afd498d0000",
+    "burnContract": "Contract Address: 0x23Ea10CC1e6EBdB499D24E45369A35f43627062f",
+    "burnGasLimit": "Gas Limit: 1500000",
+    "burnTxnAmount": "Transaction Amount: 0",
+    "burnTxnData": "Transaction Data: 0x44df8e70",
+    "message2": "If you wish to unlock your DGD on our platform, you can click the **Redeem on Ragnarok** button below. We strongly encourage you to have at least 0.1 ETH in your wallet so that you can make the necessary transactions in order for the claim to happen successfully.",
+    "button1": "Redeem on MyCrypto.com",
+    "button2": "Redeem on Ragnarok"
+  },
+  "ModalRagnarok": {
     "title": "Ragnarok: Steps to Proceed",
     "content": "The last Quarter of DigixDAO has ended. This site will enable you to unlock DGDs you have on our platform, as well as claim your ETH. If you have DGD but have not participated on our platform before, you will still be able to claim your ETH.",
     "ethRecommendation": "We strongly encourage you to have at least **0.1 ETH** in your wallet so that you can make the necessary transactions in order for the claim to happen successfully.",


### PR DESCRIPTION
Ref:
https://tracker.digixdev.com/agiles/88-19/89-79?issue=EL_v2-2052

### Description
Instructions for redeeming DGD via MyCrypto for advanced users.

### Test Plan
1. Users should successfully claim ETH via MyCrypto.com
2. Users should still be able to redeem via Ragnarok app. 
