### PR TITLE
[FIX] Added back the missing text on sidebar

### DIFF
--- a/src/translations/english/dissolution.json
+++ b/src/translations/english/dissolution.json
@@ -15,7 +15,8 @@
     "burnTxnData": "Transaction Data: 0x44df8e70",
     "message2": "If you wish to unlock your DGD on our platform, you can click the **Redeem on Ragnarok** button below. We strongly encourage you to have at least 0.1 ETH in your wallet so that you can make the necessary transactions in order for the claim to happen successfully.",
     "button1": "Redeem on MyCrypto.com",
-    "button2": "Redeem on Ragnarok"
+    "button2": "Redeem on Ragnarok",
+    "ethRecommendation": "We strongly encourage you to have at least **0.1 ETH** in your wallet so that you can make the necessary transactions in order for the claim to happen successfully."
   },
   "ModalRagnarok": {
     "title": "Ragnarok: Steps to Proceed",


### PR DESCRIPTION
### Description
This fixes the missing ETH reminder text on Ragnarok's sidebar.

![Screenshot_2022-05-02_10-14-09](https://user-images.githubusercontent.com/37611942/166187168-33c808a6-3728-4b39-9bf2-79d7197cf471.png)


### Test Plan
Sidebar must show the missing ETH Recommendation messaging.
